### PR TITLE
Remove mention of Console v3

### DIFF
--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -15,12 +15,6 @@ link:https://github.com/redpanda-data/redpanda-operator/blob/release/v25.1.x/ope
 
 See also: xref:deploy:deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc[]
 
-=== Redpanda Console v3
-
-This beta version deploys Redpanda Console v3, which includes unified authentication and authorization between the Console and Redpanda, including user impersonation. For more information, see xref:console:config/security/authentication.adoc[].
-
-This version does not support Redpanda Console v2.
-
 === Flux removed
 
 This release completely removes Flux and its CRDs. The Redpanda Operator now manages all resources. The `chartRef.useFlux` configuration is still available for backwards compatibility but MUST be set to `false`.


### PR DESCRIPTION
The operator was going to support v3 but it was removed from scope. Docs wasn't updated for the beta.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
