### PR TITLE
DOC-422: Clarify log_compression_type behavior

### DIFF
--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3752,9 +3752,9 @@ Use sliding window compaction.
 
 === log_compression_type
 
-IMPORTANT: Only the `producer` value has any effect. Redpanda brokers do not compress or recompress data based on this property. If producers send compressed data, Redpanda stores it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
+IMPORTANT: Regardless of the value specified, it is ignored. The behavior is always the same as the `producer` value. Redpanda brokers do not compress or recompress data based on this property. If producers send compressed data, Redpanda stores it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
 
-Default topic compression type.
+Default for the Kafka-compatible compression.type property. Redpanda does not recompress data.
 
 The topic property xref:./topic-properties.adoc#compressiontype[`compression.type`] overrides the value of `log_compression_type` at the topic level.
 
@@ -3762,7 +3762,7 @@ The topic property xref:./topic-properties.adoc#compressiontype[`compression.typ
 
 *Visibility:* `user`
 
-*Accepted Values:* `gzip`, `snappy`, `lz4`, `zstd`, `producer`, `none`.
+*Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored by the broker: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
 
 *Default:* `producer`
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3752,6 +3752,8 @@ Use sliding window compaction.
 
 === log_compression_type
 
+IMPORTANT: Functionally, this property serves to provide compatibility with Apache Kafka. It is visible when you describe a topic in the Admin API; otherwise, it is ignored.
+
 Default topic compression type.
 
 The topic property xref:./topic-properties.adoc#compressiontype[`compression.type`] overrides the value of `log_compression_type` at the topic level.

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3752,7 +3752,7 @@ Use sliding window compaction.
 
 === log_compression_type
 
-IMPORTANT: Regardless of the value specified, it is ignored. The behavior is always the same as the `producer` value. Redpanda brokers do not compress or recompress data based on this property. If producers send compressed data, Redpanda stores it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
+IMPORTANT: This property is ignored regardless of the value specified. The behavior is always the same as the `producer` value. Redpanda brokers do not compress or recompress data based on this property. If producers send compressed data, Redpanda stores it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and `rpk topic describe` outputs for compatibility.
 
 Default for the Kafka-compatible compression.type property. Redpanda does not recompress data.
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -3752,7 +3752,7 @@ Use sliding window compaction.
 
 === log_compression_type
 
-IMPORTANT: Functionally, this property serves to provide compatibility with Apache Kafka. It is visible when you describe a topic in the Admin API; otherwise, it is ignored.
+IMPORTANT: Only the `producer` value has any effect. Redpanda brokers do not compress or recompress data based on this property. If producers send compressed data, Redpanda stores it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
 
 Default topic compression type.
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -367,7 +367,7 @@ Configure properties for the messages of a topic:
 [[compressiontype]]
 === compression.type
 
-IMPORTANT: Functionally, this property serves to provide compatibility with Apache Kafka. It is visible when you describe a topic in the Admin API; otherwise, it is ignored.
+IMPORTANT: Only the `producer` value has any effect. Redpanda brokers do not compress or recompress messages to match this setting. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
 
 The type of compression algorithm to apply for all messages of a topic. When a compression type is set for a topic, producers compress and send messages, nodes (brokers) store and send compressed messages, and consumers receive and uncompress messages.
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -367,6 +367,8 @@ Configure properties for the messages of a topic:
 [[compressiontype]]
 === compression.type
 
+IMPORTANT: Functionally, this property serves to provide compatibility with Apache Kafka. It is visible when you describe a topic in the Admin API; otherwise, it is ignored.
+
 The type of compression algorithm to apply for all messages of a topic. When a compression type is set for a topic, producers compress and send messages, nodes (brokers) store and send compressed messages, and consumers receive and uncompress messages.
 
 Enabling compression reduces message size, which improves throughput and decreases storage for messages with repetitive values and data structures. The trade-off is increased CPU utilization and network latency to perform the compression. You can also enable producer batching to increase compression efficiency, since the messages in a batch likely have repeated data that can be compressed.

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -367,9 +367,9 @@ Configure properties for the messages of a topic:
 [[compressiontype]]
 === compression.type
 
-IMPORTANT: Only the `producer` value has any effect. Redpanda brokers do not compress or recompress messages to match this setting. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
+IMPORTANT: Regardless of the value specified, it is ignored. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
 
-The type of compression algorithm to apply for all messages of a topic. When a compression type is set for a topic, producers compress and send messages, nodes (brokers) store and send compressed messages, and consumers receive and uncompress messages.
+Redpanda does not enforce or change compression for stored data; configure compression in your producers.
 
 Enabling compression reduces message size, which improves throughput and decreases storage for messages with repetitive values and data structures. The trade-off is increased CPU utilization and network latency to perform the compression. You can also enable producer batching to increase compression efficiency, since the messages in a batch likely have repeated data that can be compressed.
 
@@ -379,14 +379,7 @@ NOTE: The valid values of `compression.type` are taken from `log_compression_typ
 
 **Default**: `none`
 
-**Values**:
-
-- `none`
-- `gzip`
-- `lz4`
-- `snappy`
-- `zstd`
-- `producer`
+*Accepted Values:* `producer`. The following values are accepted for Kafka compatibility but ignored by the broker: `gzip`, `snappy`, `lz4`, `zstd`, `none`.
 
 **Related topics**:
 

--- a/modules/reference/pages/properties/topic-properties.adoc
+++ b/modules/reference/pages/properties/topic-properties.adoc
@@ -367,7 +367,7 @@ Configure properties for the messages of a topic:
 [[compressiontype]]
 === compression.type
 
-IMPORTANT: Regardless of the value specified, it is ignored. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and rpk topic describe outputs for compatibility.
+IMPORTANT:  This property is ignored regardless of the value specified. The behavior is always the same as the `producer` value. If producers send compressed data, Redpanda stores and serves it as-is; if producers send uncompressed data, Redpanda stores it uncompressed. Other listed values are accepted for Apache Kafka compatibility but are ignored by the broker. This property may appear in Admin API and `rpk topic describe` outputs for compatibility.
 
 Redpanda does not enforce or change compression for stored data; configure compression in your producers.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-422
Review deadline: **Monday August 18th**

## Page previews
[log_compression_type](https://deploy-preview-1320--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#log_compression_type) cluster property

[compression.type](https://deploy-preview-1320--redpanda-docs-preview.netlify.app/current/reference/properties/topic-properties/#compressiontype) topic property
## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
