### PR TITLE
fix: unexpected use of --format flag.

### DIFF
--- a/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-config-set.adoc
+++ b/modules/reference/pages/rpk/rpk-redpanda/rpk-redpanda-config-set.adoc
@@ -55,13 +55,6 @@ the end of an array to extend it:
 rpk redpanda config set redpanda.advertised_kafka_api[1] '{address: 10.0.0.1, port: 9092}'
 ----
 
-The json format can be used to set values as json:
-
-[,bash]
-----
-rpk redpanda config set redpanda.rpc_server '{"address":"0.0.0.0","port":33145}' --format json
-----
-
 You may also use `<key>=<value>` notation for setting configuration properties:
 
 [,bash]


### PR DESCRIPTION
## Description

This is not a correct usage for this command.
The flag is a noop here.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
