### PR TITLE
rpk: fix default flags for rpk debug bundle

### DIFF
--- a/modules/reference/pages/rpk/rpk-debug/rpk-debug-bundle.adoc
+++ b/modules/reference/pages/rpk/rpk-debug/rpk-debug-bundle.adoc
@@ -93,7 +93,7 @@ rpk debug bundle [flags]
 
 |--controller-logs-size-limit |string |Sets the limit of the controller
 log size that can be stored in the bundle. Multipliers are also
-supported, e.g. 3MB, 1GiB (default `20MB`).
+supported, e.g. 3MB, 1GiB (default `132MB`).
 
 |--cpu-profiler-wait |duration |Specifies the duration for collecting samples for the CPU profiler (for example, 30s, 1.5m). Must be higher than 15s (default `30s`).
 
@@ -107,14 +107,14 @@ supported, e.g. 3MB, 1GiB (default `20MB`).
 reached. Multipliers are also supported, e.g. 3MB, 1GiB (default
 `100MiB`).
 
-|--logs-until |string |Include logs older than the specified date. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the link:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options (default `yesterday`). +
+|--logs-until |string |Include logs older than the specified date. This flag accepts a `journalctl` date format such as `YYYY-MM-DD`, `yesterday`, or `today`. Refer to the link:https://man7.org/linux/man-pages/man1/journalctl.1.html[`journalctl` documentation] for more options. +
 *Not supported in Kubernetes*
 
 |--metrics-interval |duration |The amount of time to wait before
 capturing the second snapshot of the metrics endpoints, for example
 `30s` (30 seconds) or `1.5m` (90 seconds). This interval is useful
 because some metrics are counters that need values at two points in
-time. Default: `12s`.
+time. Default: `10s`.
 
 |--metrics-samples |int |Number of metrics samples to take (at the interval of `--metrics-interval`). Must be higher or equals 2 (default 2).
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1829
Review deadline:

Fix flags to match https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/cli/debug/bundle/bundle.go


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
