### PR TITLE
DOC-1707: Deprecation announcement of cipher suites for Self-Managed

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -30,7 +30,13 @@ Existing Admin API endpoints from versions earlier than 25.3 remain supported, a
 
 == Schema Registry import mode
 
-Redpanda Schema Registry now supports an import mode that allows you to import existing schemas and retain their current IDs and version numbers. Import mode is useful when migrating from another schema registry. 
+Redpanda Schema Registry now supports an import mode that allows you to import existing schemas and retain their current IDs and version numbers. Import mode is useful when migrating from another schema registry.
 
 Starting with this release, import mode must be used when importing schemas. Read-write mode no longer allows specifying a schema ID and version when registering a schema.
 See xref:manage:schema-reg/schema-reg-api.adoc#set-schema-registry-mode[Use the Schema Registry API] for more information.
+
+== Deprecations
+
+Several TLSv1.2 and TLSv1.3 cipher suites have been deprecated. See xref:upgrade:deprecated/index.adoc[Deprecated Features].
+
+

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -14,7 +14,7 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 | Deprecated in  | Feature | Details
 
 | 25.3.1
-| The following TLSv1.2 and TLSv1.3 cipher suites:
+| The following TLSv1.2 cipher suites:
 
 - AES256-GCM-SHA384
 - AES256-CCM
@@ -26,6 +26,10 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 - ECDHE-ECDSA-AES128-SHA
 - AES256-SHA
 - AES128-SHA
+
+The following TLSv1.3 cipher suites:
+
+- TLS_AES_128_CCM_8_SHA256
 
 | Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your clients (for example, S3) or listeners (Kafka, Admin API, HTTP Proxy, or Schema Registry) rely on any of the deprecated cipher suites, update them to use more secure alternatives.
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -31,7 +31,7 @@ The following TLSv1.3 cipher suites:
 
 - TLS_AES_128_CCM_8_SHA256
 
-| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your clients (for example, S3) or listeners (Kafka, Admin API, HTTP Proxy, or Schema Registry) rely on any of the deprecated cipher suites, update them to use more secure alternatives.
+| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your Kafka API, Admin API, HTTP Proxy, or Schema Registry clients rely on any of the deprecated cipher suites, we recommend you update them to use more secure alternatives. These cipher suites also apply to services that Redpanda connects to, such as S3.
 
 Use available cipher suites that are determined by the OpenSSL library by specifying the minimum TLS version using the `tls_v1_2_cipher_suites` or `tls_v1_3_cipher_suites` properties.
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -13,6 +13,22 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 |===
 | Deprecated in  | Feature | Details
 
+| 25.3.1
+| The following TLSv1.2 and TLSv1.3 cipher suites:
+
+- AES256-GCM-SHA384
+- AES256-CCM
+- AES128-GCM-SHA256
+- ECDHE-RSA-AES128-SHA
+- ECDHE-RSA-AES256-SHA
+- ECDHE-ECDSA-AES256-SHA
+- AES128-CCM
+- ECDHE-ECDSA-AES128-SHA
+- AES256-SHA
+- AES128-SHA
+
+| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your clients (for example, S3) or listeners (Kafka, Admin API, HTTP Proxy, or Schema Registry) rely on any of the deprecated cipher suites, update them to use more secure alternatives. Available cipher suites are determined by the OpenSSL library and the minimum TLS version you set using the `tls_v1_2_cipher_suites` or `tls_v1_3_cipher_suites` properties.
+
 | 25.1.1
 | Throughput throttling configuration:
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -27,7 +27,9 @@ This index helps you to identify deprecated features in Redpanda releases and pl
 - AES256-SHA
 - AES128-SHA
 
-| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your clients (for example, S3) or listeners (Kafka, Admin API, HTTP Proxy, or Schema Registry) rely on any of the deprecated cipher suites, update them to use more secure alternatives. Available cipher suites are determined by the OpenSSL library and the minimum TLS version you set using the `tls_v1_2_cipher_suites` or `tls_v1_3_cipher_suites` properties.
+| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your clients (for example, S3) or listeners (Kafka, Admin API, HTTP Proxy, or Schema Registry) rely on any of the deprecated cipher suites, update them to use more secure alternatives.
+
+Use available cipher suites that are determined by the OpenSSL library by specifying the minimum TLS version using the `tls_v1_2_cipher_suites` or `tls_v1_3_cipher_suites` properties.
 
 | 25.1.1
 | Throughput throttling configuration:

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -31,7 +31,7 @@ The following TLSv1.3 cipher suites:
 
 - TLS_AES_128_CCM_8_SHA256
 
-| Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your Kafka API, Admin API, HTTP Proxy, or Schema Registry clients rely on any of the deprecated cipher suites, we recommend you update them to use more secure alternatives. These cipher suites also apply to services that Redpanda connects to, such as S3.
+| Redpanda has deprecated these cipher suites in accordance with security policy guidelines and now defaults to a more secure set of cipher suites provided by OpenSSL. If your Kafka API, Admin API, HTTP Proxy, or Schema Registry clients rely on any of the deprecated cipher suites, we recommend you update them to use more secure alternatives. These cipher suites also apply to services that Redpanda connects to, such as S3.
 
 You can configure available cipher suites by specifying xref:reference:cluster-properties.adoc#tls_v1_2_cipher_suites[`tls_v1_2_cipher_suites`] or xref:reference:cluster-properties.adoc#tls_v1_3_cipher_suites[`tls_v1_3_cipher_suites`] cluster properties in OpenSSL 3.0 format.
 

--- a/modules/upgrade/pages/deprecated/index.adoc
+++ b/modules/upgrade/pages/deprecated/index.adoc
@@ -33,7 +33,7 @@ The following TLSv1.3 cipher suites:
 
 | Redpanda has deprecated these cipher suites due to security policy guidelines, and now defaults to a more secure set of cipher suites provided by OpenSSL. If your Kafka API, Admin API, HTTP Proxy, or Schema Registry clients rely on any of the deprecated cipher suites, we recommend you update them to use more secure alternatives. These cipher suites also apply to services that Redpanda connects to, such as S3.
 
-Use available cipher suites that are determined by the OpenSSL library by specifying the minimum TLS version using the `tls_v1_2_cipher_suites` or `tls_v1_3_cipher_suites` properties.
+You can configure available cipher suites by specifying xref:reference:cluster-properties.adoc#tls_v1_2_cipher_suites[`tls_v1_2_cipher_suites`] or xref:reference:cluster-properties.adoc#tls_v1_3_cipher_suites[`tls_v1_3_cipher_suites`] cluster properties in OpenSSL 3.0 format.
 
 | 25.1.1
 | Throughput throttling configuration:


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1707
Review deadline: **Nov 7, 2025**

## Page previews

[Deprecated Redpanda Features](https://deploy-preview-1446--redpanda-docs-preview.netlify.app/25.3/upgrade/deprecated/)

Cloud side to come in a different PR

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
