### PR TITLE
Add timeouts to quickstart tests to avoid failures

### DIFF
--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -186,7 +186,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 20000, "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:first-child td:nth-child(4) button", "elementText": "View", "timeout": 20000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -187,7 +187,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "timeout": 20000, "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 30000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -186,7 +186,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:first-child td:nth-child(4) button", "elementText": "View", "timeout": 20000, "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 20000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -180,6 +180,7 @@ image::console:overview.png[]
 // (step {"find": {"selector": "[data-testid='auth-password-input']", "timeout": 10000, "click": true, "type": "secretpassword"}})
 // (step {"find": {"selector": "button", "elementText": "Log in", "timeout": 10000, "click": true}})
 // (step {"wait": 30000})
+// (step {"checkLink": "http://localhost:8080/overview", "statusCodes": 200})
 // (step {"goTo": "http://localhost:8080/overview"})
 // (step {"wait": 30000})
 // (step {"screenshot": {"path": "../../modules/console/images/overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -186,7 +186,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 10000, "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 20000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -176,9 +176,9 @@ image::console:overview.png[]
 // (step {"checkLink": "http://localhost:8080/login", "statusCodes": 200})
 // (step {"goTo": "http://localhost:8080/login"})
 // (step {"wait": 30000})
-// (step {"find": {"selector": "[data-testid='auth-username-input']", "click": true, "type": "superuser"}})
-// (step {"find": {"selector": "[data-testid='auth-password-input']", "click": true, "type": "secretpassword"}})
-// (step {"find": {"selector": "button", "elementText": "Log in", "click": true}})
+// (step {"find": {"selector": "[data-testid='auth-username-input']", "timeout": 10000, "click": true, "type": "superuser"}})
+// (step {"find": {"selector": "[data-testid='auth-password-input']", "timeout": 10000, "click": true, "type": "secretpassword"}})
+// (step {"find": {"selector": "button", "elementText": "Log in", "timeout": 10000, "click": true}})
 // (step {"wait": 30000})
 // (step {"goTo": "http://localhost:8080/overview"})
 // (step {"wait": 30000})
@@ -186,7 +186,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 10000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -187,7 +187,7 @@ image::console:overview.png[]
 
 To view details about a specific broker, click *View* at the end of the row in the *Broker Details* table.
 
-// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "elementText": "View", "timeout": 20000, "click": true}})
+// (step {"find": {"selector": ".chakra-table tbody tr:last-child td:last-child button", "timeout": 20000, "click": true}})
 // (step {"wait": 15000})
 // (step {"screenshot": {"path": "../../modules/console/images/broker-overview.png", "overwrite": "aboveVariation", "maxVariation": 10}})
 

--- a/tests/setup-tests/fetch-versions-and-rpk.json
+++ b/tests/setup-tests/fetch-versions-and-rpk.json
@@ -56,7 +56,7 @@
           "description": "Use doc-tools to install any additional test dependencies.",
           "runShell": {
             "command": "npx doc-tools install-test-dependencies",
-            "timeout": 120000
+            "timeout": 300000
           }
         },
         {


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/docs/issues/1397

In CI, it sometimes takes a bit longer for the page to load after logging in. This PR increases the default timeout of 5000 to 10000 to give the page time to load.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
