### PR TITLE
Update k-compatibility.adoc - Correct Operator Helm Chart Version

### DIFF
--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -50,7 +50,7 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 
 |25.1.x
 |25.1.1-betaX, 5.10.x, 5.9.x
-|25.1.1-betaX, 0.4.41, 0.4.36
+|25.1.1-betaX, 2.4.x, 0.4.36
 |25.1.1-betaX, 2.4.x, 2.3.x
 |3.12+
 // d (default) here is required to get footnotes to appear at the bottom of the page


### PR DESCRIPTION
## Description

As of 25.1.x of Redpanda, the 2.4.x Operator Helm chart now coincides with the 2.4.x version of the Operator. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
