### PR TITLE
docs(oidc): remove role assignment statement

### DIFF
--- a/modules/manage/partials/security/oidc/limitations.adoc
+++ b/modules/manage/partials/security/oidc/limitations.adoc
@@ -4,8 +4,6 @@
 
 - The `rpk` CLI does not support OIDC login.
 
-- Redpanda Console cannot assign roles to OIDC principals. Roles must be assigned through `rpk`.
-
 - Redpanda requires OIDC principals to be set as superusers to access the Admin API. Granular authorization is not supported.
 
 - The `rpk` CLI does not support the SASL/OAUTHBEARER mechanism for deploying data transforms. Use SASL/SCRAM instead.


### PR DESCRIPTION
## Description
The assign role limitation is not true anymore, you can assign roles via the console UI

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
