### PR TITLE
Add alias for 25.1 beta operator

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-production-deployment.adoc
@@ -1,7 +1,7 @@
 = Deploy Redpanda for Production in Kubernetes
 :description: Deploy a Redpanda cluster in Kubernetes.
 :tags: ["Kubernetes"]
-:page-aliases: deploy:deployment-option/self-hosted/kubernetes/kubernetes-best-practices.adoc, deploy:deployment-option/self-hosted/kubernetes/redpanda-cluster-recommendations.adoc, deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc
+:page-aliases: deploy:deployment-option/self-hosted/kubernetes/kubernetes-best-practices.adoc, deploy:deployment-option/self-hosted/kubernetes/redpanda-cluster-recommendations.adoc, deploy:deployment-option/self-hosted/kubernetes/kubernetes-deploy.adoc, deploy:deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc
 :page-toclevels: 1
 :env-kubernetes: true
 :page-categories: Deployment, GitOps


### PR DESCRIPTION
## Description

This pull request makes a minor documentation update by adding a new page alias to the Kubernetes production deployment guide. This helps redirect users from an older or alternate documentation path to the current page.

* Documentation update:
  * Added `deploy:deployment-option/self-hosted/kubernetes/k-25.1-beta.adoc` as a page alias in `k-production-deployment.adoc` to improve navigation and maintain backward compatibility with previous documentation links.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
