### PR TITLE
DOC-1720 Customer-Incident-Delete Records

### DIFF
--- a/modules/develop/partials/delete-topic-records.adoc
+++ b/modules/develop/partials/delete-topic-records.adoc
@@ -1,6 +1,6 @@
 == Delete records from a topic
 
-Redpanda lets you delete data from the beginning of a partition up to a specific event, also known as offset. The offset represents the true creation time of the event, not the time when it was stored by Redpanda. Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Do this when you know that all consumers have read up to that given offset, and the data is no longer needed.
+Redpanda lets you delete data from the beginning of a partition up to a specific event, also known as offset. The offset represents the true creation time of the event, not the time when it was stored by Redpanda. Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Delete records when you know that all consumers have read up to that given offset, and the data is no longer needed.
 
 There are different ways to delete records from a topic, including using the xref:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[`rpk topic trim-prefix`] command, using the `DeleteRecords` Kafka API with Kafka clients, or using {ui}.
 

--- a/modules/develop/partials/delete-topic-records.adoc
+++ b/modules/develop/partials/delete-topic-records.adoc
@@ -1,6 +1,6 @@
 == Delete records from a topic
 
-Redpanda lets you delete data from the beginning of a partition up to a specific event, also known as offset. The offset represents the true creation time of the event, not the time when it was stored by Redpanda. Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Delete records when you know that all consumers have read up to that given offset, and the data is no longer needed.
+Redpanda lets you delete data from the beginning of a partition up to a specific offset (a monotonically increasing sequence number for records in a partition). Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Delete records when you know that all consumers have read up to that given offset, and the data is no longer needed. 
 
 There are different ways to delete records from a topic, including using the xref:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[`rpk topic trim-prefix`] command, using the `DeleteRecords` Kafka API with Kafka clients, or using {ui}.
 

--- a/modules/develop/partials/delete-topic-records.adoc
+++ b/modules/develop/partials/delete-topic-records.adoc
@@ -2,7 +2,7 @@
 
 Redpanda lets you delete data from the beginning of a partition up to a specific event, also known as offset. The offset represents the true creation time of the event, not the time when it was stored by Redpanda. Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Do this when you know that all consumers have read up to that given offset, and the data is no longer needed.
 
-There are different ways to delete records from a topic, including using the xref:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[`rpk topic trim-prefix`] command or using the `DeleteRecords` Kafka API with Kafka clients.
+There are different ways to delete records from a topic, including using the xref:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[`rpk topic trim-prefix`] command, using the `DeleteRecords` Kafka API with Kafka clients, or using {ui}.
 
 [NOTE]
 ====

--- a/modules/develop/partials/delete-topic-records.adoc
+++ b/modules/develop/partials/delete-topic-records.adoc
@@ -10,3 +10,5 @@ There are different ways to delete records from a topic, including using the xre
 - Object storage is deleted asynchronously. After messages are deleted, the partition's start offset will have advanced, but garbage collection of deleted segments may not be complete.
 - Similar to Kafka, after deleting records, local storage and object storage may still contain data for deleted offsets. (Redpanda does not truncate segments. Instead, it bumps the start offset, then it attempts to delete as many whole segments as possible.) Data before the new start offset is not visible to clients but could be read by someone with access to the local disk of a Redpanda node.
 ====
+
+include::shared:partial$warning-delete-records.adoc[]

--- a/modules/develop/partials/delete-topic-records.adoc
+++ b/modules/develop/partials/delete-topic-records.adoc
@@ -1,6 +1,6 @@
 == Delete records from a topic
 
-Redpanda lets you delete data from the beginning of a partition up to a specific offset (a monotonically increasing sequence number for records in a partition). Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than you anticipated in your retention plan. Delete records when you know that all consumers have read up to that given offset, and the data is no longer needed. 
+Redpanda allows you to delete data from the beginning of a partition up to a specific offset (a monotonically increasing sequence number for records in a partition). Deleting records frees up disk space, which is especially helpful if your producers are pushing more data than anticipated in your retention plan. Delete records when you know that all consumers have read up to that given offset, and the data is no longer needed. 
 
 There are different ways to delete records from a topic, including using the xref:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[`rpk topic trim-prefix`] command, using the `DeleteRecords` Kafka API with Kafka clients, or using {ui}.
 

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
@@ -10,9 +10,7 @@ within the segment before the requested offset can no longer be read.
 
 The `--offset/-o` flag allows you to indicate which index you want to set the
 partition's low watermark (start offset) to. It can be a single integer value
-denoting the offset, or a timestamp if you prefix the offset with an '@'. You may
-select which partition you want to trim the offset from with the `--partitions/-p`
-flag.
+denoting the offset, or it can be a timestamp if you prefix the offset with an '@'. You can select which partition you want to trim the offset from with the `--partitions/-p` flag.
 
 The `--from-file` option allows to trim the offsets specified in a text file with
 the following format:
@@ -24,6 +22,8 @@ the following format:
 ----
 
 or the equivalent keyed JSON/YAML file.
+
+include::shared:partial$warning-delete-records.adoc[]
 
 == Examples
 

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
@@ -10,7 +10,7 @@ within the segment before the requested offset can no longer be read.
 
 The `--offset/-o` flag allows you to indicate which index you want to set the
 partition's low watermark (start offset) to. It can be a single integer value
-denoting the offset, or it can be a timestamp if you prefix the offset with an '@'. You can select which partition you want to trim the offset from with the `--partitions/-p` flag.
+denoting the offset, or it can be a timestamp if you prefix the offset with an '@'. You can select which partition to trim the offset from using the `--partitions/-p` flag.
 
 The `--from-file` option allows to trim the offsets specified in a text file with
 the following format:

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
@@ -5,7 +5,7 @@ Trim records from topics
 
 This command allows you to trim records from topics, where Redpanda
 sets the LogStartOffset for partitions to the requested offset. All segments
-whose base offset is less then the requested offset are deleted, and any records
+whose base offset is less than the requested offset are deleted, and any records
 within the segment before the requested offset can no longer be read.
 
 The `--offset/-o` flag allows you to indicate which index you want to set the

--- a/modules/shared/partials/warning-delete-records.adoc
+++ b/modules/shared/partials/warning-delete-records.adoc
@@ -1,6 +1,6 @@
 [WARNING]
 ====
-When you delete records from a topic with a timestamp, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
+When you delete records from a topic with a timestamp, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may result in unintended deletion of data. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid accidental data loss. For example:
 
 [,bash]
 ----

--- a/modules/shared/partials/warning-delete-records.adoc
+++ b/modules/shared/partials/warning-delete-records.adoc
@@ -1,0 +1,9 @@
+[WARNING]
+====
+When you pass a timestamp to `rpk topic trim-prefix` using `@<timestamp>`, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
+
+[,bash]
+----
+rpk topic consume <topic> -n 50 --format '%o %d{go[2006-01-02T15:04:05Z07:00]} %k %v'
+----
+====

--- a/modules/shared/partials/warning-delete-records.adoc
+++ b/modules/shared/partials/warning-delete-records.adoc
@@ -1,6 +1,6 @@
 [WARNING]
 ====
-When you pass a timestamp to `rpk topic trim-prefix` using `@<timestamp>`, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
+When you pass a timestamp to `rpk topic trim-prefix`, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
 
 [,bash]
 ----

--- a/modules/shared/partials/warning-delete-records.adoc
+++ b/modules/shared/partials/warning-delete-records.adoc
@@ -1,6 +1,6 @@
 [WARNING]
 ====
-When you pass a timestamp to `rpk topic trim-prefix`, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
+When you delete records from a topic with a timestamp, Redpanda advances the partition start offset to the first record whose timestamp is after the threshold. If record timestamps are not in order with respect to offsets, this may truncate an entire partition. Before using a timestamp, verify that timestamps increase in the same order as offsets in the topic to avoid unintended data loss. For example:
 
 [,bash]
 ----


### PR DESCRIPTION
## Description
This pull request improves documentation related to deleting records from a topic in Redpanda. The main focus is on clarifying the risks of using timestamps with the `rpk topic trim-prefix` command and ensuring users are aware of potential unintended data loss. 

* Added a new shared warning partial (`warning-delete-records.adoc`) that explains the risks of using timestamps with `rpk topic trim-prefix`, including potential for truncating an entire partition if timestamps are unordered.
* Included the new warning partial in both the general topic record deletion documentation (`delete-topic-records.adoc`) and the `rpk topic trim-prefix` reference documentation to alert users in both contexts. [[1]](diffhunk://#diff-365f4c59015bb50e67128532dfc486e2d24def485a58b9d7e6934fc6e62db843R13-R14) [[2]](diffhunk://#diff-512d0901046e9223ad2816cdaa1ebd5bdeaf9ea52baa17fbd275e2333fc9cd3fR26-R27)

Resolves https://redpandadata.atlassian.net/browse/DOC-1720
Review deadline:

## Page previews
rpk topic trim prefix ([SM](https://deploy-preview-1388--redpanda-docs-preview.netlify.app/current/reference/rpk/rpk-topic/rpk-topic-trim-prefix/), [Cloud](https://deploy-preview-1388--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-topic/rpk-topic-trim-prefix/))
Delete records from a topic ([SM](https://deploy-preview-1388--redpanda-docs-preview.netlify.app/current/develop/config-topics/#delete-records-from-a-topic), [Cloud](https://deploy-preview-1388--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/config-topics/#delete-records-from-a-topic))

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
