### PR TITLE
Lowercase field names required for Glue

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -39,7 +39,7 @@ endif::[]
 
 === Lowercase field names required
 
-You must use only lowercase field names. AWS Glue automatically converts all table column names to lowercase. Redpanda relies on exact column name matching to manage schemas, and using uppercase letters can break schema management when Redpanda can't find matching columns.
+Use only lowercase field names. AWS Glue converts all table column names to lowercase, and Redpanda requires exact column name matches to manage schemas. Using uppercase letters prevents Redpanda from finding matching columns, which breaks schema management.
 
 === Nested partition spec support
 

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -37,6 +37,10 @@ endif::[]
 
 == Limitations
 
+=== Lowercase field names required
+
+You must use only lowercase field names. AWS Glue automatically converts all table column names to lowercase. Redpanda matches columns by name for schema management, and using uppercase letters can cause errors when Redpanda can't find matching columns.
+
 === Nested partition spec support
 
 AWS Glue does not support partitioning on nested fields. If Redpanda detects that

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -39,7 +39,7 @@ endif::[]
 
 === Lowercase field names required
 
-You must use only lowercase field names. AWS Glue automatically converts all table column names to lowercase. Redpanda matches columns by name for schema management, and using uppercase letters can cause errors when Redpanda can't find matching columns.
+You must use only lowercase field names. AWS Glue automatically converts all table column names to lowercase. Redpanda relies on exact column name matching to manage schemas, and using uppercase letters can break schema management when Redpanda can't find matching columns.
 
 === Nested partition spec support
 


### PR DESCRIPTION
## Description

This pull request adds an important clarification to the documentation for AWS Glue integration, specifically regarding field naming requirements. The update highlights a limitation that requires all table column names to be lowercase to avoid schema matching errors.

Documentation update for AWS Glue integration:

* Added a new section explaining that only lowercase field names are supported, as AWS Glue automatically converts all column names to lowercase. This prevents errors in Redpanda when matching columns for schema management.

Resolves https://redpandadata.atlassian.net/browse/1748
Review deadline:

## Page previews

https://deploy-preview-1387--redpanda-docs-preview.netlify.app/current/manage/iceberg/iceberg-topics-aws-glue/#lowercase-field-names-required

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
