### PR TITLE
docs: update cloud_store_url_style description

### DIFF
--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1712,26 +1712,28 @@ Maximum backoff interval when there is nothing to upload for a partition, in mil
 
 === cloud_storage_url_style
 
-Configure the addressing style that controls how Redpanda formats bucket URLs when communicating with S3-compatible object storage.
+Configure the addressing style that controls how Redpanda formats bucket URLs for S3-compatible object storage.
 
 Leave this property unset (`null`) to use automatic configuration:
 
 * For AWS S3: Redpanda attempts `virtual_host` addressing first, then falls back to `path` style if needed
 * For MinIO: Redpanda automatically uses `path` style regardless of `MINIO_DOMAIN` configuration
 
-Set this property explicitly when:
+Set this property explicitly to override automatic configuration, ensure consistent behavior across deployments, or when using S3-compatible storage that requires a specific URL format.
 
-* You use S3-compatible storage that requires a specific URL format
-* You want to override the default MinIO behavior (for example, to use `virtual_host` with a properly configured `MINIO_DOMAIN`)
-* You want consistent behavior across deployments
+CAUTION: AWS deprecated path-style addressing for buckets created after September 30, 2020. If you use Amazon S3 with newly created buckets, use `virtual_host` addressing.
 
-NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. If you have configured `MINIO_DOMAIN` and want to use `virtual_host` addressing, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style. 
+NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. To use `virtual_host` addressing with a configured `MINIO_DOMAIN`, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style.
 
 *Requires restart:* Yes
 
 *Visibility:* `user`
 
-*Accepted values:* 
+*Type:* string
+
+*Accepted values:* [`virtual_host`, `path`, `null`]
+
+*Example formats:*
 
 * `virtual_host` - Example: `<bucket-name>.s3.amazonaws.com` 
 * `path` - Example: `s3.amazonaws.com/<bucket-name>`

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1712,7 +1712,7 @@ Maximum backoff interval when there is nothing to upload for a partition, in mil
 
 === cloud_storage_url_style
 
-Configure the addressing style for Amazon S3 requests. This property controls how Redpanda formats S3 bucket URLs when communicating with object storage.
+Configure the addressing style that controls how Redpanda formats bucket URLs when communicating with S3-compatible object storage.
 
 Leave this property unset (`null`) to use automatic configuration:
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1725,7 +1725,7 @@ Set this property explicitly when:
 * You want to override the default MinIO behavior (for example, to use `virtual_host` with a properly configured `MINIO_DOMAIN`)
 * You want consistent behavior across deployments
 
-NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. If you have configured `MINIO_DOMAIN` and want to use `virtual_host` addressing, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style.
+NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. If you have configured `MINIO_DOMAIN` and want to use `virtual_host` addressing, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style. 
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1712,13 +1712,20 @@ Maximum backoff interval when there is nothing to upload for a partition, in mil
 
 === cloud_storage_url_style
 
-Specifies the addressing style to use for Amazon S3 requests. This configuration determines how S3 bucket URLs are formatted. Path style is supported for backward compatibility with legacy systems. 
+Configure the addressing style for Amazon S3 requests. This property controls how Redpanda formats S3 bucket URLs when communicating with object storage.
 
-When this property is not set (`null`), the client tries to use `virtual_host` addressing. 
+Leave this property unset (`null`) to use automatic configuration:
 
-If the initial request fails, the client automatically tries the `path` style. 
+* For AWS S3: Redpanda attempts `virtual_host` addressing first, then falls back to `path` style if needed
+* For MinIO: Redpanda automatically uses `path` style regardless of `MINIO_DOMAIN` configuration
 
-If neither addressing style works, Redpanda terminates the startup, requiring manual configuration to proceed.
+Set this property explicitly when:
+
+* You use S3-compatible storage that requires a specific URL format
+* You want to override the default MinIO behavior (for example, to use `virtual_host` with a properly configured `MINIO_DOMAIN`)
+* You want consistent behavior across deployments
+
+NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. If you have configured `MINIO_DOMAIN` and want to use `virtual_host` addressing, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style.
 
 *Requires restart:* Yes
 
@@ -1728,7 +1735,7 @@ If neither addressing style works, Redpanda terminates the startup, requiring ma
 
 * `virtual_host` - Example: `<bucket-name>.s3.amazonaws.com` 
 * `path` - Example: `s3.amazonaws.com/<bucket-name>`
-* `null`
+* `null` - Enable automatic configuration
 
 *Default:* `null`
 

--- a/modules/reference/pages/properties/object-storage-properties.adoc
+++ b/modules/reference/pages/properties/object-storage-properties.adoc
@@ -1721,7 +1721,7 @@ Leave this property unset (`null`) to use automatic configuration:
 
 Set this property explicitly to override automatic configuration, ensure consistent behavior across deployments, or when using S3-compatible storage that requires a specific URL format.
 
-CAUTION: AWS deprecated path-style addressing for buckets created after September 30, 2020. If you use Amazon S3 with newly created buckets, use `virtual_host` addressing.
+CAUTION: AWS requires virtual-hosted addressing for buckets created after September 30, 2020. If you use AWS S3 with buckets created after this date, use `virtual_host` addressing.
 
 NOTE: For MinIO deployments, Redpanda defaults to `path` style when this property is unset. To use `virtual_host` addressing with a configured `MINIO_DOMAIN`, set this property explicitly to `virtual_host`. For other S3-compatible storage backends, consult your provider's documentation to determine the required URL style.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1462
Review deadline:

Due to changes requested in https://redpandadata.atlassian.net/browse/DOC-1482 and behavior modification introduced in https://github.com/redpanda-data/redpanda/pull/26690 we rewrote the entire object description.

When this doc PR is merged, description improvements will be introduced in https://github.com/redpanda-data/redpanda/blob/dev/src/v/config/configuration.cc#L2050

Added caution notice per https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/ and
https://aws.amazon.com/blogs/storage/update-to-amazon-s3-path-deprecation-plan/

## Page previews

https://deploy-preview-1229--redpanda-docs-preview.netlify.app/current/reference/properties/object-storage-properties/#cloud_storage_url_style

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
