### PR TITLE
Remove panda from homepage

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -82,7 +82,7 @@ asciidoc:
         reason: Page moved to Redpanda Labs.
     # Data for the home page
     page-home-intro: Redpanda is a Kafka-compatible event streaming platform built for data-intensive applications. Install Self-Managed Redpanda in your environment with the free Community Edition or with the Enterprise Edition for additional features like Tiered Storage, Continuous Data Balancing, and Audit Logging. 
-    page-home-image: panda.png # images must be in modules/ROOT/images
+    #page-home-image:
     page-home-intro-learn-more: get-started:intro-to-events.adoc
     page-home-primary-row-title: Deploy
     page-home-primary-row:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -25,7 +25,7 @@ content:
     branches: main
 ui:
   bundle:
-    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
+    url: https://github.com/redpanda-data/docs-ui/releases/download/v2.11.0-alpha/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -25,7 +25,7 @@ content:
     branches: main
 ui:
   bundle:
-    url: https://github.com/redpanda-data/docs-ui/releases/download/v2.11.0-alpha/ui-bundle.zip
+    url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:


### PR DESCRIPTION
Part of https://github.com/redpanda-data/docs-ui/pull/341

## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1722

This pull request comments out the `page-home-image` property under the `asciidoc:` section, which previously referenced `panda.png`. This will remove the homepage image.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
