### PR TITLE
DOC-1778: Removed github from OIDC authN list

### DIFF
--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -265,9 +265,6 @@ You can use any OIDC-compliant IdP with Redpanda Console. Here are common provid
 
 | Keycloak
 | `\https://<keycloak-host>/realms/<realm>`
-
-| GitHub (Enterprise)
-| `\https://github.com/login/oauth`
 |===
 
 Some IdPs, such as Google, issue opaque access tokens that are not JWTs. While these tokens work for logging in to Redpanda Console (the ID token is a JWT), they cannot be used for impersonation with the Kafka API. In such cases, impersonation must be disabled, and Redpanda Console must be configured to use static service account credentials instead.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1778
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X ] Small fix (typos, links, copyedits, etc)
