### PR TITLE
docs: remove schema from the listener configuration

### DIFF
--- a/modules/manage/pages/security/listener-configuration.adoc
+++ b/modules/manage/pages/security/listener-configuration.adoc
@@ -92,7 +92,7 @@ redpanda:
 
   advertised_kafka_api:
     - name: tls_listener
-      address: https://kafka.example.com
+      address: redpanda.example.com
       port: 9094
 
   kafka_api_tls:
@@ -104,7 +104,7 @@ redpanda:
       require_client_auth: true
 ----
 
-Ensure `kafka.example.com` matches the SAN in `broker.crt` and that clients trust the `ca.crt`.
+Ensure `redpanda.example.com` matches the SAN in `broker.crt` and that clients trust the `ca.crt`.
 
 == Mixed-mode authentication with multiple listeners
 


### PR DESCRIPTION
This can produce unexpected results on clients downstream, and opting for TLS in the configuration should be enough, as it's currently documented.

See https://github.com/redpanda-data/redpanda/discussions/27933

## Description

Resolves: N/A
Review deadline: N/A (would love Core eyes before merging)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)
