### PR TITLE
DOC-1741 Console Shadowing DR

### DIFF
--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -16,7 +16,7 @@ Explore a comprehensive overview of your cluster, including:
 * *Broker monitoring*: View and manage the health, status, and configurations of your brokers.
 * *Topic management*: Create, configure, and monitor topics, including detailed information on partitions, replicas, and message counts.
 * *Consumer group insights*: Track the activity and performance of your consumer groups, manage offsets, and identify potential bottlenecks.
-* [*Shadow links management*]: Create shadow links to continuously replicate topics, ACLs, and consumer groups from a source cluster into a shadow cluster. This is useful for disaster recovery.
+* *Shadow links management*: Create shadow links to continuously replicate topics, ACLs, and consumer groups from a source cluster into a shadow cluster. This is useful for disaster recovery.
 
 
 image::broker-overview.png[]

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -16,7 +16,7 @@ Explore a comprehensive overview of your cluster, including:
 * *Broker monitoring*: View and manage the health, status, and configurations of your brokers.
 * *Topic management*: Create, configure, and monitor topics, including detailed information on partitions, replicas, and message counts.
 * *Consumer group insights*: Track the activity and performance of your consumer groups, manage offsets, and identify potential bottlenecks.
-* *Shadow links management*: Create shadow links to continuously replicate topics, ACLs, and consumer groups from a source cluster into a shadow cluster. This is useful for disaster recovery.
+* xref:manage:disaster-recovery/shadowing/overview.adoc[*Shadow link management*]: Create shadow links for asynchronous, offset-preserving replication between distinct Redpanda clusters. The shadow cluster operates in read-only mode while continuously receiving updates from the source cluster. During a disaster, you can failover individual topics or an entire shadow link to make resources fully writable for production traffic.
 
 
 image::broker-overview.png[]

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -16,6 +16,8 @@ Explore a comprehensive overview of your cluster, including:
 * *Broker monitoring*: View and manage the health, status, and configurations of your brokers.
 * *Topic management*: Create, configure, and monitor topics, including detailed information on partitions, replicas, and message counts.
 * *Consumer group insights*: Track the activity and performance of your consumer groups, manage offsets, and identify potential bottlenecks.
+* [*Shadow links management*]: Create shadow links to continuously replicate topics, ACLs, and consumer groups from a source cluster into a shadow cluster. This is useful for disaster recovery.
+
 
 image::broker-overview.png[]
 


### PR DESCRIPTION
## Description
This pull request adds a bullet point in Console overview describing "Shadow links management," which enables users to replicate topics, ACLs, and consumer groups from a source cluster into a shadow cluster for disaster recovery purposes.

Resolves https://redpandadata.atlassian.net/browse/DOC-1741
Review deadline:

## Page previews
[Intro to Console](https://deploy-preview-1464--redpanda-docs-preview.netlify.app/25.3/console/#cluster-management)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
