### PR TITLE
Single source connected client monitoring docs for Cloud

### DIFF
--- a/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
@@ -12,7 +12,7 @@ ifdef::env-cloud[]
 Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
 
 * Use the xref:reference:public-metrics-reference.adoc#redpanda_rpc_active_connections[`redpanda_rpc_active_connections` metric] to view current Kafka client connections.
-* For clusters on v25.3 and later, use `rpk cluster connections list` or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify:
+* For clusters on v25.3 and later, use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify:
 +
 -- 
 ** Which clients and applications are connected

--- a/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
@@ -6,16 +6,32 @@
 
 Optimize the availability of your clusters by configuring and tuning properties.
 
-// Don't display ListKafkaConnections in Cloud docs until support is added
 ifdef::env-cloud[]
-TIP: Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. Use the xref:reference:public-metrics-reference.adoc#redpanda_rpc_active_connections[`redpanda_rpc_active_connections` metric] to view current Kafka client connections.
+[TIP]
+====
+Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
+
+* Use the xref:reference:public-metrics-reference.adoc#redpanda_rpc_active_connections[`redpanda_rpc_active_connections` metric] to view current Kafka client connections.
+* For clusters on v25.3 and later, use `rpk cluster connections list` or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify:
++
+-- 
+** Which clients and applications are connected
+** Long-lived connections and long-running requests
+** Connections with no activity 
+** Whether any clients are causing excessive load
+--
++
+By reviewing connection details, you can make informed decisions about tuning connection limits and troubleshooting issues.
+
+See also: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[Data Plane API reference], xref:manage:monitor-cloud.adoc#throughput[Monitor Redpanda Cloud]
+====
 endif::[]
 ifndef::env-cloud[]
 [TIP]
 ====
 Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
 
-* Internal metrics that follow the `vectorized_kafka_rpc_.\*connect.*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
+* Internal metrics that follow the `vectorized_kafka_rpc_.\*connect*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
 * For Redpanda v25.3 and later, use `rpk cluster connections list` or the Admin API ListKafkaConnections endpoint to identify:
 +
 -- 

--- a/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
+++ b/modules/manage/pages/cluster-maintenance/configure-client-connections.adoc
@@ -32,7 +32,7 @@ ifndef::env-cloud[]
 Before you configure connection limits or reconnection settings, start by gathering detailed data about your client connections. 
 
 * Internal metrics that follow the `vectorized_kafka_rpc_.\*connect*` naming pattern provide details on Kafka client connection activity. For example, xref:reference:internal-metrics-reference.adoc#vectorized_kafka_rpc_active_connections[`vectorized_kafka_rpc_active_connections`] reports the current number of active connections.
-* For Redpanda v25.3 and later, use `rpk cluster connections list` or the Admin API ListKafkaConnections endpoint to identify:
+* For Redpanda v25.3 and later, use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the Admin API ListKafkaConnections endpoint to identify:
 +
 -- 
 ** Which clients and applications are connected

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -28,7 +28,7 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc} to view detailed information about active Kafka client connections.
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the pass:q,a[{connected-clients-api-doc}] to view detailed information about active Kafka client connections.
 
 For example, to view a cluster's connected clients in order of highest current produce throughput, run:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -5,11 +5,11 @@
 // tag::single-source[]
 ifdef::env-cloud[]
 :monitor-doc: manage:monitor-cloud.adoc#throughput
-:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[GET /v1/monitoring/kafka/connections] Data Plane API endpoint
+:connected-clients-api-doc-ref: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections
 endif::[]
 ifndef::env-cloud[]
 :monitor-doc: manage:monitoring.adoc#throughput
-:connected-clients-api-doc: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections] Admin API endpoint
+:connected-clients-api-doc-ref: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections
 endif::[]
 
 Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers. You can configure limits at two levels:
@@ -28,7 +28,13 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc} to view detailed information about active Kafka client connections.
+ifndef::env-cloud[]
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc-ref}[ListKafkaConnections] Admin API endpoint to view detailed information about active Kafka client connections.
+endif::[]
+
+ifdef::env-cloud[]
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc-ref}[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint to view detailed information about active Kafka client connections.
+endif::[]
 
 For example, to view a cluster's connected clients in order of highest current produce throughput, run:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -81,7 +81,7 @@ curl -s -X POST \
 .Show example API response
 [%collapsible]
 ====
-[,json,role=no-copy,lines=54]
+[,json,role=no-copy,lines=55]
 ----
 {
   "connections": [
@@ -277,7 +277,7 @@ curl -s -X POST \
 .Show example API response
 [%collapsible]
 ====
-[,json,lines=23]
+[,json,lines=24]
 ----
 {
   "connections": [

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -5,7 +5,7 @@
 // tag::single-source[]
 ifdef::env-cloud[]
 :monitor-doc: manage:monitor-cloud.adoc#throughput
-:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint
+:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[GET /v1/monitoring/kafka/connections] Data Plane API endpoint
 endif::[]
 ifndef::env-cloud[]
 :monitor-doc: manage:monitoring.adoc#throughput
@@ -28,7 +28,7 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the pass:a[{connected-clients-api-doc}] to view detailed information about active Kafka client connections.
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc} to view detailed information about active Kafka client connections.
 
 For example, to view a cluster's connected clients in order of highest current produce throughput, run:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -56,6 +56,7 @@ b41584f3-2662-4185-a4b8-0d8510f5c780  OPEN   UNAUTHENTICATED  perf-producer-clie
 ----
 --
 
+ifndef::env-cloud[]
 curl::
 +
 --
@@ -141,6 +142,95 @@ curl -s -X POST \
 ----
 ====
 --
+endif::[]
+
+ifdef::env-cloud[]
+Data Plane API::
++
+--
+[,bash]
+----
+curl \
+  --request GET 'https://<dataplane-api-url>/v1/monitoring/kafka/connections' \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --data '{
+    "filter": "",
+    "order_by": "recent_request_statistics.produce_bytes desc"
+  }'
+----
+
+.Show example API response
+[%collapsible]
+====
+[,json,role=no-copy,lines=54]
+----
+{
+  "connections": [
+    {
+      "node_id": 0,
+      "shard_id": 0,
+      "uid": "b20601a3-624c-4a8c-ab88-717643f01d56",
+      "state": "KAFKA_CONNECTION_STATE_OPEN",
+      "open_time": "2025-10-15T14:15:15.755065000Z",
+      "close_time": "1970-01-01T00:00:00.000000000Z",
+      "authentication_info": {
+        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
+        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
+        "user_principal": ""
+      },
+      "listener_name": "",
+      "tls_info": {
+        "enabled": false
+      },
+      "source": {
+        "ip_address": "127.0.0.1",
+        "port": 55012
+      },
+      "client_id": "perf-producer-client",
+      "client_software_name": "apache-kafka-java",
+      "client_software_version": "3.9.0",
+      "transactional_id": "my-tx-id",
+      "group_id": "",
+      "group_instance_id": "",
+      "group_member_id": "",
+      "api_versions": {
+        "18": 4,
+        "22": 3,
+        "3": 12,
+        "24": 3,
+        "0": 7
+      },
+      "idle_duration": "0s",
+      "in_flight_requests": {
+        "sampled_in_flight_requests": [
+          {
+            "api_key": 0,
+            "in_flight_duration": "0.000406892s"
+          }
+        ],
+        "has_more_requests": false
+      },
+      "total_request_statistics": {
+        "produce_bytes": "78927173",
+        "fetch_bytes": "0",
+        "request_count": "4853",
+        "produce_batch_count": "4849"
+      },
+      "recent_request_statistics": {
+        "produce_bytes": "78927173",
+        "fetch_bytes": "0",
+        "request_count": "4853",
+        "produce_batch_count": "4849"
+      }
+    },
+    ...
+  ],
+  "total_size": "9"
+}
+----
+====
+--
+endif::[]
 ======
 
 To view connections for a specific client, you can use a filter expression:
@@ -179,7 +269,7 @@ curl -s -X POST \
 .Show example API response
 [%collapsible]
 ====
-[,json,lines=24]
+[,json,lines=23]
 ----
 {
   "connections": [

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -1,6 +1,7 @@
 = Manage Throughput
 :description: Learn how to manage the throughput of Kafka traffic.
 :page-categories: Management, Networking
+
 // tag::single-source[]
 ifdef::env-cloud[]
 :monitor-doc: manage:monitor-cloud.adoc#throughput
@@ -253,6 +254,7 @@ b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-clie
 ----
 --
 
+ifndef::env-cloud[]
 curl::
 +
 --
@@ -330,6 +332,87 @@ curl -s -X POST \
 ----
 ====
 --
+endif::[]
+
+ifdef::env-cloud[]
+Data Plane API::
++
+--
+[,bash]
+----
+curl \
+  --request GET 'https://<dataplane-api-url>/v1/monitoring/kafka/connections' \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --data '{
+    "filter": "client_id = \"perf-producer-client\""
+  }' 
+----
+
+.Show example API response
+[%collapsible]
+====
+[,json,lines=23]
+----
+{
+  "connections": [
+    {
+      "node_id": 0,
+      "shard_id": 0,
+      "uid": "b41584f3-2662-4185-a4b8-0d8510f5c780",
+      "state": "KAFKA_CONNECTION_STATE_OPEN",
+      "open_time": "2025-10-15T14:15:15.219538000Z",
+      "close_time": "1970-01-01T00:00:00.000000000Z",
+      "authentication_info": {
+        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
+        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
+        "user_principal": ""
+      },
+      "listener_name": "",
+      "tls_info": {
+        "enabled": false
+      },
+      "source": {
+        "ip_address": "127.0.0.1",
+        "port": 55002
+      },
+      "client_id": "perf-producer-client",
+      "client_software_name": "apache-kafka-java",
+      "client_software_version": "3.9.0",
+      "transactional_id": "",
+      "group_id": "",
+      "group_instance_id": "",
+      "group_member_id": "",
+      "api_versions": {
+        "18": 4,
+        "3": 12,
+        "10": 4
+      },
+      "idle_duration": "7.743592270s",
+      "in_flight_requests": {
+        "sampled_in_flight_requests": [],
+        "has_more_requests": false
+      },
+      "total_request_statistics": {
+        "produce_bytes": "0",
+        "fetch_bytes": "0",
+        "request_count": "3",
+        "produce_batch_count": "0"
+      },
+      "recent_request_statistics": {
+        "produce_bytes": "0",
+        "fetch_bytes": "0",
+        "request_count": "3",
+        "produce_batch_count": "0"
+      }
+    },
+    ...
+  ],
+  "total_size": "2"
+}
+----
+====
+--
+endif::[]
 ======
 
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -28,7 +28,7 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the pass:q,a[{connected-clients-api-doc}] to view detailed information about active Kafka client connections.
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the pass:a[{connected-clients-api-doc}] to view detailed information about active Kafka client connections.
 
 For example, to view a cluster's connected clients in order of highest current produce throughput, run:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 You may find it helpful to check the xref:{monitor-doc}[current produce and consume throughput] of a client before you configure throughput quotas.
 
-Use the `rpk cluster connections list` command or the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections] Admin API endpoint to view detailed information about active Kafka client connections.
+Use the xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] command or the {connected-clients-api-doc} to view detailed information about active Kafka client connections.
 
 For example, to view a cluster's connected clients in order of highest current produce throughput, run:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -2,8 +2,14 @@
 :description: Learn how to manage the throughput of Kafka traffic.
 :page-categories: Management, Networking
 // tag::single-source[]
-ifdef::env-cloud[:monitor-doc: manage:monitor-cloud.adoc#throughput]
-ifndef::env-cloud[:monitor-doc: manage:monitoring.adoc#throughput]
+ifdef::env-cloud[]
+:monitor-doc: manage:monitor-cloud.adoc#throughput
+:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint
+endif::[]
+ifndef::env-cloud[]
+:monitor-doc: manage:monitoring.adoc#throughput
+:connected-clients-api-doc: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections] Admin API endpoint
+endif::[]
 
 Redpanda supports throughput throttling on both ingress and egress independently, and allows configuration at the broker and client levels. This helps prevent clients from causing unbounded network and disk usage on brokers. You can configure limits at two levels:
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -136,10 +136,10 @@ rate(redpanda_rpc_sent_bytes{redpanda_server="kafka"}[$__rate_interval])
 ==== Identify high-throughput clients
 
 ifndef::env-cloud[]
-Use `rpk cluster connections list` or the ListKafkaConnections endpoint in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the ListKafkaConnections endpoint in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
 endif::[]
 ifdef::env-cloud[]
-Use `rpk cluster connections list` or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
 endif::[]
 
 For example, to list connections with a current produce throughput greater than 1MB, run:

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -161,6 +161,7 @@ b20601a3-624c-4a8c-ab88-717643f01d56  OPEN   UNAUTHENTICATED  perf-producer-clie
 ----
 --
 
+ifndef::env-cloud[]
 curl::
 +
 --
@@ -238,6 +239,7 @@ curl -s -X POST "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaC
 ----
 ====
 --
+endif::[]
 
 ifdef::env-cloud[]
 Data Plane API::

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -1,6 +1,13 @@
 == Monitor for performance and health
 // tag::single-source[]
 
+ifndef::env-cloud[]
+:connected-clients-api-doc: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[Admin API reference]
+endif::[]
+ifdef::env-cloud[]
+:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[Data Plane API reference]
+endif::[]
+
 This section provides guidelines and example queries using Redpanda's public metrics to optimize your system's performance and monitor its health.
 
 To help detect and mitigate anomalous system behaviors, capture baseline metrics of your healthy system at different stages (at start-up, under high load, in steady state) so you can set thresholds and alerts according to those baselines.
@@ -125,11 +132,15 @@ For the consume rate, create a query to get the total consume rate across all to
 rate(redpanda_rpc_sent_bytes{redpanda_server="kafka"}[$__rate_interval])
 ----
 
-// Don't display ListKafkaConnections in Cloud docs until support is added 
-ifndef::env-cloud[]
+
 ==== Identify high-throughput clients
 
-Use `rpk cluster connections list` or the ListKafkaConnections service in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+ifndef::env-cloud[]
+Use `rpk cluster connections list` or the ListKafkaConnections endpoint in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+endif::[]
+ifdef::env-cloud[]
+Use `rpk cluster connections list` or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+endif::[]
 
 For example, to list connections with a current produce throughput greater than 1MB, run:
 
@@ -227,10 +238,92 @@ curl -s -X POST "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaC
 ----
 ====
 --
+
+ifdef::env-cloud[]
+Data Plane API::
++
+--
+[,bash]
+----
+curl \
+ --request GET 'https://<dataplane-api-url>/v1/monitoring/kafka/connections' \
+ --header "Authorization: Bearer $ACCESS_TOKEN" \
+ --data '{"filter":"recent_request_statistics.produce_bytes > 1000000", "order_by":"recent_request_statistics.produce_bytes desc"}' | jq
+----
+
+.Show example API response
+[%collapsible]
+====
+[,bash,role=no-copy,lines=54]
+----
+{
+  "connections": [
+    {
+      "node_id": 0,
+      "shard_id": 0,
+      "uid": "b20601a3-624c-4a8c-ab88-717643f01d56",
+      "state": "KAFKA_CONNECTION_STATE_OPEN",
+      "open_time": "2025-10-15T14:15:15.755065000Z",
+      "close_time": "1970-01-01T00:00:00.000000000Z",
+      "authentication_info": {
+        "state": "AUTHENTICATION_STATE_UNAUTHENTICATED",
+        "mechanism": "AUTHENTICATION_MECHANISM_UNSPECIFIED",
+        "user_principal": ""
+      },
+      "listener_name": "",
+      "tls_info": {
+        "enabled": false
+      },
+      "source": {
+        "ip_address": "127.0.0.1",
+        "port": 55012
+      },
+      "client_id": "perf-producer-client",
+      "client_software_name": "apache-kafka-java",
+      "client_software_version": "3.9.0",
+      "transactional_id": "my-tx-id",
+      "group_id": "",
+      "group_instance_id": "",
+      "group_member_id": "",
+      "api_versions": {
+        "18": 4,
+        "22": 3,
+        "3": 12,
+        "24": 3,
+        "0": 7
+      },
+      "idle_duration": "0s",
+      "in_flight_requests": {
+        "sampled_in_flight_requests": [
+          {
+            "api_key": 0,
+            "in_flight_duration": "0.000406892s"
+          }
+        ],
+        "has_more_requests": false
+      },
+      "total_request_statistics": {
+        "produce_bytes": "78927173",
+        "fetch_bytes": "0",
+        "request_count": "4853",
+        "produce_batch_count": "4849"
+      },
+      "recent_request_statistics": {
+        "produce_bytes": "78927173",
+        "fetch_bytes": "0",
+        "request_count": "4853",
+        "produce_batch_count": "4849"
+      }
+    }
+  ]
+}
+----
+====
+--
+endif::[]
 ======
 
-You can adjust the filter and sorting criteria as necessary. See the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[Admin API reference] for more details. 
-endif::[]
+You can adjust the filter and sorting criteria as necessary. See the {connected-clients-api-doc} for more details. 
 
 === Latency
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -2,10 +2,10 @@
 // tag::single-source[]
 
 ifndef::env-cloud[]
-:connected-clients-api-doc: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[Admin API reference]
+:connected-clients-api-doc-ref: link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections
 endif::[]
 ifdef::env-cloud[]
-:connected-clients-api-doc: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[Data Plane API reference]
+:connected-clients-api-doc-ref: link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections
 endif::[]
 
 This section provides guidelines and example queries using Redpanda's public metrics to optimize your system's performance and monitor its health.
@@ -136,10 +136,10 @@ rate(redpanda_rpc_sent_bytes{redpanda_server="kafka"}[$__rate_interval])
 ==== Identify high-throughput clients
 
 ifndef::env-cloud[]
-Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the ListKafkaConnections endpoint in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the {connected-clients-api-doc-ref}[ListKafkaConnections] endpoint in Admin API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
 endif::[]
 ifdef::env-cloud[]
-Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the `GET /v1/monitoring/kafka/connections` endpoint in the Data Plane API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
+Use xref:reference:rpk/rpk-cluster/rpk-cluster-connections-list.adoc[`rpk cluster connections list`] or the {connected-clients-api-doc-ref}[`GET /v1/monitoring/kafka/connections`] endpoint in the Data Plane API to identify which client connections are driving the majority of, or the change in, the produce or consume throughput for a cluster.
 endif::[]
 
 For example, to list connections with a current produce throughput greater than 1MB, run:
@@ -256,7 +256,7 @@ curl \
 .Show example API response
 [%collapsible]
 ====
-[,bash,role=no-copy,lines=54]
+[,bash,role=no-copy,lines=55]
 ----
 {
   "connections": [
@@ -325,7 +325,7 @@ curl \
 endif::[]
 ======
 
-You can adjust the filter and sorting criteria as necessary. See the {connected-clients-api-doc} for more details. 
+You can adjust the filter and sorting criteria as necessary. 
 
 === Latency
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -173,7 +173,7 @@ curl -s -X POST "localhost:9644/redpanda.core.admin.v2.ClusterService/ListKafkaC
 .Show example API response
 [%collapsible]
 ====
-[,bash,role=no-copy,lines=54]
+[,bash,role=no-copy,lines=55]
 ----
 {
   "connections": [
@@ -256,7 +256,7 @@ curl \
 .Show example API response
 [%collapsible]
 ====
-[,bash,role=no-copy,lines=55]
+[,bash,role=no-copy,lines=54]
 ----
 {
   "connections": [

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
@@ -8,11 +8,11 @@ This command displays a table of active and recently closed connections within t
 Use filtering and sorting to identify the connections of the client applications that you are interested in. See `--help` for the list of filtering arguments and sorting arguments.
 
 ifndef::env-cloud[]
-In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]. 
+In addition to filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]. 
 endif::[]
 
 ifdef::env-cloud[]
-In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint. 
+In addition to filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint. 
 endif::[]
 
 By default only a subset of the per-connection data is printed. To see all of the available data, use `--format=json`.

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
@@ -1,5 +1,6 @@
 = rpk cluster connections list
 
+// tag::single-source[]
 Display statistics about current Kafka connections.
 
 This command displays a table of active and recently closed connections within the cluster.
@@ -94,3 +95,5 @@ rpk cluster connections list --format=json --state="OPEN"
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+
+// end::single-source[]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
@@ -6,7 +6,7 @@ This command displays a table of active and recently closed connections within t
 
 Use filtering and sorting to identify the connections of the client applications that you are interested in. See `--help` for the list of filtering arguments and sorting arguments.
 
-In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]: 
+In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]. 
 
 By default only a subset of the per-connection data is printed. To see all of the available data, use `--format=json`.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
@@ -7,7 +7,13 @@ This command displays a table of active and recently closed connections within t
 
 Use filtering and sorting to identify the connections of the client applications that you are interested in. See `--help` for the list of filtering arguments and sorting arguments.
 
+ifndef::env-cloud[]
 In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]. 
+endif::[]
+
+ifdef::env-cloud[]
+In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/cloud-dataplane/operation/operation-monitoringservice_listkafkaconnections[`GET /v1/monitoring/kafka/connections`] Data Plane API endpoint. 
+endif::[]
 
 By default only a subset of the per-connection data is printed. To see all of the available data, use `--format=json`.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections-list.adoc
@@ -6,7 +6,7 @@ This command displays a table of active and recently closed connections within t
 
 Use filtering and sorting to identify the connections of the client applications that you are interested in. See `--help` for the list of filtering arguments and sorting arguments.
 
-In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the [ListKafkaConnections endpoint](https://docs.redpanda.com/api/doc/admin/version/11f41833-5783-4f1a-ad64-5957267abd52/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections): 
+In addition to the filtering shorthand CLI arguments (For example, `--client-id`, `--state`), you can also use the `--filter-raw` and `--order-by` arguments that take string expressions. To understand the syntax of these arguments, refer to the Admin API docs of the filter and order-by fields of the link:/api/doc/admin/v2/operation/operation-redpanda-core-admin-v2-clusterservice-listkafkaconnections[ListKafkaConnections endpoint]: 
 
 By default only a subset of the per-connection data is printed. To see all of the available data, use `--format=json`.
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-connections.adoc
@@ -1,4 +1,5 @@
 = rpk cluster connections
+// tag::single-source[]
 
 Manage and monitor cluster connections.
 
@@ -32,3 +33,5 @@ connections, connection
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+
+// end::single-source[]


### PR DESCRIPTION
## Description

Add and conditionalize connected client monitoring content for Cloud docs. Related PR: https://github.com/redpanda-data/cloud-docs/pull/459

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline: 19 Nov

## Page previews

Cloud doc previews:

[What's New in Cloud](https://deploy-preview-459--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
Manage Throughput > [View connected client details](https://deploy-preview-459--rp-cloud.netlify.app/redpanda-cloud/manage/cluster-maintenance/manage-throughput/)
Monitor Redpanda Cloud > Throughput > [Identify high-throughput clients](https://deploy-preview-459--rp-cloud.netlify.app/redpanda-cloud/manage/monitor-cloud/#identify-high-throughput-clients)
[Configure client connections](https://deploy-preview-459--rp-cloud.netlify.app/redpanda-cloud/manage/cluster-maintenance/configure-client-connections/)
[rpk cluster connections list](https://deploy-preview-459--rp-cloud.netlify.app/redpanda-cloud/reference/rpk/rpk-cluster/rpk-cluster-connections-list/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
