### PR TITLE
DOC-1719: Update incorrect OIDC examples

### DIFF
--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -1281,7 +1281,7 @@ authorization:
   roleBindings:
   - roleName: editor
     users:
-      - loginType: oidc
+      - loginType: OIDC
         name: "<sub-from-token>"
 ----
 --
@@ -1316,7 +1316,7 @@ spec:
             roleBindings:
             - roleName: editor
               users:
-                - loginType: oidc
+                - loginType: OIDC
                   name: "<sub-from-token>"
 ----
 
@@ -1337,7 +1337,7 @@ console:
         roleBindings:
         - roleName: editor
           users:
-            - loginType: oidc
+            - loginType: OIDC
               name: "<sub-from-token>"
 ----
 ====
@@ -1361,7 +1361,7 @@ config:
     roleBindings:
     - roleName: editor
       users:
-        - loginType: oidc
+        - loginType: OIDC
           name: "<sub-from-token>"
 ----
 
@@ -1618,7 +1618,7 @@ authorization:
   roleBindings:
   - roleName: admin
     users:
-      - loginType: oidc
+      - loginType: OIDC
         name: "<sub-from-token>"
 ----
 --
@@ -1654,7 +1654,7 @@ spec:
             roleBindings:
             - roleName: admin
               users:
-                - loginType: oidc
+                - loginType: OIDC
                   name: "<sub-from-token>"
 ----
 
@@ -1676,7 +1676,7 @@ console:
         roleBindings:
         - roleName: admin
           users:
-            - loginType: oidc
+            - loginType: OIDC
               name: "<sub-from-token>"
 ----
 ====
@@ -1701,7 +1701,7 @@ config:
     roleBindings:
     - roleName: admin
       users:
-        - loginType: oidc
+        - loginType: OIDC
           name: "<sub-from-token>"
 ----
 


### PR DESCRIPTION
## Description

The update standardizes the loginType value from "oidc" to "OIDC" across YAML/Adoc examples in modules/console/pages/config/security/authentication.adoc. Multiple example blocks for authorization, spec, console, config, and deployment contexts were edited to use the uppercase "OIDC". No other content, structure, or semantics were changed, and no public or exported entities were modified.

Resolves [https://redpandadata.atlassian.net/browse/<jira-ticket>](https://redpandadata.atlassian.net/browse/DOC-1719)
Review deadline: **10/09/2025**

## Page previews
[Static credentials with OIDC bearer token](https://deploy-preview-1380--redpanda-docs-preview.netlify.app/current/console/config/security/authentication/#static-credentials-with-oidc-bearer-token)

Same heading, but different URL/section):
[Static credentials with OIDC bearer token](https://deploy-preview-1380--redpanda-docs-preview.netlify.app/current/console/config/security/authentication/#static-credentials-with-oidc-bearer-token-2)

## Checks

- [ ] New feature
- [ ] Content gap
- [ X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
