### PR TITLE
Create link and describe resource utilization recommendations in Requirements and Recommendations

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -92,7 +92,7 @@ endif::[]
 
 - Each Redpanda broker must have at least 2 MB of memory for each topic partition replica.
 +
-The total memory available for partition replicas is determined as a percentage of the cluster's total memory, which is controlled by the xref:reference:tunable-properties.adoc#topic_partitions_memory_allocation_percent[`topic_partitions_memory_allocation_percent`] setting. Each partition replica consumes xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition`] bytes from this pool. If insufficient memory is available, topic operations will fail. You can adjust the allocation ratio using topic_partitions_memory_allocation_percent, but doing so is not recommended, as lowering it may lead to instability or degraded performance.
+The total memory available for partition replicas is determined as a percentage of the cluster's total memory, which is controlled by the xref:reference:tunable-properties.adoc#topic_partitions_memory_allocation_percent[`topic_partitions_memory_allocation_percent`] setting. Each partition replica consumes xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition`] bytes from this pool. If insufficient memory is available, topic operations will fail. You can adjust the allocation ratio using `topic_partitions_memory_allocation_percent`, but doing so is not recommended, as lowering it may lead to instability or degraded performance.
 
 *Recommendations*:
 

--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -78,14 +78,20 @@ endif::[]
 
 *Requirements*:
 
-- Two physical, not virtual, cores for each node.
+- Each node must have at least two physical CPU cores.
+- x86_64 (Westmere or newer) and AWS Graviton processors are supported.
+ifdef::env-kubernetes[]
+- Each Redpanda Pod requires at least 2 GiB of memory per core.
++
+** Request a minimum of 2.22 GiB per core to meet Redpanda's memory allocation strategy.
++
+See xref:manage:kubernetes/k-manage-resources.adoc[] for detailed guidance and examples.
+endif::[]
 
-- x86_64 (Westmere or newer) and AWS Graviton family processors are supported.
+- Each Redpanda broker must have at least 2 GB of memory per core.
 
-- 2 GB or more of memory per core.
-
-- 2 MB of memory for each topic partition replica.
-
+- Each Redpanda broker must have at least 2 MB of memory for each topic partition replica.
++
 The total memory available for partition replicas is determined as a percentage of the cluster's total memory, which is controlled by the xref:reference:tunable-properties.adoc#topic_partitions_memory_allocation_percent[`topic_partitions_memory_allocation_percent`] setting. Each partition replica consumes xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition`] bytes from this pool. If insufficient memory is available, topic operations will fail. You can adjust the allocation ratio using topic_partitions_memory_allocation_percent, but doing so is not recommended, as lowering it may lead to instability or degraded performance.
 
 *Recommendations*:
@@ -93,7 +99,23 @@ The total memory available for partition replicas is determined as a percentage 
 - Four physical cores for each node are strongly recommended.
 
 ifdef::env-kubernetes[]
-- xref:./kubernetes-deploy.adoc#resources[Set resource requests and limits for memory and CPU].
+== Pod resource configuration
+
+To ensure stable performance and predictable scheduling in Kubernetes, configure Redpanda Pods with appropriate CPU and memory requests and limits:
+
+* Set `resources.requests.memory` and `resources.limits.memory` to the same value.
+** Request at least 2.22 GiB of memory per core to meet Redpanda's heap and overhead requirements.
+* Set `resources.cpu.cores` to an even integer (for example, `4`, `6`, or `8`) to align with the Kubernetes static CPU manager policy.
+* Match CPU and memory resource settings for all containers in the Pod, including init containers and sidecars, to receive the `Guaranteed` QoS class.
+* Enable memory locking with the `--lock-memory` flag to prevent paging and improve performance.
+
+This configuration:
+
+* Grants Redpanda exclusive access to CPU cores and memory
+* Reduces the risk of throttling, eviction, and OOM kills
+* Provides predictable and isolated runtime performance
+
+See xref:manage:kubernetes/k-manage-resources.adoc[Manage Pod Resources in Kubernetes] for configuration examples using both Helm and the Redpanda Operator.
 endif::[]
 
 == Storage


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1253
Review deadline: July 3

This pull request updates the `modules/deploy/partials/requirements.adoc` file to clarify hardware requirements and improve Kubernetes-specific guidance for deploying Redpanda. The most important changes include rephrasing general hardware requirements, adding detailed Kubernetes memory recommendations, and introducing a new section on configuring Pod resources in Kubernetes.

### General hardware requirements:
* Rephrased the CPU and memory requirements for each node to improve clarity. For example, "Two physical, not virtual, cores for each node" was updated to "Each node must have at least two physical CPU cores."
* Updated memory requirements for Redpanda brokers to specify "at least 2 MB of memory for each topic partition replica" and clarified memory allocation strategies.

### Kubernetes-specific updates:
* Added a recommendation to request a minimum of 2.22 GiB of memory per core for Redpanda Pods to align with Redpanda's memory allocation strategy.
* Introduced a new "Pod resource configuration" section with detailed best practices for setting CPU and memory requests/limits in Kubernetes. This includes guidelines for achieving the `Guaranteed` QoS class and enabling memory locking for improved performance.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
