### PR TITLE
Update k-compatibility.adoc

### DIFF
--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -75,7 +75,7 @@ d|1.28.x - 1.32.x{fn-k8s-compatibility}
 d|1.28.x - 1.32.x{fn-k8s-compatibility}
 
 |5.9.x
-|0.4.41
+|2.4.x
 |2.4.x
 |3.11+
 d|1.28.x - 1.31.x{fn-k8s-compatibility}


### PR DESCRIPTION
## Description

Typo as 0.4.41 does not exist and 2.4.1[https://github.com/redpanda-data/helm-charts/releases/tag/operator-v2.4.1] is the correct version of the Helm chart.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
