### PR TITLE
Fix deprecated kubectl version --short --client command

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/aks-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/aks-guide.adoc
@@ -17,7 +17,7 @@ to get access to the Azure CLI.
 +
 [,bash]
 ----
-kubectl version --short --client
+kubectl version --client
 ----
 
 * Install https://helm.sh/docs/intro/install/[Helm^]. Minimum required Helm version: {supported-helm-version}

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/eks-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/eks-guide.adoc
@@ -230,7 +230,7 @@ You must have https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.h
 To check if you have `kubectl` installed:
 
 ```bash
-kubectl version --short --client
+kubectl version --client
 ```
 
 === Helm

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/gke-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/gke-guide.adoc
@@ -16,7 +16,7 @@ Deploy a secure Redpanda cluster and Redpanda Console in Google Kubernetes Engin
 +
 [,bash]
 ----
-kubectl version --short --client
+kubectl version --client
 ----
 
 * Ensure https://helm.sh/docs/intro/install/[Helm^] is installed. Minimum required Helm version: {supported-helm-version}

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deploy-connectors.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-deploy-connectors.adoc
@@ -38,7 +38,7 @@ NOTE: If you want to use other connectors, you must create a custom Docker image
 To check if you have `kubectl` installed:
 +
 ```bash
-kubectl version --short --client
+kubectl version --client
 ```
 
 - https://helm.sh/docs/intro/install/[Helm^] installed with at least version {supported-helm-version}.

--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/local-guide.adoc
@@ -50,7 +50,7 @@ minikube::
 * https://kubernetes.io/docs/tasks/tools/[Install `kubectl`^]. Minimum required Kubernetes version: {supported-kubernetes-version}
 +
 ```bash
-kubectl version --short --client
+kubectl version --client
 ```
 
 * https://helm.sh/docs/intro/install/[Install Helm^]. Minimum required Helm version: {supported-helm-version}

--- a/modules/manage/partials/monitor-connectors.adoc
+++ b/modules/manage/partials/monitor-connectors.adoc
@@ -15,7 +15,7 @@ To check if you have `kubectl` installed:
 +
 [,bash]
 ----
-kubectl version --short --client
+kubectl version --client
 ----
 
 - https://helm.sh/docs/intro/install/[Helm^] installed with at least version {supported-helm-version}.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1561
Resolves https://github.com/redpanda-data/redpanda/issues/27062
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
