### PR TITLE
Single source Iceberg+Snowflake integration doc for Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1389-cloud-snowflake-secrets-doc'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, api, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1389-cloud-snowflake-secrets-doc'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -70,9 +70,14 @@ ifdef::env-cloud[]
 +
 [,bash]
 ----
-rpk cluster config set iceberg_enabled=true iceberg_catalog_type=rest
-iceberg_rest_catalog_endpoint=https://<snowflake-orgname>-<open-catalog-account-name>.snowflakecomputing.com/polaris/api/catalog iceberg_rest_catalog_authentication_mode=oauth2 iceberg_rest_catalog_client_id=<open-catalog-connection-client-id> iceberg_rest_catalog_client_secret=${secrets.<open-catalog-client-secret-name>}
-iceberg_rest_catalog_prefix: <open-catalog-name>
+rpk cluster config set \
+  iceberg_enabled=true \
+  iceberg_catalog_type=rest \
+  iceberg_rest_catalog_endpoint=https://<snowflake-orgname>-<open-catalog-account-name>.snowflakecomputing.com/polaris/api/catalog \
+  iceberg_rest_catalog_authentication_mode=oauth2 \
+  iceberg_rest_catalog_client_id=<open-catalog-connection-client-id> \
+  iceberg_rest_catalog_client_secret=${secrets.<open-catalog-client-secret-name>} \
+  iceberg_rest_catalog_prefix=<open-catalog-name>
 
 # Optional properties:
 # iceberg_translation_interval_ms_default=1000

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -66,7 +66,7 @@ To configure your Redpanda cluster to enable Iceberg on a topic and integrate wi
 
 ifdef::env-cloud[]
 . xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[Store the Open Catalog client secret in your cluster] using `rpk` or the Data Plane API.
-. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below using `rpk` or the Control Plane API. For example, to use `rpk cluster config set`, run the following:
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below using `rpk` or the Control Plane API. For example, to use `rpk cluster config set`, run:
 +
 [,bash]
 ----
@@ -135,17 +135,17 @@ Successfully updated configuration. New configuration version is 2.
 . You must restart your cluster so that the configuration changes take effect.
 endif::[]
 
-. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes.
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns: one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes.
 ifdef::env-cloud[]
 +
 Use any of the following to set `redpanda.iceberg.mode`:
 +
-* `rpk`. See the examples below for running the `rpk topic` commands.
+* `rpk`. See the following examples to run `rpk topic` commands.
 * The Cloud UI. Navigate to *Topics* to create a new topic and specify `redpanda.iceberg.mode` in *Additional Configuration*, or edit an existing topic under the topic's *Configuration* tab.
 * The Data Plane API to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/topics[create a new topic] or xref:api:ROOT:cloud-dataplane-api.adoc#patch-/v1/topics/-topic_name-/configurations[update a property for an existing topic]. Specify the key-value pair for `redpanda.iceberg.mode` in the request body.
 endif::[]
 +
-The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`.  
+The following examples show how to use `rpk` to create a new topic or alter the configuration for an existing topic, setting the Iceberg mode to `key_value`.  
 +
 .Create a new topic and set `redpanda.iceberg.mode`:
 [,bash]

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -139,7 +139,7 @@ ifdef::env-cloud[]
 Use any of the following to set `redpanda.iceberg.mode`:
 +
 --
-* `rpk`. See the examples below for running the `rpk topic` command.
+* `rpk`. See the examples below for running the `rpk topic` commands.
 * The Cloud UI. Navigate to *Topics* to create a new topic and specify `redpanda.iceberg.mode` in *Additional Configuration*, or edit an existing topic under the topic's *Configuration* tab.
 * The Data Plane API to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/topics[create a new topic] or xref:api:ROOT:cloud-dataplane-api.adoc#patch-/v1/topics/-topic_name-/configurations[update a property for an existing topic]. Specify the key-value pair for `redpanda.iceberg.mode` in the request body.
 --

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -87,7 +87,7 @@ Use your own values for the following placeholders:
 +
 TIP: In Snowflake, navigate to **Admin**, then **Accounts**. Click the ellipsis near your Open Catalog account name, and select **Manage URLs**. The **Current URL** contains `<snowflake-orgname>` and `<open-catalog-account-name>`.
 - `<open-catalog-connection-client-id>`: The client ID of the service connection you created in an earlier step.
-- `<open-catalog-client-secret-name>`: The name of the secret you created in the previous step. You must pass the secret name to the `${secrets.<secret-name>}` placeholder, not the secret value.
+- `<open-catalog-client-secret-name>`: The name of the secret you created in the previous step. You must pass the secret name to the `${secrets.<secret-name>}` placeholder, not the secret value itself.
 - `<open-catalog-name>`: The name of your catalog in Open Catalog.
 --
 +
@@ -133,7 +133,19 @@ Successfully updated configuration. New configuration version is 2.
 . You must restart your cluster so that the configuration changes take effect.
 endif::[]
 
-. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show  how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`.  
+. Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes.
+ifdef::env-cloud[]
++
+Use any of the following to set `redpanda.iceberg.mode`:
++
+--
+* `rpk`. See the examples below for running the `rpk topic` command.
+* The Cloud UI. Navigate to *Topics* to create a new topic and specify `redpanda.iceberg.mode` in *Additional Configuration*, or edit an existing topic under the topic's *Configuration* tab.
+* The Data Plane API to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/topics[create a new topic] or xref:api:ROOT:cloud-dataplane-api.adoc#patch-/v1/topics/-topic_name-/configurations[update a property for an existing topic]. Specify the key-value pair for `redpanda.iceberg.mode` in the request body.
+--
+endif::[]
++
+The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`.  
 +
 .Create a new topic and set `redpanda.iceberg.mode`:
 [,bash]

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -7,13 +7,20 @@
 include::shared:partial$enterprise-license.adoc[]
 ====
 
+// tag::single-source[]
+
 This guide walks you through querying Redpanda topics as Iceberg tables in https://docs.snowflake.com/en/user-guide/tables-iceberg[Snowflake^], with AWS S3 as object storage and a catalog integration using https://other-docs.snowflake.com/en/opencatalog/overview[Open Catalog^].
 
 == Prerequisites
 
+ifdef::env-cloud[]
+* `rpk` or familiarity with the Redpanda Cloud API to use secrets in your cluster configuration. For `rpk`, see xref:manage:rpk/rpk-install.adoc[]. For the Cloud API, you must xref:manage:api/cloud-api-authentication.adoc[authenticate] using a service account.
+endif::[]
+ifndef::env-cloud[]
 * xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.
 +
 You need the S3 bucket URI, so you can configure it as external storage for Open Catalog.
+endif::[]
 * A Snowflake account.
 * An Open Catalog account. To https://other-docs.snowflake.com/en/opencatalog/create-open-catalog-account[create an Open Catalog account^], you require ORGADMIN access in Snowflake.
 * An internal catalog created in Open Catalog with your Tiered Storage AWS S3 bucket configured as external storage.
@@ -58,6 +65,38 @@ Grant privileges to the principal created in the previous step:
 
 To configure your Redpanda cluster to enable Iceberg on a topic and integrate with Open Catalog:
 
+ifdef::env-cloud[]
+. xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[Store the Open Catalog client secret in your cluster] using `rpk` or the Data Plane API.
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below using `rpk` or the Control Plane API. For example, to use `rpk cluster config set`, run the following:
++
+[,bash]
+----
+rpk cluster config set iceberg_enabled=true iceberg_catalog_type=rest
+iceberg_rest_catalog_endpoint=https://<snowflake-orgname>-<open-catalog-account-name>.snowflakecomputing.com/polaris/api/catalog iceberg_rest_catalog_authentication_mode=oauth2 iceberg_rest_catalog_client_id=<open-catalog-connection-client-id> iceberg_rest_catalog_client_secret=${secrets.<open-catalog-client-secret-name>}
+iceberg_rest_catalog_prefix: <open-catalog-name>
+
+# Optional properties:
+# iceberg_translation_interval_ms_default=1000
+# iceberg_catalog_commit_interval_ms=1000
+----
++
+Use your own values for the following placeholders:
++
+--
+- `<snowflake-orgname>` and `<open-catalog-account-name>`: Your https://docs.snowflake.com/en/sql-reference/sql/create-catalog-integration-open-catalog#required-parameters[Open Catalog account URI^] is composed of these values.
++
+TIP: In Snowflake, navigate to **Admin**, then **Accounts**. Click the ellipsis near your Open Catalog account name, and select **Manage URLs**. The **Current URL** contains `<snowflake-orgname>` and `<open-catalog-account-name>`.
+- `<open-catalog-connection-client-id>`: The client ID of the service connection you created in an earlier step.
+- `<open-catalog-client-secret-name>`: The name of the secret you created in the previous step. You must pass the secret name to the `${secrets.<secret-name>}` placeholder, not the secret value.
+- `<open-catalog-name>`: The name of your catalog in Open Catalog.
+--
++
+[,bash,role=no-copy]
+----
+Successfully updated configuration. New configuration version is 2.
+----
+endif::[]
+ifndef::env-cloud[]
 . Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below. You must restart your cluster if you change this configuration for a running cluster. You can run `rpk cluster config edit` to update these properties:
 +
 [,bash]
@@ -92,6 +131,7 @@ Successfully updated configuration. New configuration version is 2.
 ----
 
 . You must restart your cluster so that the configuration changes take effect.
+endif::[]
 
 . Enable the integration for a topic by configuring the topic property `redpanda.iceberg.mode`. This mode creates an Iceberg table for the topic consisting of two columns, one for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Enable Iceberg integration] for more details on Iceberg modes. The following examples show  how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`.  
 +
@@ -218,3 +258,5 @@ Your query results should look like the following:
 +--------------------------------------------------------------------------------------------------------------+------------+
 
 ----
+
+// end::single-source[]

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -19,7 +19,7 @@ endif::[]
 ifndef::env-cloud[]
 * xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.
 +
-You need the S3 bucket URI, so you can configure it as external storage for Open Catalog.
+You need the S3 bucket URI to configure it as external storage for Open Catalog.
 endif::[]
 * A Snowflake account.
 * An Open Catalog account. To https://other-docs.snowflake.com/en/opencatalog/create-open-catalog-account[create an Open Catalog account^], you require ORGADMIN access in Snowflake.
@@ -27,11 +27,10 @@ endif::[]
 +
 Follow this guide to https://other-docs.snowflake.com/en/opencatalog/create-catalog#create-a-catalog-using-amazon-simple-storage-service-amazon-s3[create a catalog^] with the S3 bucket configured as external storage. You require admin permissions to carry out these steps in AWS:
 +
---
 . If you don't already have one, create an IAM policy that gives Open Catalog read and write access to your S3 bucket.
 . Create an IAM role and attach the IAM policy to the role.
 . After creating a new catalog in Open Catalog, grant the catalog's AWS IAM user access to the S3 bucket.
---
++
 * A Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume[external volume^] set up using the Tiered Storage bucket. 
 +
 Follow this guide to https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[configure the external volume with S3^]. You can use the same IAM policy as the catalog for the external volume's IAM role and user. 
@@ -116,14 +115,12 @@ iceberg_catalog_commit_interval_ms: 1000
 +
 Use your own values for the following placeholders:
 +
---
 - `<snowflake-orgname>` and `<open-catalog-account-name>`: Your https://docs.snowflake.com/en/sql-reference/sql/create-catalog-integration-open-catalog#required-parameters[Open Catalog account URI^] is composed of these values.
 +
 TIP: In Snowflake, navigate to **Admin**, then **Accounts**. Click the ellipsis near your Open Catalog account name, and select **Manage URLs**. The **Current URL** contains `<snowflake-orgname>` and `<open-catalog-account-name>`.
 - `<open-catalog-connection-client-id>`: The client ID of the service connection you created in an earlier step.
 - `<open-catalog-connection-client-secret>`: The client secret of the service connection you created in an earlier step.
 - `<open-catalog-name>`: The name of your catalog in Open Catalog.
---
 +
 [,bash,role=no-copy]
 ----
@@ -138,11 +135,9 @@ ifdef::env-cloud[]
 +
 Use any of the following to set `redpanda.iceberg.mode`:
 +
---
 * `rpk`. See the examples below for running the `rpk topic` commands.
 * The Cloud UI. Navigate to *Topics* to create a new topic and specify `redpanda.iceberg.mode` in *Additional Configuration*, or edit an existing topic under the topic's *Configuration* tab.
 * The Data Plane API to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/topics[create a new topic] or xref:api:ROOT:cloud-dataplane-api.adoc#patch-/v1/topics/-topic_name-/configurations[update a property for an existing topic]. Specify the key-value pair for `redpanda.iceberg.mode` in the request body.
---
 endif::[]
 +
 The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic, or alter the configuration for an existing topic, to set the Iceberg mode to `key_value`.  


### PR DESCRIPTION
## Description

This pull request introduces changes to support documenting the integration of Redpanda topics with Snowflake using Iceberg tables. Key updates include switching the branch for the `cloud-docs` repository in the Antora playbook, adding 
conditional instructions for Redpanda Cloud users, and enhancing topic configuration details for Iceberg integration. 

See accompanying cloud PR: https://github.com/redpanda-data/cloud-docs/pull/302

Below is a breakdown of the most important changes:

### Antora Playbook Update
* Updated the branch for the `cloud-docs` repository in `local-antora-playbook.yml` to `DOC-1389-cloud-snowflake-secrets-doc`, replacing the previous `main` branch.

### Documentation Enhancements for Iceberg-Snowflake Integration
* **Prerequisites Section**: Added conditional instructions for Redpanda Cloud users to use `rpk` or the Cloud API for secrets management and cluster configuration. Non-cloud users are directed to configure object storage and enable Tiered Storage.
* **Cluster Configuration**: Introduced step-by-step instructions for enabling Iceberg and setting catalog integration properties, with separate guidance for Redpanda Cloud and non-cloud environments. Cloud-specific instructions include using `rpk`, the Control Plane API, or the Data Plane API.
* **Topic Configuration**: Enhanced details on enabling Iceberg mode for topics, including additional methods for Redpanda Cloud users, such as using the Cloud UI or Data Plane API.

### Code Tagging
* Added `// tag::single-source[]` and `// end::single-source[]` markers to encapsulate the single-source documentation section. [[1]](diffhunk://#diff-504f69a50b1fee44f43795311954bf91f6e3e8112bf49a18660430416be2b3b6R10-R23) [[2]](diffhunk://#diff-504f69a50b1fee44f43795311954bf91f6e3e8112bf49a18660430416be2b3b6R273-R274)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

Cloud: https://deploy-preview-1131--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/redpanda-topics-iceberg-snowflake-catalog/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
