### PR TITLE
secrets update

### DIFF
--- a/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
+++ b/modules/get-started/pages/licensing/add-license-redpanda/kubernetes.adoc
@@ -25,8 +25,8 @@ You can store the license in a Kubernetes Secret and reference it in your Helm v
 +
 [,bash]
 ----
-kubectl create secret generic redpanda-license
---from-file=license=./redpanda.license
+kubectl create secret generic redpanda-license \
+--from-file=license=./redpanda.license \
 --namespace <namespace>
 ----
 +


### PR DESCRIPTION
was missing the \ on the command

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
