### PR TITLE
DOC-1221

### DIFF
--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -180,7 +180,7 @@ Each subject has three properties that are configurable to bind a role to one or
 
 | group
 | GitHub
-| GitHub team name (slug) within your GitHub organization. You must also specify the `organization` field.
+| GitHub team name within your GitHub organization. You must also specify the `organization` field.
 
 | user
 | Keycloak
@@ -256,7 +256,7 @@ roleBindings:
         name: 00gcgwvqiwitcrgge696  # Okta Group ID
       - kind: group
         provider: GitHub
-        name: engineers  # GitHub team name (slug)
+        name: engineers  # GitHub team name
         organization: redpanda-data # Required: GitHub organization name
       - kind: group
         provider: AzureAD

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -70,9 +70,11 @@ roles:
       - <permission-key>     # specific permission identifiers
 ----
 
-You need to specify the file paths to the roles configuration file and the role bindings configuration file in the main Redpanda Console configuration file. These file paths are set using the `rolesFilepath` and `roleBindingsFilepath` options under the `enterprise.rbac` configuration block. For example:
+You need to specify the file paths to the roles configuration file and the role bindings configuration file in the main Redpanda Console configuration file. These file paths are set using the `rolesFilepath` and `roleBindingsFilepath` options under the `enterprise.rbac` configuration block. 
 
-NOTE: You only need a roles file if you want to define custom roles. If you only use the built-in roles (viewer, editor, admin), you can omit rolesFilepath.
+NOTE: You only need a roles file if you want to define custom roles. If you only use the built-in roles (viewer, editor, admin), you can omit `rolesFilepath`.
+
+For example:
 
 [,yaml]
 ----

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -55,9 +55,24 @@ The `admin` role grants all permissions that come with the `editor` role and add
 
 == Configure roles and role bindings
 
-Both roles and role binding configurations are applied through separate YAML files that Redpanda Console loads at startup. You need to specify the file paths to the roles configuration file and the role bindings configuration file in the main Redpanda Console configuration file. These file paths are set using the `rolesFilepath` and `roleBindingsFilepath` options under the `enterprise.rbac` configuration block.
+Redpanda Console provides three <<default-roles,default roles>> (viewer, editor, admin) that cover most use cases. You can also define custom roles with specific permissions through YAML configuration files.
 
-Here is an example of how to configure these file paths in your Redpanda Console configuration file:
+Both roles and role binding configurations are applied through separate YAML files that Redpanda Console loads at startup. 
+
+[,yaml]
+----
+# roles.yaml (example structure for custom roles)
+# Note: Default roles (viewer, editor, admin) are built-in and don't need to be defined here
+roles:
+  - name: <string>          # required, unique (for example, "topic-reader", "schema-admin")
+    description: <string>    # optional description of the role
+    permissions:             # list of UI capabilities/permissions
+      - <permission-key>     # specific permission identifiers
+----
+
+You need to specify the file paths to the roles configuration file and the role bindings configuration file in the main Redpanda Console configuration file. These file paths are set using the `rolesFilepath` and `roleBindingsFilepath` options under the `enterprise.rbac` configuration block. For example:
+
+NOTE: You only need a roles file if you want to define custom roles. If you only use the built-in roles (viewer, editor, admin), you can omit rolesFilepath.
 
 [,yaml]
 ----
@@ -66,16 +81,18 @@ licenseFilepath: "/etc/redpanda/redpanda.license"
 enterprise:
   rbac:
     enabled: true
+    rolesFilepath: "/etc/redpanda/roles.yaml"
     roleBindingsFilepath: "/etc/redpanda/role-bindings.yaml"
 ----
 
-- `roleBindingsFilepath` specifies the path to your role bindings file. This file should contain the role bindings that associate the <<default-roles, default roles>> with specific users or groups.
+- `rolesFilepath` specifies the path to your roles file. This file should contain custom role definitions beyond the default roles (viewer, editor, admin). If you only use default roles, this configuration is optional.
+- `roleBindingsFilepath` specifies the path to your role bindings file. This file should contain the role bindings that associate roles with specific users or groups.
 
 Ensure that the paths provided are correct and that the Redpanda Console process has read access to these files.
 
-* The `role-bindings.yaml` file should be stored in a secure location, with appropriate file permissions to prevent unauthorized access or modification.
-* Regularly review and update the `role-bindings.yaml` file to ensure that they reflect your organization's current access control policies.
-* After making changes to this file, restart Redpanda Console to apply the updates.
+* These files should be stored in a secure location, with appropriate file permissions to prevent unauthorized access or modification.
+* Regularly review and update the `role-bindings.yaml` file to ensure that it reflects your organization's current access control policies.
+* After making changes to these files, restart Redpanda Console to apply the updates.
 
 == Role bindings
 
@@ -129,6 +146,12 @@ Each subject has three properties that are configurable to bind a role to one or
 * `provider`: One of `AzureAD` (Microsoft Entra ID), `Google`, `GitHub`, `Keycloak`, `Okta`, `OIDC`, or `Plain`.
 * `name`: Depending on your `kind` and `provider`, the `name` property may refer to different things. Here is an overview:
 
+[NOTE]
+====
+* When `kind: group` and `provider: GitHub`, you must include an organization alongside the team name (as shown in the example). 
+* Group memberships are resolved at startup and cached for 15 minutes. Restart Console or wait for cache expiry for changes to take effect. 
+====
+
 [cols="1m,1m,2a"]
 |===
 | Kind | Provider | Name Reference
@@ -155,7 +178,7 @@ Each subject has three properties that are configurable to bind a role to one or
 
 | group
 | GitHub
-| GitHub team name within your GitHub organization
+| GitHub team name (slug) within your GitHub organization. You must also specify the `organization` field.
 
 | user
 | Keycloak
@@ -231,8 +254,8 @@ roleBindings:
         name: 00gcgwvqiwitcrgge696  # Okta Group ID
       - kind: group
         provider: GitHub
-        name: engineers  # GitHub Team ID
-        organization: redpanda-data # GitHub organization name
+        name: engineers  # GitHub team name (slug)
+        organization: redpanda-data # Required: GitHub organization name
       - kind: group
         provider: AzureAD
         name: ef0dd5b8-93c3-4a4f-9d90-cba243973d32 # AzureAD group's OID
@@ -246,7 +269,7 @@ roleBindings:
     subjects:
       - kind: group
         provider: Okta
-        name: 00gcgwvqiwitcrgge696 # Okta Group ID
+        name: 00gdh4p8udfkrjge123 # Different Okta Group ID for viewers
       - kind: user
         provider: GitHub
         name: nat # GitHub username

--- a/modules/console/pages/config/security/authorization.adoc
+++ b/modules/console/pages/config/security/authorization.adoc
@@ -64,10 +64,10 @@ Both roles and role binding configurations are applied through separate YAML fil
 # roles.yaml (example structure for custom roles)
 # Note: Default roles (viewer, editor, admin) are built-in and don't need to be defined here
 roles:
-  - name: <string>          # required, unique (for example, "topic-reader", "schema-admin")
-    description: <string>    # optional description of the role
-    permissions:             # list of UI capabilities/permissions
-      - <permission-key>     # specific permission identifiers
+  - name: <string>            # required, unique (for example, "topic-reader", "schema-admin")
+    description: <string>     # optional description of the role
+    permissions:              # list of UI capabilities/permissions
+      - <permission-key>      # specific permission identifiers
 ----
 
 You need to specify the file paths to the roles configuration file and the role bindings configuration file in the main Redpanda Console configuration file. These file paths are set using the `rolesFilepath` and `roleBindingsFilepath` options under the `enterprise.rbac` configuration block. 


### PR DESCRIPTION
## Description
This pull request updates the Redpanda Console authorization documentation to clarify how to configure roles and role bindings. The changes improve guidance on using built-in and custom roles, file configuration, and specifics for GitHub group bindings.

* Added documentation for defining custom roles in a `roles.yaml` file and clarified that built-in roles (viewer, editor, admin) do not need to be defined in this file. Also explained when the `rolesFilepath` option is required.
* Updated configuration examples and descriptions to specify the purpose of `rolesFilepath` and `roleBindingsFilepath`, and improved instructions on securely storing and updating these files.
* Improved example YAML to clarify the expected fields for GitHub and Okta group bindings, including the use of team name (slug) and organization for GitHub, and a corrected Okta group ID for viewers. [[1]](diffhunk://#diff-65034e6679891f34d1b838901ef6e5cf3098eca3fd92bddfac7e86265942bf74L234-R258) [[2]](diffhunk://#diff-65034e6679891f34d1b838901ef6e5cf3098eca3fd92bddfac7e86265942bf74L249-R272)

Resolves https://redpandadata.atlassian.net/browse/DOC-1221
Review deadline:

## Page previews
[Console/Authorization/Configure roles & role bindings](https://deploy-preview-1322--redpanda-docs-preview.netlify.app/24.3/console/config/security/authorization/#configure-roles-and-role-bindings)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
