### PR TITLE
Add BigLake REST Catalog doc

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -183,6 +183,7 @@
 *** xref:manage:iceberg/rest-catalog/index.adoc[Integrate with REST Catalogs]
 **** xref:manage:iceberg/iceberg-topics-aws-glue.adoc[AWS Glue]
 **** xref:manage:iceberg/iceberg-topics-databricks-unity.adoc[Databricks Unity Catalog]
+**** xref:manage:iceberg/iceberg-topics-gcp-biglake.adoc[GCP BigLake]
 **** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Snowflake and Open Catalog]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[Query Iceberg Topics]
 ** xref:manage:schema-reg/index.adoc[Schema Registry]

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -7,6 +7,12 @@ This topic includes new content added in version {page-component-version}. For a
 * xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
 * xref:redpanda-cloud:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Iceberg topics with GCP BigLake
+
+A new xref:manage:iceberg/iceberg-topics-gcp-biglake.adoc[REST catalog integration] with Google Cloud BigLake allows you to add Redpanda topics as Iceberg tables in your data lakehouse.
+
+See xref:manage:iceberg/use-iceberg-catalogs.adoc[] for details on configuring Iceberg REST catalog integrations with Redpanda.
+
 == Shadowing
 
 Redpanda v25.3 introduces xref:deploy:redpanda/manual/disaster-recovery/shadowing/index.adoc[], an enterprise-licensed disaster recovery solution that provides asynchronous, offset-preserving replication between distinct Redpanda clusters. Shadowing enables cross-region data protection by replicating topic data, configurations, consumer group offsets, ACLs, and Schema Registry data with byte-level fidelity.

--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -256,7 +256,7 @@ Your query results should look like the following:
 +-----------------------------------------------------+----------------+
 ----
 
-== See also
+include::shared:partial$suggested-reading.adoc[]
 
 - xref:manage:iceberg/query-iceberg-topics.adoc[]
 

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -222,7 +222,7 @@ Your query results should look like the following:
 +----------------------------------------------------------------------+------------+
 ----
 
-== See also
+include::shared:partial$suggested-reading.adoc[]
 
 - xref:manage:iceberg/query-iceberg-topics.adoc[]
 

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -36,6 +36,10 @@ BigLake metastore does not support multi-region buckets. Use single-region bucke
 
 Currently, it is not possible to delete non-empty BigLake Iceberg catalogs through the BigLake interface. If you need to reconfigure your setup, create a new bucket or use the REST API to remove the existing catalog.
 
+=== Topic names
+
+BigLake does not support Iceberg table names that contain dots (`.`). When creating Iceberg topics in Redpanda that you plan to access through BigLake, ensure that the topic names do not include dots.
+
 == Set up Google Cloud resources
 
 === Create a storage bucket
@@ -160,7 +164,10 @@ iceberg_rest_catalog_gcp_user_project: <gcp-project-id>
 iceberg_dlq_table_suffix: _dlq
 ----
 +
-Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.
+--
+* Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.
+* You must set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). The example above uses `_dlq` as the suffix for the xref:manage:iceberg/about-iceberg-topics.adoc#troubleshoot-errors[dead-letter queue (DLQ) table].
+--
 
 . Start Redpanda:
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -157,6 +157,7 @@ iceberg_rest_catalog_oauth2_server_uri: https://oauth2.googleapis.com/token
 iceberg_rest_catalog_authentication_mode: gcp
 iceberg_rest_catalog_warehouse: gs://<bucket-name>/
 iceberg_rest_catalog_gcp_user_project: <gcp-project-id>
+iceberg_dlq_table_suffix: _dlq
 ----
 +
 Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -192,7 +192,7 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 rpk profile create quickstart --from-profile rpk-profile.yaml
 ----
 
-. Enable Iceberg for the topic `transactions` topic:
+. Enable Iceberg for the `transactions` topic. This topic is created for you in the quickstart setup:
 +
 [,bash]
 ----

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -38,7 +38,12 @@ Currently, it is not possible to delete non-empty BigLake Iceberg catalogs throu
 
 === Topic names
 
-BigLake does not support Iceberg table names that contain dots (`.`). When creating Iceberg topics in Redpanda that you plan to access through BigLake, ensure that the topic names do not include dots.
+BigLake does not support Iceberg table names that contain dots (`.`). When creating Iceberg topics in Redpanda that you plan to access through BigLake, either:
+
+- Use the `iceberg_topic_name_dot_replacement` cluster property to set a replacement string for dots in topic names. Ensure that the replacement value does not cause table name collisions. For example, `current.orders` and `current_orders` would both map to the same table name if you set the replacement to an underscore (`_`).
+- Ensure that the new topic names do not include dots.
+
+You must also set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). See <<configure-topic-for-iceberg>> for the list of cluster properties to set when enabling the BigLake REST catalog integration.
 
 == Set up Google Cloud resources
 
@@ -159,7 +164,7 @@ curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf - && \
 cd docker-compose
 ----
 
-. Edit the `docker-compose.yml` file to replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `image: docker.redpanda.com/redpandadata/nightly`.
+. Edit the `docker-compose.yml` file to replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `docker.redpanda.com/redpandadata/redpanda-unstable:v25.3.1-rc2`.
 
 . Edit the `bootstrap.yaml` file to enable Tiered Storage and Iceberg features. Add or modify these sections:
 +

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -22,9 +22,9 @@ NOTE: BigLake support for the Iceberg REST Catalog API is currently in preview. 
 == Prerequisites
 
 * A Google Cloud Platform (GCP) project.
-* The https://docs.cloud.google.com/sdk/docs/install[`gcloud` CLI] installed and configured for your GCP project.
+* The https://docs.cloud.google.com/sdk/docs/install[`gcloud` CLI^] installed and configured for your GCP project.
 ** Your Redpanda cluster must be deployed on GCP VMs. If you do not have permissions to create VMs and service accounts in your project, ask your administrator to create them for you.
-* https://cloud.google.com/biglake/docs/enable-biglake-api[BigLake API] enabled for your GCP project.
+* https://cloud.google.com/biglake/docs/enable-biglake-api[BigLake API^] enabled for your GCP project.
 
 == Limitations
 
@@ -79,7 +79,7 @@ Replace the placeholder values:
 
 Grant the necessary permissions to your service account:
 
-. Grant the service account the https://docs.cloud.google.com/storage/docs/access-control/iam-roles[Storage Object Admin role] to access the bucket:
+. Grant the service account the https://docs.cloud.google.com/storage/docs/access-control/iam-roles[Storage Object Admin role^] to access the bucket:
 +
 [,bash]
 ----
@@ -261,7 +261,7 @@ gcloud storage buckets delete gs://<bucket-name>
 gcloud iam service-accounts delete <service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com
 ----
 
-NOTE: Manually delete the BigLake catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API].
+NOTE: Manually delete the BigLake catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API^].
 
 == See also
 

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -128,6 +128,27 @@ gcloud compute ssh --zone <zone> <instance-name>
 ----
 
 . Install Docker and Docker Compose following the https://docs.docker.com/engine/install/debian/[Docker installation guide^] for Debian.
++
+[,bash]
+----
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+
+# Install Docker Engine, CLI, and Compose
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+----
 
 . Download the Redpanda Quickstart files:
 +
@@ -138,7 +159,7 @@ curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf - && \
 cd docker-compose
 ----
 
-. In the `docker-compose.yml` file, replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `image: docker.redpanda.com/redpandadata/redpanda-unstable:v25.3.1-rc2`.
+. Edit the `docker-compose.yml` file to replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `image: docker.redpanda.com/redpandadata/nightly`.
 
 . Edit the `bootstrap.yaml` file to enable Tiered Storage and Iceberg features. Add or modify these sections:
 +
@@ -146,14 +167,14 @@ cd docker-compose
 ----
 # Enable Tiered Storage
 cloud_storage_enabled: true
+cloud_storage_region: n/a # GCP does not require region to be set
 cloud_storage_api_endpoint: storage.googleapis.com
 cloud_storage_api_endpoint_port: 443
 cloud_storage_disable_tls: false
 cloud_storage_bucket: <bucket-name>
 cloud_storage_credentials_source: gcp_instance_metadata
-cloud_storage_region: n/a # GCP does not require region to be set
 
-# Enable Iceberg catalog (enterprise feature)
+# Configure Iceberg REST catalog integration with BigLake
 iceberg_enabled: true
 iceberg_catalog_type: rest
 iceberg_rest_catalog_endpoint: https://biglake.googleapis.com/iceberg/v1/restcatalog
@@ -176,7 +197,7 @@ iceberg_dlq_table_suffix: _dlq
 docker compose up -d
 ----
 
-== Configure topics for Iceberg
+== Configure topic for Iceberg
 
 . Install and configure `rpk`:
 +
@@ -209,7 +230,7 @@ rpk topic alter-config transactions --set redpanda.iceberg.mode=value_schema_lat
 ----
 SELECT
     *
-FROM `<bucket-name>`.redpanda.transactions
+FROM `<bucket-name>>redpanda`.transactions
 ORDER BY
     redpanda.timestamp DESC
 LIMIT 10

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -1,0 +1,238 @@
+= Query Iceberg Topics using GCP BigLake
+:description: Add Redpanda topics as Iceberg tables to your Google BigLake data lakehouse that you can query from Google BigQuery.
+:page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+
+[NOTE]
+====
+include::shared:partial$enterprise-license.adoc[]
+====
+
+// tag::single-source[]
+ifndef::env-cloud[]
+:rp_version: 25.3
+:rpk_install_doc: get-started:rpk-install.adoc
+endif::[]
+
+This guide walks you through querying Redpanda topics as Iceberg tables stored in Google Cloud Storage, using a REST catalog integration with https://cloud.google.com/biglake/docs/introduction[Google BigLake^]. You create a new storage bucket to store Iceberg data, create a new service account with required permissions, deploy Redpanda using Docker on Google Cloud VMs, and enable the Iceberg integration for a pre-existing Redpanda topic so you can query it from BigQuery.
+
+For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
+
+NOTE: BigLake support for the Iceberg REST Catalog API is currently in preview. See the https://cloud.google.com/biglake[BigLake product page] for the latest updates.
+
+== Prerequisites
+
+* A Google Cloud Platform (GCP) project.
+* The https://docs.cloud.google.com/sdk/docs/install[`gcloud` CLI] installed and configured for your GCP project.
+** Your Redpanda cluster must be deployed on GCP VMs. If you do not have permissions to create VMs and service accounts in your project, ask your administrator to create them for you.
+* https://cloud.google.com/biglake/docs/enable-biglake-api[BigLake API] enabled for your GCP project.
+
+== Limitations
+
+=== Multi-region bucket support
+
+BigLake metastore does not support multi-region buckets. Use single-region buckets to store your Iceberg topics.
+
+=== Catalog deletion
+
+Currently, it is not possible to delete non-empty BigLake Iceberg catalogs through the BigLake interface. If you need to reconfigure your setup, create a new bucket or use the REST API to remove the existing catalog.
+
+== Set up Google Cloud resources
+
+=== Create a storage bucket
+
+Create a new Google Cloud Storage bucket to store Iceberg data:
+
+[,bash]
+----
+gcloud storage buckets create gs://<bucket-name> --location=<region>
+----
+
+Replace the placeholder values:
+
+* `<bucket-name>`: A globally unique name for your bucket.
+* `<region>`: The region where you want to create the bucket, for example, `europe-west2`.
+
+=== Create a service account for Redpanda
+
+Create a service account that will be used by the VMs running Redpanda. Redpanda uses this account for writing data to Tiered Storage, Iceberg data and metadata, and for interacting with the BigLake catalog:
+
+[,bash]
+----
+gcloud iam service-accounts create <service-account-name> --display-name "<display-name>"
+----
+
+Replace the placeholder values:
+
+* `<service-account-name>`: You can use a https://docs.cloud.google.com/iam/docs/service-accounts-create[name^] that contains lowercase alphanumeric characters and dashes. 
+* `<display-name>`: Enter a display name for the service account.
+
+=== Grant required permissions
+
+Grant the necessary permissions to your service account:
+
+. Grant the service account the https://docs.cloud.google.com/storage/docs/access-control/iam-roles[Storage Object Admin role] to access the bucket:
++
+[,bash]
+----
+gcloud storage buckets add-iam-policy-binding gs://<bucket-name> \
+  --member="serviceAccount:<service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+----
+
+. Grant https://docs.cloud.google.com/iam/docs/roles-permissions/serviceusage[Service Usage Consumer^] and https://docs.cloud.google.com/iam/docs/roles-permissions/biglake#biglake.editor[BigLake Editor^] roles for using the Iceberg REST catalog:
++
+[,bash]
+----
+gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
+  --member="serviceAccount:<service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com" \
+  --role="roles/serviceusage.serviceUsageConsumer"
+
+gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
+  --member="serviceAccount:<service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com" \
+  --role="roles/biglake.editor"
+----
+
+== Deploy Redpanda on GCP
+
+=== Create VM instances
+
+Create a VM instance to run Redpanda:
+
+[,bash]
+----
+gcloud compute instances create <instance-name> \
+    --zone=<zone> \
+    --machine-type=e2-medium \
+    --service-account=<service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/cloud-platform \
+    --create-disk=auto-delete=yes,boot=yes,device-name=<instance-name>,image=projects/debian-cloud/global/images/debian-12-bookworm-v20251014,mode=rw,size=20,type=pd-standard
+----
+
+Replace the placeholder values:
+
+* `<instance-name>`: A name for your VM instance.
+* `<service-account-name>`: The name of the service account you created earlier.
+* `<zone>`: The fully-qualified zone name, for example, `europe-west2-a`.
+
+=== Install and configure Redpanda
+
+. Connect to your VM instance:
++
+[,bash]
+----
+gcloud compute ssh --zone <zone> <instance-name>
+----
+
+. Install Docker and Docker Compose following the https://docs.docker.com/engine/install/debian/[Docker installation guide^] for Debian.
+
+. Download the Redpanda Quickstart files:
++
+[,bash]
+----
+mkdir redpanda-quickstart && cd redpanda-quickstart && \
+curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf - && \
+cd docker-compose
+----
+
+. In the `docker-compose.yml` file, replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `image: docker.redpanda.com/redpandadata/redpanda-unstable:v25.3.1-rc2`.
+
+. Edit the `bootstrap.yaml` file to enable Tiered Storage and Iceberg features. Add or modify these sections:
++
+[,yaml]
+----
+# Enable Tiered Storage
+cloud_storage_enabled: true
+cloud_storage_api_endpoint: storage.googleapis.com
+cloud_storage_api_endpoint_port: 443
+cloud_storage_disable_tls: false
+cloud_storage_bucket: <bucket-name>
+cloud_storage_credentials_source: gcp_instance_metadata
+cloud_storage_region: n/a # GCP does not require region to be set
+
+# Enable Iceberg catalog (enterprise feature)
+iceberg_enabled: true
+iceberg_catalog_type: rest
+iceberg_rest_catalog_endpoint: https://biglake.googleapis.com/iceberg/v1/restcatalog
+iceberg_rest_catalog_oauth2_server_uri: https://oauth2.googleapis.com/token
+iceberg_rest_catalog_authentication_mode: gcp
+iceberg_rest_catalog_warehouse: gs://<bucket-name>/
+iceberg_rest_catalog_gcp_user_project: <gcp-project-id>
+----
++
+Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.
+
+. Start Redpanda:
++
+[,bash]
+----
+docker compose up -d
+----
+
+== Configure topics for Iceberg
+
+. Install and configure `rpk`:
++
+[,bash]
+----
+sudo apt-get install unzip
+
+curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip &&
+  mkdir -p ~/.local/bin &&
+  export PATH="~/.local/bin:$PATH" &&
+  unzip rpk-linux-amd64.zip -d ~/.local/bin/
+
+rpk profile create quickstart --from-profile rpk-profile.yaml
+----
+
+. Enable Iceberg for the topic `transactions` topic:
++
+[,bash]
+----
+rpk topic alter-config transactions --set redpanda.iceberg.mode=value_schema_latest:subject=transactions
+----
+
+== Query Iceberg tables in BigQuery
+
+. Navigate to the https://console.cloud.google.com/bigquery[BigQuery console^].
+
+. Query your Iceberg table using SQL. For example:
++
+[,sql]
+----
+SELECT
+    *
+FROM `<bucket-name>`.redpanda.transactions
+ORDER BY
+    redpanda.timestamp DESC
+LIMIT 10
+----
++
+Replace `<bucket-name>` with your bucket name.
+
+Your Redpanda topics are now available as Iceberg tables in BigLake, allowing you to run analytics queries directly on your streaming data.
+
+== Clean up resources
+
+When you're finished, you can clean up the resources you created:
+
+[,bash]
+----
+# Delete VM instances
+gcloud compute instances delete <instance-name> --zone=<zone>
+
+# Delete the storage bucket
+gcloud storage buckets delete gs://<bucket-name>
+
+# Delete the service account
+gcloud iam service-accounts delete <service-account-name>@$(gcloud config get-value project).iam.gserviceaccount.com
+----
+
+NOTE: Manually delete the BigLake catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API].
+
+== See also
+
+- xref:manage:iceberg/use-iceberg-catalogs.adoc[]
+- xref:manage:iceberg/query-iceberg-topics.adoc[]
+- https://cloud.google.com/biglake/docs/introduction[Google BigLake documentation^]
+
+// end::single-source[]

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -17,7 +17,7 @@ This guide walks you through querying Redpanda topics as Iceberg tables stored i
 
 For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
 
-NOTE: BigLake support for the Iceberg REST Catalog API is currently in preview. See the https://cloud.google.com/biglake[BigLake product page] for the latest updates.
+NOTE: Check the https://cloud.google.com/biglake[BigLake product page^] for the latest status and availability of the REST Catalog API.
 
 == Prerequisites
 
@@ -263,7 +263,7 @@ gcloud iam service-accounts delete <service-account-name>@$(gcloud config get-va
 
 NOTE: Manually delete the BigLake catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API^].
 
-== See also
+include::shared:partial$suggested-reading.adoc[]
 
 - xref:manage:iceberg/use-iceberg-catalogs.adoc[]
 - xref:manage:iceberg/query-iceberg-topics.adoc[]

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -1,4 +1,4 @@
-= Query Iceberg Topics using GCP BigLake
+= Use Iceberg Topics with GCP BigLake
 :description: Add Redpanda topics as Iceberg tables to your Google BigLake data lakehouse that you can query from Google BigQuery.
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
 
@@ -13,7 +13,13 @@ ifndef::env-cloud[]
 :rpk_install_doc: get-started:rpk-install.adoc
 endif::[]
 
-This guide walks you through querying Redpanda topics as Iceberg tables stored in Google Cloud Storage, using a REST catalog integration with https://cloud.google.com/biglake/docs/introduction[Google BigLake^]. You create a new storage bucket to store Iceberg data, create a new service account with required permissions, deploy Redpanda using Docker on Google Cloud VMs, and enable the Iceberg integration for a pre-existing Redpanda topic so you can query it from BigQuery.
+This guide walks you through querying Redpanda topics as Iceberg tables stored in Google Cloud Storage, using a REST catalog integration with https://cloud.google.com/biglake/docs/introduction[Google BigLake^]. In this guide, you do the following:
+
+- Create Google Cloud resources such as a storage bucket and service account
+- Grant permissions to the service account to access Iceberg data in the bucket
+- Create a catalog in BigLake
+- Configure the BigLake integration for your Redpanda cluster
+- Query the Iceberg data in Google BigQuery
 
 For general information about Iceberg catalog integrations in Redpanda, see xref:manage:iceberg/use-iceberg-catalogs.adoc[].
 
@@ -22,9 +28,17 @@ NOTE: Check the https://cloud.google.com/biglake[BigLake product page^] for the 
 == Prerequisites
 
 * A Google Cloud Platform (GCP) project.
++
+If you do not have permissions to manage GCP resources such as VMs, storage buckets, and service accounts in your project, ask your project owner to create or update them for you.
 * The https://docs.cloud.google.com/sdk/docs/install[`gcloud` CLI^] installed and configured for your GCP project.
-** Your Redpanda cluster must be deployed on GCP VMs. If you do not have permissions to create VMs and service accounts in your project, ask your administrator to create them for you.
 * https://cloud.google.com/biglake/docs/enable-biglake-api[BigLake API^] enabled for your GCP project.
+* Redpanda v{full-version} or later. Your Redpanda cluster must be deployed on GCP VMs.
+* `rpk` xref:{rpk_install_doc}[installed or updated] to the latest version.
+ifndef::env-cloud[]
+* xref:manage:tiered-storage.adoc#configure-object-storage[Object storage configured] for your cluster and xref:manage:tiered-storage.adoc#enable-tiered-storage[Tiered Storage enabled] for the topics for which you want to generate Iceberg tables.
++
+You also use the GCS bucket URI to set the warehouse location for the BigLake catalog.
+endif::[]
 
 == Limitations
 
@@ -43,27 +57,13 @@ BigLake does not support Iceberg table names that contain dots (`.`). When creat
 - Use the `iceberg_topic_name_dot_replacement` cluster property to set a replacement string for dots in topic names. Ensure that the replacement value does not cause table name collisions. For example, `current.orders` and `current_orders` would both map to the same table name if you set the replacement to an underscore (`_`).
 - Ensure that the new topic names do not include dots.
 
-You must also set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). See <<configure-topic-for-iceberg>> for the list of cluster properties to set when enabling the BigLake REST catalog integration.
+You must also set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). See <<configure-redpanda-for-iceberg>> for the list of cluster properties to set when enabling the BigLake REST catalog integration.
 
 == Set up Google Cloud resources
 
-=== Create a storage bucket
-
-Create a new Google Cloud Storage bucket to store Iceberg data:
-
-[,bash]
-----
-gcloud storage buckets create gs://<bucket-name> --location=<region>
-----
-
-Replace the placeholder values:
-
-* `<bucket-name>`: A globally unique name for your bucket.
-* `<region>`: The region where you want to create the bucket, for example, `europe-west2`.
-
 === Create a service account for Redpanda
 
-Create a service account that will be used by the VMs running Redpanda. Redpanda uses this account for writing data to Tiered Storage, Iceberg data and metadata, and for interacting with the BigLake catalog:
+If you don't already have a Google Cloud service account to use, create a new service account that will be used by the VMs running Redpanda. Redpanda uses this account for writing data to Tiered Storage, Iceberg data and metadata, and for interacting with the BigLake catalog:
 
 [,bash]
 ----
@@ -77,7 +77,10 @@ Replace the placeholder values:
 
 === Grant required permissions
 
-Grant the necessary permissions to your service account:
+Grant the necessary permissions to your service account. To run the following commands, replace the placeholder values:
+
+* `<service-account-name>`: The name of your service account.
+* `<bucket-name>`: The name of your storage bucket.
 
 . Grant the service account the https://docs.cloud.google.com/storage/docs/access-control/iam-roles[Storage Object Admin role^] to access the bucket:
 +
@@ -101,7 +104,43 @@ gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
   --role="roles/biglake.editor"
 ----
 
-== Deploy Redpanda on GCP
+=== Create a BigLake catalog
+
+Create a BigLake Iceberg REST catalog:
+
+[,bash]
+----
+gcloud alpha biglake iceberg catalogs create \
+    catalog-id <bucket-id>
+    --project <gcp-project-id> \
+    --catalog-type CATALOG_TYPE_GCS_BUCKET \
+    --credential-mode CREDENTIAL_MODE_END_USER
+----
+
+Replace the placeholder values:
+
+* `<bucket-name>`: Use the name of your storage bucket as the catalog ID.
+* `<gcp-project-id>`: Your GCP project ID.
+
+== Optional: Deploy Redpanda quickstart on GCP
+
+If you want to quickly test Iceberg topics in BigLake, you can deploy a test environment using the Redpanda Self-Managed quickstart. In this section, you create a new storage bucket for Tiered Storage and Iceberg data. You configure a Redpanda cluster for the BigLake catalog integration and deploy the cluster on a GCP Linux VM instance using Docker Compose.
+
+NOTE: If you already have a Redpanda cluster deployed on GCP, skip to <<configure-redpanda-for-iceberg>>.
+
+=== Create a storage bucket
+
+Create a new Google Cloud Storage bucket to store Iceberg data:
+
+[,bash]
+----
+gcloud storage buckets create gs://<bucket-name> --location=<region>
+----
+
+Replace the placeholder values:
+
+* `<bucket-name>`: A globally unique name for your bucket.
+* `<region>`: The region where you want to create the bucket, for example, `europe-west2`.
 
 === Create VM instances
 
@@ -155,16 +194,22 @@ sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ----
 
-. Download the Redpanda Quickstart files:
+. Download the Redpanda Self-Managed quickstart files:
 +
-[,bash]
+[,bash,subs="attributes+"]
 ----
-mkdir redpanda-quickstart && cd redpanda-quickstart && \
-curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf - && \
-cd docker-compose
+mkdir redpanda-quickstart && cd redpanda-quickstart && \ <1>
+ifdef::page-component-version-is-latest[]
+curl -sSL https://docs.redpanda.com/redpanda-quickstart.tar.gz | tar xzf - && \ <2>
+endif::[]
+ifndef::page-component-version-is-latest[]
+curl -sSL https://docs.redpanda.com/{page-component-version}-redpanda-quickstart.tar.gz | tar xzf - && \ <2>
+endif::[]
+cd docker-compose <3>
 ----
-
-. Edit the `docker-compose.yml` file to replace all instances of `image: docker.redpanda.com/redpandadata/redpanda:v25.2.10` with `docker.redpanda.com/redpandadata/redpanda-unstable:v25.3.1-rc2`.
+<1> Create and navigate to the `redpanda-quickstart` directory.
+<2> Download and extract the archive.
+<3> Navigate to the Docker Compose configuration directory.
 
 . Edit the `bootstrap.yaml` file to enable Tiered Storage and Iceberg features. Add or modify these sections:
 +
@@ -194,6 +239,8 @@ iceberg_dlq_table_suffix: _dlq
 * Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.
 * You must set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). The example above uses `_dlq` as the suffix for the xref:manage:iceberg/about-iceberg-topics.adoc#troubleshoot-errors[dead-letter queue (DLQ) table].
 --
++
+NOTE: If you edit `bootstrap.yml`, you can skip the cluster configuration step in <<configure-redpanda-for-iceberg>> and proceed to the next step in that section to enable Iceberg for a topic.
 
 . Start Redpanda:
 +
@@ -201,8 +248,6 @@ iceberg_dlq_table_suffix: _dlq
 ----
 docker compose up -d
 ----
-
-== Configure topic for Iceberg
 
 . Install and configure `rpk`:
 +
@@ -218,18 +263,63 @@ curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-
 rpk profile create quickstart --from-profile rpk-profile.yaml
 ----
 
-. Enable Iceberg for the `transactions` topic. This topic is created for you in the quickstart setup:
+== Configure Redpanda for Iceberg
+
+. Edit your cluster configuration to set the `iceberg_enabled` property to `true`, and set the catalog integration properties listed in the example below.
+ifndef::env-cloud[]
 +
+Run `rpk cluster config edit` to update these properties:
++
+[,yaml]
+----
+iceberg_enabled: true
+iceberg_catalog_type: rest
+iceberg_rest_catalog_endpoint: https://biglake.googleapis.com/iceberg/v1/restcatalog
+iceberg_rest_catalog_oauth2_server_uri: https://oauth2.googleapis.com/token
+iceberg_rest_catalog_authentication_mode: gcp
+iceberg_rest_catalog_warehouse: gs://<bucket-name>/
+iceberg_rest_catalog_gcp_user_project: <gcp-project-id>
+iceberg_dlq_table_suffix: _dlq
+----
++
+--
+* Replace `<bucket-name>` with your bucket name and `<gcp-project-id>` with your Google Cloud project ID.
+* You must set the `iceberg_dlq_table_suffix` property to a value that does not include dots or tildes (`~`). The example above uses `_dlq` as the suffix for the xref:manage:iceberg/about-iceberg-topics.adoc#troubleshoot-errors[dead-letter queue (DLQ) table].
+--
+
+ifndef::env-cloud[]
+. If you change the configuration for a running cluster, you must restart that cluster now.
+endif::[]
+
+. Enable the REST catalog integration for a topic by configuring the topic property `redpanda.iceberg.mode`. The following examples show how to use xref:get-started:rpk-install.adoc[`rpk`] to either create a new topic or alter the configuration for an existing topic and set the Iceberg mode to `key_value`. The `key_value` mode creates a two-column Iceberg table for the topic, with one column for the record metadata including the key, and another binary column for the record's value. See xref:manage:iceberg/choose-iceberg-mode.adoc[] for more details on Iceberg modes.  
++
+.Create a new topic and set `redpanda.iceberg.mode`:
+[,bash]
+----
+rpk topic create <topic-name> --topic-config=redpanda.iceberg.mode=key_value
+----
++
+.Set `redpanda.iceberg.mode` for an existing topic:
+[,bash]
+----
+rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
+---- 
++
+[NOTE]
+====
+If you're using the Self-managed quickstart for testing, your Redpanda cluster includes a `transactions` topic with data in it, and a sample schema in the Schema Registry. To enable Iceberg for the `transactions` topic, run:
+
 [,bash]
 ----
 rpk topic alter-config transactions --set redpanda.iceberg.mode=value_schema_latest:subject=transactions
 ----
+====
 
-== Query Iceberg tables in BigQuery
+== Query Iceberg topics in BigQuery
 
 . Navigate to the https://console.cloud.google.com/bigquery[BigQuery console^].
 
-. Query your Iceberg table using SQL. For example:
+. Query your Iceberg topic using SQL. For example, to query the `transactions` topic:
 +
 [,sql]
 ----
@@ -245,9 +335,9 @@ Replace `<bucket-name>` with your bucket name.
 
 Your Redpanda topics are now available as Iceberg tables in BigLake, allowing you to run analytics queries directly on your streaming data.
 
-== Clean up resources
+== Optional: Clean up resources
 
-When you're finished, you can clean up the resources you created:
+When you're finished with the quickstart example, you can clean up the resources you created:
 
 [,bash]
 ----

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -344,6 +344,6 @@ The following are not supported for JSON Schema:
 
 // end::single-source[]
 
-== See also
+include::shared:partial$suggested-reading.adoc[]
 
 - xref:reference:properties/topic-properties.adoc#redpanda-iceberg-mode[`redpanda.iceberg.mode` topic property reference]


### PR DESCRIPTION
## Description

Enable BigLake REST Catalog integration and query Iceberg topics in BigQuery. This guide describes deploying Redpanda using Docker on GCP Linux VMs and integrating a "prefilled" Iceberg topic in BigLake.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

[Use Iceberg Topics using GCP BigLake](https://deploy-preview-1443--redpanda-docs-preview.netlify.app/25.3/manage/iceberg/iceberg-topics-gcp-biglake/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
