### PR TITLE
[25.2] Bump topics cleanup

### DIFF
--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -66,7 +66,7 @@ To configure your Redpanda cluster to enable Iceberg on a topic and integrate wi
 
 ifdef::env-cloud[]
 . xref:manage:iceberg/use-iceberg-catalogs.adoc#store-a-secret-for-rest-catalog-authentication[Store the Open Catalog client secret in your cluster] using `rpk` or the Data Plane API.
-. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below using `rpk` or the Control Plane API. For example, to use `rpk cluster config set`, run:
+. xref:manage:iceberg/use-iceberg-catalogs.adoc#use-a-secret-in-cluster-configuration[Edit your cluster configuration] to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below using `rpk` or the Control Plane API. For example, to use `rpk cluster config set`, run:
 +
 [,bash]
 ----

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -14,7 +14,7 @@ This guide walks you through querying Redpanda topics as Iceberg tables in https
 == Prerequisites
 
 ifdef::env-cloud[]
-* `rpk` or familiarity with the Redpanda Cloud API to use secrets in your cluster configuration. For `rpk`, see xref:manage:rpk/rpk-install.adoc[]. For the Cloud API, you must xref:manage:api/cloud-api-authentication.adoc[authenticate] using a service account.
+* `rpk` or familiarity with the Redpanda Cloud API to use secrets in your cluster configuration. For `rpk`, see xref:manage:rpk/rpk-install.adoc[]. For the Cloud API, you must link:/api/cloud-controlplane/authentication[authenticate] using a service account.
 endif::[]
 ifndef::env-cloud[]
 * xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.

--- a/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/partials/iceberg/use-iceberg-catalogs.adoc
@@ -116,7 +116,7 @@ ifdef::env-cloud[]
 
 To store a secret that you can reference in your catalog authentication cluster properties, you must create the secret using `rpk` or the Data Plane API. Secrets are stored in the secret management solution of your cloud provider. Redpanda retrieves the secrets at runtime. 
 
-For more information, see xref:manage:rpk/intro-to-rpk.adoc[] and xref:manage:api/cloud-api-overview.adoc[].
+For more information, see xref:manage:rpk/intro-to-rpk.adoc[] and link:/api/doc/cloud-dataplane/topic/topic-cloud-api-overview[Cloud API Overview].
 
 If you need to configure any of the following properties, you must set their values using secrets:
 

--- a/modules/manage/partials/mountable-topics.adoc
+++ b/modules/manage/partials/mountable-topics.adoc
@@ -11,7 +11,7 @@ include::shared:partial$enterprise-license.adoc[]
 * Enable xref:manage:tiered-storage.adoc[Tiered Storage] for specific topics, or for the entire cluster (all topics).
 endif::[]
 ifdef::env-cloud[]
-xref:manage:rpk/rpk-install.adoc[Install `rpk`] or xref:manage:api/cloud-api-authentication.adoc[authenticate] to the Cloud API.
+xref:manage:rpk/rpk-install.adoc[Install `rpk`] or link:/api/doc/cloud-dataplane/authentication[authenticate] to the Cloud API.
 
 If using the API, make sure that you have the correct xref:manage:api/cloud-dataplane-api.adoc#get-data-plane-api-url[Data Plane API URL].
 endif::[]


### PR DESCRIPTION
## Description

This is the remainder of old xrefs that should now point to the new Bump API docs instead. This fixes build errors seen on the `main` branch -- more PRs will be open to clean up the rest of the xrefs in 25.1, 24.3, 24.2, and 24.1.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
