### PR TITLE
DOC-1793 add time-based retention to beta what's new

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -34,3 +34,7 @@ Redpanda Schema Registry now supports an import mode that allows you to import e
 
 Starting with this release, import mode must be used when importing schemas. Read-write mode no longer allows specifying a schema ID and version when registering a schema.
 See xref:manage:schema-reg/schema-reg-api.adoc#set-schema-registry-mode[Use the Schema Registry API] for more information.
+
+== Time-based retention validation
+
+Redpanda introduces timestamp validation controls to improve the accuracy and reliability of xref:manage:cluster-maintenance/disk-utilization.adoc#set-time-based-retention[time-based retention]. The new properties `log_message_timestamp_before_max_ms` and `log_message_timestamp_after_max_ms` ensure that messages are accepted only if their timestamps fall within a valid range. This prevents retention issues caused by invalid or out-of-range timestamps.


### PR DESCRIPTION
## Description
This PR adds a blurb to the What's New for the new time-based retention validation added in https://github.com/redpanda-data/docs/pull/1429

Resolves https://redpandadata.atlassian.net/browse/DOC-1793
Review deadline:

## Page previews
[What's New](https://deploy-preview-1444--redpanda-docs-preview.netlify.app/25.3/get-started/release-notes/redpanda/#time-based-retention-validation)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
