### PR TITLE
Fix acceptance tests fetcher

### DIFF
--- a/.github/workflows/fetch-acceptance-tests.yml
+++ b/.github/workflows/fetch-acceptance-tests.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -27,7 +28,6 @@ jobs:
         with:
           ref: main
           token: ${{ env.ACTIONS_BOT_TOKEN }}
-          path: redpanda-docs
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -36,7 +36,7 @@ jobs:
         run: |
           npm install
       - name: Run the script and save the output
-        run: npx doc-tools fetch -o redpanda-data -r redpanda-operator -p acceptance/features -d ../../modules/manage/examples/kubernetes
+        run: npx doc-tools fetch -o redpanda-data -r redpanda-operator -p acceptance/features -d modules/manage/examples/kubernetes
         env:
           VBOT_GITHUB_API_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Create pull request
@@ -48,4 +48,3 @@ jobs:
           title: "auto-docs: Update K8s acceptance tests"
           body: "This PR auto-updates the acceptance tests we use as examples in our Kubernetes docs."
           labels: auto-docs
-          path: redpanda-docs


### PR DESCRIPTION
## Description

The changes focus on improving permissions for pull request automation and correcting file paths used by the workflow.

**Workflow permissions and automation:**

* Updated permissions for the workflow to allow write access to `contents` and `pull-requests`, enabling the workflow to create and modify pull requests automatically.

**File path corrections and cleanup:**

* Removed the `path: redpanda-docs` parameter from both the repository checkout and pull request creation steps, simplifying file handling. [[1]](diffhunk://#diff-c216c35fa7712cd7be675113952c46180328dde7d438e5cac626bf5ad2f39919L30) [[2]](diffhunk://#diff-c216c35fa7712cd7be675113952c46180328dde7d438e5cac626bf5ad2f39919L51)
* Fixed the directory argument in the `doc-tools fetch` command to use the correct relative path (`modules/manage/examples/kubernetes`) for acceptance test examples.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
