### PR TITLE
Iceberg: Emphasize setting REST catalog type and endpoint properties together

### DIFF
--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -59,6 +59,13 @@ To connect to a REST catalog, set the following cluster configuration properties
 
 * config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`]: `rest`
 * config_ref:iceberg_rest_catalog_endpoint,true,properties/cluster-properties[`iceberg_rest_catalog_endpoint`]: The endpoint URL for your Iceberg catalog, which you either manage directly, or is managed by an external catalog service.
+
+NOTE: You must set `iceberg_rest_catalog_endpoint` at the same time as you set `iceberg_catalog_type` to `rest`.
+
+==== Configure authentication
+
+To authenticate with the REST catalog, set the following cluster properties:
+
 * config_ref:iceberg_rest_catalog_authentication_mode,true,properties/cluster-properties[`iceberg_rest_catalog_authentication_mode`]: The authentication mode to use for the REST catalog. Choose from `oauth2`, `bearer`, or `none` (default).
 ifdef::env-cloud[]
 +

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -58,9 +58,9 @@ endif::[]
 To connect to a REST catalog, set the following cluster configuration properties:
 
 * config_ref:iceberg_catalog_type,true,properties/cluster-properties[`iceberg_catalog_type`]: `rest`
-* config_ref:iceberg_rest_catalog_endpoint,true,properties/cluster-properties[`iceberg_rest_catalog_endpoint`]: The endpoint URL for your Iceberg catalog, which you either manage directly, or is managed by an external catalog service.
+* config_ref:iceberg_rest_catalog_endpoint,true,properties/cluster-properties[`iceberg_rest_catalog_endpoint`]: The endpoint URL for your Iceberg catalog. You either manage this directly, or you have this managed by an external catalog service.
 
-NOTE: You must set `iceberg_rest_catalog_endpoint` at the same time as you set `iceberg_catalog_type` to `rest`.
+NOTE: You must set `iceberg_rest_catalog_endpoint` at the same time that you set `iceberg_catalog_type` to `rest`.
 
 ==== Configure authentication
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1898,6 +1898,8 @@ The frequency at which the Iceberg coordinator commits topic files to the catalo
 
 Iceberg catalog type that Redpanda will use to commit table metadata updates. Supported types: `rest`, `object_storage`.
 
+NOTE: You must set <<iceberg_rest_catalog_endpoint,`iceberg_rest_catalog_endpoint`>> at the same time as you set `iceberg_catalog_type` to `rest`.
+
 *Requires restart:* Yes
 
 *Visibility:* `user`
@@ -2175,6 +2177,8 @@ Path to certificate revocation list for `iceberg_rest_catalog_trust_file`.
 === iceberg_rest_catalog_endpoint
 
 URL of Iceberg REST catalog endpoint.
+
+NOTE: If you set <<iceberg_catalog_type,`iceberg_catalog_type`>> to `rest`, you must also set this property at the same time.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -1898,7 +1898,7 @@ The frequency at which the Iceberg coordinator commits topic files to the catalo
 
 Iceberg catalog type that Redpanda will use to commit table metadata updates. Supported types: `rest`, `object_storage`.
 
-NOTE: You must set <<iceberg_rest_catalog_endpoint,`iceberg_rest_catalog_endpoint`>> at the same time as you set `iceberg_catalog_type` to `rest`.
+NOTE: You must set <<iceberg_rest_catalog_endpoint,`iceberg_rest_catalog_endpoint`>> at the same time that you set `iceberg_catalog_type` to `rest`.
 
 *Requires restart:* Yes
 


### PR DESCRIPTION
## Description

This pull request updates the Iceberg catalog documentation to clarify configuration requirements and add details about authentication. The most important changes include adding notes about required property pairings and introducing a new section on authentication for the REST catalog.

### Updates to Iceberg catalog configuration requirements:

* [`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R62-R68): Added a note specifying that `iceberg_rest_catalog_endpoint` must be set alongside `iceberg_catalog_type` when using the `rest` catalog type.
* [`modules/reference/pages/properties/cluster-properties.adoc`](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1901-R1902): Added a similar note in two places to emphasize that `iceberg_rest_catalog_endpoint` must be configured concurrently with `iceberg_catalog_type` when set to `rest`. [[1]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R1901-R1902) [[2]](diffhunk://#diff-3fde27ab5428093199a2b3d7cb276434773ebceeaa97ca18a6c199fd6af459c9R2181-R2182)

### New section on authentication:

* [`modules/manage/partials/iceberg/use-iceberg-catalogs.adoc`](diffhunk://#diff-8a1d2144ab6d9a2c0149032efbcfcd9bade68a17cd3b60b8a1fd7027881db5f4R62-R68): Introduced a new subsection, "Configure authentication," detailing the `iceberg_rest_catalog_authentication_mode` property and its options (`oauth2`, `bearer`, or `none`).

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 

## Page previews

Self-managed: Use Iceberg Catalogs > [Set cluster properties](https://deploy-preview-1183--redpanda-docs-preview.netlify.app/current/manage/iceberg/use-iceberg-catalogs/#set-cluster-properties)
Cloud: Use Iceberg Catalogs > [Set cluster properties](https://deploy-preview-1183--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#set-cluster-properties)
Cluster properties > [iceberg_rest_catalog_endpoint](https://deploy-preview-1183--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/#iceberg_rest_catalog_endpoint)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
