### PR TITLE
DOC-1353 Add troubleshooting for mismatched RBAC settings

### DIFF
--- a/modules/troubleshoot/partials/errors-and-solutions.adoc
+++ b/modules/troubleshoot/partials/errors-and-solutions.adoc
@@ -305,6 +305,19 @@ helm repo update
 
 //end::deployment-name-exists[]
 
+//tag::deployment-forbidden-debug-bundle[]
+=== redpanda-rpk-debug-bundle is forbidden
+
+You may see this error if your Redpanda Operator's own RBAC (the chart values) is out-of-sync with the Pod-level RBAC (in the Redpanda resource) it's trying to manage:
+
+[.no-copy]
+----
+… forbidden: user "…-operator" … attempting to grant RBAC permissions not currently held …
+----
+
+To fix this error, make sure you haven't disabled `rbac.createRPKBundleCRs` in the Redpanda Operator chart while still leaving `spec.clusterSpec.rbac.rpkDebugBundle` enabled in your Redpanda resource. Either enable both or disable both.
+//end::deployment-forbidden-debug-bundle[]
+
 //tag::deployment-data-dir-not-writable[]
 === Fatal error during checker "Data directory is writable" execution
 

--- a/modules/troubleshoot/partials/errors-and-solutions.adoc
+++ b/modules/troubleshoot/partials/errors-and-solutions.adoc
@@ -308,7 +308,7 @@ helm repo update
 //tag::deployment-forbidden-debug-bundle[]
 === redpanda-rpk-debug-bundle is forbidden
 
-You may see this error if your Redpanda Operator's own RBAC (the chart values) is out-of-sync with the Pod-level RBAC (in the Redpanda resource) it's trying to manage:
+If you see this error, your Redpanda Operator’s RBAC settings are out of sync with the Pod-level RBAC in the Redpanda resource:
 
 [.no-copy]
 ----

--- a/modules/troubleshoot/partials/errors-and-solutions.adoc
+++ b/modules/troubleshoot/partials/errors-and-solutions.adoc
@@ -308,14 +308,14 @@ helm repo update
 //tag::deployment-forbidden-debug-bundle[]
 === redpanda-rpk-debug-bundle is forbidden
 
-If you see this error, your Redpanda Operator’s RBAC settings are out of sync with the Pod-level RBAC in the Redpanda resource:
+If you see this error, your Redpanda Operator's RBAC settings are out of sync with the Pod-level RBAC in the Redpanda resource:
 
 [.no-copy]
 ----
 … forbidden: user "…-operator" … attempting to grant RBAC permissions not currently held …
 ----
 
-To fix this error, make sure you haven't disabled `rbac.createRPKBundleCRs` in the Redpanda Operator chart while still leaving `spec.clusterSpec.rbac.rpkDebugBundle` enabled in your Redpanda resource. Either enable both or disable both.
+To fix this error, make sure you haven't disabled xref:reference:k-operator-helm-spec.adoc#rbac-createrpkbundlecrs[`rbac.createRPKBundleCRs`] in the Redpanda Operator chart while still leaving xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-rbac[`spec.clusterSpec.rbac.rpkDebugBundle`] enabled in your Redpanda resource. Either enable both or disable both.
 //end::deployment-forbidden-debug-bundle[]
 
 //tag::deployment-data-dir-not-writable[]


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1353
Review deadline: 18 May

This pull request adds a new troubleshooting section to the documentation to address a specific RBAC-related error encountered when using the Redpanda Operator.

### Documentation Update:
* [`modules/troubleshoot/partials/errors-and-solutions.adoc`](diffhunk://#diff-3fe3b232ac4dc7efbade4487926eaf73030ab18fd87ffab804cc51dadb991fc5R308-R320): Added a new section titled `redpanda-rpk-debug-bundle is forbidden` to explain the cause of an RBAC permissions error and provide guidance on resolving it by aligning the `rbac.createRPKBundleCRs` and `spec.clusterSpec.rbac.rpkDebugBundle` settings.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
