### PR TITLE
Doc 1698: cluster settings: `iceberg_rest_catalog_base_location` bucket should always be the same as `cloud_storage_bucket`

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -136,6 +136,8 @@ iceberg_delete: false
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://glue.<glue-region>.amazonaws.com/iceberg
 iceberg_rest_catalog_authentication_mode: aws_sigv4
+ # Because Tiered Storage does not support the use of distinct buckets for Iceberg,
+ # always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
 iceberg_rest_catalog_base_location: s3://<bucket-name>/<warehouse-path>
 # Use the iceberg_rest_catalog_aws_* properties if you want to 
 # use separate AWS credentials for the catalog, or omit these lines to reuse S3 
@@ -171,10 +173,9 @@ rpk cluster config set \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
   # Because Tiered Storage does not support the use of distinct buckets for Iceberg,
-  # always place iceberg_rest_catalog_base_location in the same bucket as cloud_storage_bucket
-   
+  # always place iceberg_rest_catalog_base_location in the same S3 bucket as cloud_storage_bucket
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
-  # Set credentials source to config_file if using 
+  # Set credentials source to config_file if using
   # iceberg_rest_catalog_aws_access_key and iceberg_rest_catalog_aws_secret_key
   iceberg_rest_catalog_credentials_source=config_file \
   iceberg_rest_catalog_aws_region=<glue-region> \

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -170,8 +170,9 @@ rpk cluster config set \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
-  # Always place iceberg_rest_catalog_base_location in the same bucket as cloud_storage_bucket
-  # because Tiered Storage does not support the use of distinct buckets for Iceberg
+  # Because Tiered Storage does not support the use of distinct buckets for Iceberg,
+  # always place iceberg_rest_catalog_base_location in the same bucket as cloud_storage_bucket
+   
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
   # Set credentials source to config_file if using 
   # iceberg_rest_catalog_aws_access_key and iceberg_rest_catalog_aws_secret_key

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -170,6 +170,8 @@ rpk cluster config set \
   iceberg_catalog_type=rest \
   iceberg_rest_catalog_endpoint=https://glue.<glue-region>.amazonaws.com/iceberg \
   iceberg_rest_catalog_authentication_mode=aws_sigv4 \
+  # Always place iceberg_rest_catalog_base_location in the same bucket as cloud_storage_bucket
+  # because Tiered Storage does not support the use of distinct buckets for Iceberg
   iceberg_rest_catalog_base_location=s3://<bucket-name>/<warehouse-path> \
   # Set credentials source to config_file if using 
   # iceberg_rest_catalog_aws_access_key and iceberg_rest_catalog_aws_secret_key

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2335,7 +2335,7 @@ AWS service name for SigV4 signing when using aws_sigv4 authentication mode. Def
 NOTE: This property is available in Redpanda version 25.1.7 and later.
 
 Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
-If you require this option for AWS Glue, note that Tiered Storage does not support the use of distinct buckets for Iceberg, so be sure to always place `iceberg_rest_catalog_base_location` in the same S3 bucket as `cloud_storage_bucket`.
+If you use AWS Glue with Iceberg, the `iceberg_rest_catalog_base_location` must point to the same S3 bucket as `cloud_storage_bucket`. Tiered Storage does not support storing Iceberg data and catalog objects in different buckets. Use a single bucket for both.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2335,7 +2335,8 @@ AWS service name for SigV4 signing when using aws_sigv4 authentication mode. Def
 NOTE: This property is available in Redpanda version 25.1.7 and later.
 
 Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
-When using with Tiered Storage, always place `iceberg_rest_catalog_base_location` in the same bucket as `cloud_storage_bucket` because Tiered Storage does not support the use of distinct buckets for Iceberg.
+Because Tiered Storage does not support the use of distinct buckets for Iceberg,
+always place `iceberg_rest_catalog_base_location` in the same S3 bucket as `cloud_storage_bucket`.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2335,7 +2335,7 @@ AWS service name for SigV4 signing when using aws_sigv4 authentication mode. Def
 NOTE: This property is available in Redpanda version 25.1.7 and later.
 
 Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
-If you use AWS Glue with Iceberg, the `iceberg_rest_catalog_base_location` must point to the same S3 bucket as `cloud_storage_bucket`. Tiered Storage does not support storing Iceberg data and catalog objects in different buckets. Use a single bucket for both.
+NOTE: Specify `iceberg_rest_catalog_base_location` only when your catalog explicitly requires it (for example, for AWS Glue); otherwise, leave it unset and the REST catalog will choose the location. If you provide a value, it must use the same S3 bucket as `cloud_storage_bucket` because Tiered Storage does not support separate Iceberg buckets. Once Iceberg is enabled, do not change this value.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2335,6 +2335,7 @@ AWS service name for SigV4 signing when using aws_sigv4 authentication mode. Def
 NOTE: This property is available in Redpanda version 25.1.7 and later.
 
 Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
+When using with Tiered Storage, always place `iceberg_rest_catalog_base_location` in the same bucket as `cloud_storage_bucket` because Tiered Storage does not support the use of distinct buckets for Iceberg.
 
 *Requires restart:* Yes
 

--- a/modules/reference/pages/properties/cluster-properties.adoc
+++ b/modules/reference/pages/properties/cluster-properties.adoc
@@ -2335,8 +2335,7 @@ AWS service name for SigV4 signing when using aws_sigv4 authentication mode. Def
 NOTE: This property is available in Redpanda version 25.1.7 and later.
 
 Base URI for the Iceberg REST catalog. If unset, the REST catalog server determines the location. Some REST catalogs, like AWS Glue, require the client to set this. After Iceberg is enabled, do not change this value.
-Because Tiered Storage does not support the use of distinct buckets for Iceberg,
-always place `iceberg_rest_catalog_base_location` in the same S3 bucket as `cloud_storage_bucket`.
+If you require this option for AWS Glue, note that Tiered Storage does not support the use of distinct buckets for Iceberg, so be sure to always place `iceberg_rest_catalog_base_location` in the same S3 bucket as `cloud_storage_bucket`.
 
 *Requires restart:* Yes
 


### PR DESCRIPTION
## Description

**SMEs:** Does this apply for _both_ Self-Managed and Cloud? Please advise. Thx

Resolves https://redpandadata.atlassian.net/browse/DOC-1698
Review deadline: **10/09/2025**

## Page previews

[Update cluster configuration](https://deploy-preview-1379--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-aws-glue/#update-cluster-configuration)

[iceberg_rest_catalog_base_location](https://deploy-preview-1379--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#iceberg_rest_catalog_base_location)

## Checks

- [ ] New feature
- [ ] Content gap
- [ X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
