### PR TITLE
Add schema registry endpoints to rpk config for the quickstart

### DIFF
--- a/tests/docker-compose/rpk-profile.yaml
+++ b/tests/docker-compose/rpk-profile.yaml
@@ -22,3 +22,11 @@ admin_api:
     - 127.0.0.1:19644 # Admin API for Broker 1: Accessible on localhost, port 19644
     - 127.0.0.1:29644 # Admin API for Broker 2: Accessible on localhost, port 29644
     - 127.0.0.1:39644 # Admin API for Broker 3: Accessible on localhost, port 39644
+
+# Configuration for connecting to the Redpanda Schema Registry API.
+schema_registry:
+  # List of Schema Registry API endpoints.
+  addresses:
+    - 127.0.0.1:18081 # Schema Registry API for Broker 1: Accessible on localhost, port 18081
+    - 127.0.0.1:28081 # Schema Registry API for Broker 2: Accessible on localhost, port 28081
+    - 127.0.0.1:38081 # Schema Registry API for Broker 3: Accessible on localhost, port 38081


### PR DESCRIPTION
## Description

The `rpk` config didn't have schema registry endpoints configured so out of the box `rpk registry` commands did not work.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
