### PR TITLE
[25.3] Add rpk cluster connections list examples

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Connected client monitoring
 
-You can view details about Kafka client connections using the Admin API ListKafkaConnections endpoint. This allows you to view detailed information about about active client connections on a cluster, and identify and troubleshoot problematic clients. For more information, see xref:manage:monitoring.adoc#identify-high-throughput-clients[Monitor Redpanda].
+You can view details about Kafka client connections using `rpk` orthe Admin API ListKafkaConnections endpoint. This allows you to view detailed information about about active client connections on a cluster, and identify and troubleshoot problematic clients. For more information, see xref:manage:monitoring.adoc#identify-high-throughput-clients[Monitor Redpanda].
 
 == New Admin API endpoints 
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -9,7 +9,7 @@ This topic includes new content added in version {page-component-version}. For a
 
 == Connected client monitoring
 
-You can view details about Kafka client connections using `rpk` orthe Admin API ListKafkaConnections endpoint. This allows you to view detailed information about about active client connections on a cluster, and identify and troubleshoot problematic clients. For more information, see xref:manage:monitoring.adoc#identify-high-throughput-clients[Monitor Redpanda].
+You can view details about Kafka client connections using `rpk` or the Admin API ListKafkaConnections endpoint. This allows you to view detailed information about active client connections on a cluster, and identify and troubleshoot problematic clients. For more information, see xref:manage:monitoring.adoc#identify-high-throughput-clients[Monitor Redpanda].
 
 == New Admin API endpoints 
 

--- a/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
@@ -16,7 +16,7 @@ ifndef::env-cloud[]
 Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
 
 * Internal metrics that follow the `vectorized_kafka_rpc_.*connect.*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
-* For Redpanda v25.3 and later, use the Admin API ListKafkaConnections endpoint to identify:
+* For Redpanda v25.3 and later, use `rpk cluster connections list` or the Admin API ListKafkaConnections endpoint to identify:
 +
 -- 
 ** Which clients and applications are connected

--- a/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
@@ -15,7 +15,7 @@ ifndef::env-cloud[]
 ====
 Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
 
-* Internal metrics that follow the `vectorized_kafka_rpc_.*connect.*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
+* Internal metrics that follow the `vectorized_kafka_rpc_.\*connect.*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
 * For Redpanda v25.3 and later, use `rpk cluster connections list` or the Admin API ListKafkaConnections endpoint to identify:
 +
 -- 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -21,8 +21,38 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the Admin API link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections] endpoint to view detailed information about active Kafka client connections. For example, to view a cluster's connected clients in order of highest current produce throughput, you can use the following request:
+Use the `rpk cluster connections list` command or the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections] Admin API endpoint to view detailed information about active Kafka client connections.
 
+For example, to view a cluster's connected clients in order of highest current produce throughput, run:
+
+[tabs]
+======
+rpk::
++
+--
+[,bash]
+----
+rpk cluster connections list --order-by="recent_request_statistics.produce_bytes desc"
+----
+
+[,text,role="no-copy no-wrap"]
+----
+UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE           PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
+b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55012   0     0      9s         0s             78.9MB         0B              292
+36338ca5-86b7-4478-ad23-32d49cfaef61  OPEN   UNAUTHENTICATED  rpk                   127.0.0.1:49722   0     0      13s        13.694243104s  0B             0B              1
+7e277ef6-0176-4007-b100-6581bfde570f  OPEN   UNAUTHENTICATED  rpk                   127.0.0.1:49736   0     0      13s        10.093957335s  0B             0B              2
+567d9918-d3dc-4c74-ab5d-85f70cd3ee35  OPEN   UNAUTHENTICATED  rpk                   127.0.0.1:49748   0     0      13s        0.591413542s   0B             0B              5
+08616f21-08f9-46e7-8f06-964bd8240d9b  OPEN   UNAUTHENTICATED  rpk                   127.0.0.1:49764   0     0      13s        10.094602845s  0B             0B              2
+e4d5b57e-5c76-4975-ada8-17a88d68a62d  OPEN   UNAUTHENTICATED  rpk                   127.0.0.1:54992   0     0      10s        0.302090085s   0B             14.5MB          27
+b41584f3-2662-4185-a4b8-0d8510f5c780  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55002   0     0      8s         7.743592270s   0B             0B              1
+62fde947-411d-4ea8-9461-3becc2631b46  CLOSED UNAUTHENTICATED  rpk                   127.0.0.1:48578   0     0      26s        0.000737836s   0B             0B              1
+95387e2e-2ec4-4040-aa5e-4257a3efa1a2  CLOSED UNAUTHENTICATED  rpk                   127.0.0.1:48564   0     0      26s        0.208180826s   0B             0B              1
+----
+--
+
+curl::
++
+--
 [,bash]
 ----
 curl -s -X POST \
@@ -34,10 +64,10 @@ curl -s -X POST \
   "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaConnections"
 ----
 
-The response lists each connection's details:
-
-.Show sample response
-[,json,lines=54+103+153]
+.Show example API response
+[%collapsible]
+====
+[,json,role=no-copy,lines=54]
 ----
 {
   "connections": [
@@ -98,113 +128,38 @@ The response lists each connection's details:
         "produceBatchCount": "4849"
       }
     },
-    {
-      "nodeId": 0,
-      "shardId": 0,
-      "uid": "36338ca5-86b7-4478-ad23-32d49cfaef61",
-      "state": "KAFKA_CONNECTION_STATE_OPEN",
-      "openTime": "2025-10-15T14:15:09.801571000Z",
-      "closeTime": "1970-01-01T00:00:00.000000000Z",
-      "authenticationInfo": {
-        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
-        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
-        "userPrincipal": ""
-      },
-      "listenerName": "",
-      "tlsInfo": {
-        "enabled": false
-      },
-      "source": {
-        "ipAddress": "127.0.0.1",
-        "port": 49722
-      },
-      "clientId": "rpk",
-      "clientSoftwareName": "kgo",
-      "clientSoftwareVersion": "unknown",
-      "transactionalId": "",
-      "groupId": "",
-      "groupInstanceId": "",
-      "groupMemberId": "",
-      "apiVersions": {
-        "18": 4,
-        "3": 12
-      },
-      "idleDuration": "13.694243104s",
-      "inFlightRequests": {
-        "sampledInFlightRequests": [],
-        "hasMoreRequests": false
-      },
-      "totalRequestStatistics": {
-        "produceBytes": "0",
-        "fetchBytes": "0",
-        "requestCount": "2",
-        "produceBatchCount": "0"
-      },
-      "recentRequestStatistics": {
-        "produceBytes": "0",
-        "fetchBytes": "0",
-        "requestCount": "2",
-        "produceBatchCount": "0"
-      }
-    },
-    {
-      "nodeId": 0,
-      "shardId": 0,
-      "uid": "7e277ef6-0176-4007-b100-6581bfde570f",
-      "state": "KAFKA_CONNECTION_STATE_OPEN",
-      "openTime": "2025-10-15T14:15:09.804034000Z",
-      "closeTime": "1970-01-01T00:00:00.000000000Z",
-      "authenticationInfo": {
-        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
-        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
-        "userPrincipal": ""
-      },
-      "listenerName": "",
-      "tlsInfo": {
-        "enabled": false
-      },
-      "source": {
-        "ipAddress": "127.0.0.1",
-        "port": 49736
-      },
-      "clientId": "rpk",
-      "clientSoftwareName": "kgo",
-      "clientSoftwareVersion": "unknown",
-      "transactionalId": "",
-      "groupId": "",
-      "groupInstanceId": "",
-      "groupMemberId": "",
-      "apiVersions": {
-        "18": 4,
-        "3": 12,
-        "10": 4
-      },
-      "idleDuration": "10.093957335s",
-      "inFlightRequests": {
-        "sampledInFlightRequests": [],
-        "hasMoreRequests": false
-      },
-      "totalRequestStatistics": {
-        "produceBytes": "0",
-        "fetchBytes": "0",
-        "requestCount": "4",
-        "produceBatchCount": "0"
-      },
-      "recentRequestStatistics": {
-        "produceBytes": "0",
-        "fetchBytes": "0",
-        "requestCount": "4",
-        "produceBatchCount": "0"
-      }
-    },
     ...
   ]
   "totalSize": "9"
 }
 ----
+====
+--
+======
 
 To view connections for a specific client, you can use a filter expression:
 
+[tabs]
+======
+rpk::
++
+--
+[,bash]
+----
+rpk cluster connections list --client-id="perf-producer-client"
+----
+
+[,text,role="no-copy no-wrap"]
+----
+UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE          PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
+b41584f3-2662-4185-a4b8-0d8510f5c780  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55002   0     0      8s         7.743592270s  0B             0B              1
+b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55012   0     0      9s         0s            78.9MB         0B              292
+----
+--
+
+curl::
++
+--
 [,bash]
 ----
 curl -s -X POST \
@@ -215,8 +170,10 @@ curl -s -X POST \
   "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaConnections"
 ----
 
-.Show sample response
-[,json,lines=23+73+123]
+.Show example API response
+[%collapsible]
+====
+[,json,lines=24]
 ----
 {
   "connections": [
@@ -270,67 +227,14 @@ curl -s -X POST \
         "produceBatchCount": "0"
       }
     },
-    {
-      "nodeId": 0,
-      "shardId": 0,
-      "uid": "b20601a3-624c-4a8c-ab88-717643f01d56",
-      "state": "KAFKA_CONNECTION_STATE_OPEN",
-      "openTime": "2025-10-15T14:15:15.755065000Z",
-      "closeTime": "1970-01-01T00:00:00.000000000Z",
-      "authenticationInfo": {
-        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
-        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
-        "userPrincipal": ""
-      },
-      "listenerName": "",
-      "tlsInfo": {
-        "enabled": false
-      },
-      "source": {
-        "ipAddress": "127.0.0.1",
-        "port": 55012
-      },
-      "clientId": "perf-producer-client",
-      "clientSoftwareName": "apache-kafka-java",
-      "clientSoftwareVersion": "3.9.0",
-      "transactionalId": "my-tx-id",
-      "groupId": "",
-      "groupInstanceId": "",
-      "groupMemberId": "",
-      "apiVersions": {
-        "18": 4,
-        "22": 3,
-        "3": 12,
-        "24": 3,
-        "0": 7
-      },
-      "idleDuration": "0s",
-      "inFlightRequests": {
-        "sampledInFlightRequests": [
-          {
-            "apiKey": 0,
-            "inFlightDuration": "0.000406892s"
-          }
-        ],
-        "hasMoreRequests": false
-      },
-      "totalRequestStatistics": {
-        "produceBytes": "78927173",
-        "fetchBytes": "0",
-        "requestCount": "4853",
-        "produceBatchCount": "4849"
-      },
-      "recentRequestStatistics": {
-        "produceBytes": "78927173",
-        "fetchBytes": "0",
-        "requestCount": "4853",
-        "produceBatchCount": "4849"
-      }
-    }
+    ...
   ],
   "totalSize": "2"
 }
 ----
+====
+--
+======
 
 
 == Throughput throttling enforcement

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -35,7 +35,7 @@ rpk::
 rpk cluster connections list --order-by="recent_request_statistics.produce_bytes desc"
 ----
 
-[,text,role="no-copy no-wrap"]
+[,bash,role="no-copy no-wrap"]
 ----
 UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE           PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
 b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55012   0     0      9s         0s             78.9MB         0B              292
@@ -149,7 +149,7 @@ rpk::
 rpk cluster connections list --client-id="perf-producer-client"
 ----
 
-[,text,role="no-copy no-wrap"]
+[,bash,role="no-copy no-wrap"]
 ----
 UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE          PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
 b41584f3-2662-4185-a4b8-0d8510f5c780  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55002   0     0      8s         7.743592270s  0B             0B              1

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -143,7 +143,7 @@ rpk::
 rpk cluster connections list --filter-raw="recent_request_statistics.produce_bytes > 1000000" --order-by="recent_request_statistics.produce_bytes desc"
 ----
 
-[,text,role="no-copy no-wrap"]
+[,bash,role="no-copy no-wrap"]
 ----
 UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE  PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
 b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55012   0     0      9s         0s    78.9MB         0B              292

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -129,10 +129,30 @@ rate(redpanda_rpc_sent_bytes{redpanda_server="kafka"}[$__rate_interval])
 ifndef::env-cloud[]
 ==== Identify high-throughput clients
 
-Use the ListKafkaConnections service in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+Use `rpk cluster connections list` or the ListKafkaConnections service in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
 
-For example, to list connections with a current produce throughput greater than 1MB, use the following request:
+For example, to list connections with a current produce throughput greater than 1MB, run:
 
+[tabs]
+======
+rpk::
++
+--
+[,bash]
+----
+rpk cluster connections list --filter-raw="recent_request_statistics.produce_bytes > 1000000" --order-by="recent_request_statistics.produce_bytes desc"
+----
+
+[,text,role="no-copy no-wrap"]
+----
+UID                                   STATE  USER             CLIENT-ID             IP:PORT           NODE  SHARD  OPEN-TIME  IDLE  PROD-TPUT/SEC  FETCH-TPUT/SEC  REQS/MIN
+b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-client  127.0.0.1:55012   0     0      9s         0s    78.9MB         0B              292
+----
+--
+
+curl::
++
+--
 [,bash]
 ----
 curl -s -X POST "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaConnections" --header "Content-Type: application/json" --data '{"filter":"recent_request_statistics.produce_bytes > 1000000", "order_by":"recent_request_statistics.produce_bytes desc"}' | jq
@@ -206,6 +226,8 @@ curl -s -X POST "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaC
 }
 ----
 ====
+--
+======
 
 You can adjust the filter and sorting criteria as necessary. See the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[Admin API reference] for more details. 
 endif::[]


### PR DESCRIPTION
## Description

This pull request updates Redpanda documentation to highlight and demonstrate the use of the `rpk cluster connections list` command for monitoring Kafka client connections, in addition to the existing Admin API method. The changes add practical examples, command usage tabs, and improve clarity for users on how to identify and troubleshoot client connections using both CLI and API approaches.

**Enhancements to client connection monitoring documentation:**

* Added references and examples for using the `rpk cluster connections list` command alongside the Admin API `ListKafkaConnections` endpoint throughout the documentation, making it easier for users to monitor client connections via CLI or API. [[1]](diffhunk://#diff-fc3054c55a548a4251d6c9e7fbaf1ed2d657cfcba83ea857e47c52f70a79829eL12-R12) [[2]](diffhunk://#diff-7ae98691f208cf8bca145de052b59275214e9de65f10ba9d2629771e4be29835L19-R19) [[3]](diffhunk://#diff-558c582cab3e7b6976b9c376a5f1614875d67a20634284a81316b78aec6c88a8L132-R155)

* Introduced tabbed code examples showing both `rpk` and `curl` usage for listing, filtering, and sorting Kafka client connections, including sample command outputs and improved formatting for clarity. [[1]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L24-R55) [[2]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L101-R162) [[3]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L218-R176) [[4]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L273-R237) [[5]](diffhunk://#diff-558c582cab3e7b6976b9c376a5f1614875d67a20634284a81316b78aec6c88a8L132-R155)

**Improvements to example responses and formatting:**

* Updated example API responses to be collapsible and more concise, replacing long inlined JSON with expandable sections and ellipses to focus on relevant details. [[1]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L37-R70) [[2]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L101-R162) [[3]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L218-R176) [[4]](diffhunk://#diff-054298b57d90b7ce401e83a4c630c53ea43885dd92d67c79a3fe8ab93fe618e5L273-R237)

* Enhanced filtering and sorting instructions for identifying high-throughput clients, including practical filter examples and output samples for both CLI and API methods. [[1]](diffhunk://#diff-558c582cab3e7b6976b9c376a5f1614875d67a20634284a81316b78aec6c88a8L132-R155) [[2]](diffhunk://#diff-558c582cab3e7b6976b9c376a5f1614875d67a20634284a81316b78aec6c88a8R229-R230)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 31 Oct

## Page previews

Manage Throughput > [View connected client details](https://deploy-preview-1431--redpanda-docs-preview.netlify.app/25.3/manage/cluster-maintenance/manage-throughput/#view-connected-client-details)
Monitor Redpanda > [Identify high-throughput clients](https://deploy-preview-1431--redpanda-docs-preview.netlify.app/25.3/manage/monitoring/#identify-high-throughput-clients)
[Configure Client Connections](https://deploy-preview-1431--redpanda-docs-preview.netlify.app/25.3/manage/cluster-maintenance/configure-client-connections/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
