### PR TITLE
Update authentication.adoc - update details on config-watcher

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -321,7 +321,7 @@ kubectl create secret generic redpanda-superusers \
   --dry-run=client -o yaml | kubectl apply -f -
 ----
 +
-The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the mounted secret file for changes from the Kubernetes API. When changes are observed, it creates and updates users accordingly.
+The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the superusers Secret for changes. When changes are observed, it creates and updates users accordingly.
 .
 
 - If you created superusers using a YAML list, you can update the list:

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -321,7 +321,7 @@ kubectl create secret generic redpanda-superusers \
   --dry-run=client -o yaml | kubectl apply -f -
 ----
 +
-The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the mounted secret file for changes from the Kubernetes API. When changes are observed, it creates and updates users based on the new file content.
+The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the mounted secret file for changes from the Kubernetes API. When changes are observed, it creates and updates users accordingly.
 .
 
 - If you created superusers using a YAML list, you can update the list:

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -321,7 +321,8 @@ kubectl create secret generic redpanda-superusers \
   --dry-run=client -o yaml | kubectl apply -f -
 ----
 +
-The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod polls the Secret resource for changes and triggers a rolling upgrade to add the new superusers to the Redpanda cluster.
+The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the mounted secret file for changes from the Kubernetes API. When changes are observed, it creates and updates users based on the new file content.
+.
 
 - If you created superusers using a YAML list, you can update the list:
 +

--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -322,7 +322,6 @@ kubectl create secret generic redpanda-superusers \
 ----
 +
 The xref:reference:k-redpanda-helm-spec.adoc#statefulset-sidecars-configwatcher-enabled[`config-watcher` sidecar] in the Pod watches the superusers Secret for changes. When changes are observed, it creates and updates users accordingly.
-.
 
 - If you created superusers using a YAML list, you can update the list:
 +


### PR DESCRIPTION
## Description

Removes description around rolling-updates as this was expected by customers who would wait for pods to update and manually restart their broker pods. Related to: https://redpandadata.atlassian.net/browse/K8S-645

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
