### PR TITLE
DOC-1667 Document Shadow Link in Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1621-Document-Cloud-Feature-Shadowing-Disaster-Recovery-Enterprise'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1621-Document-Cloud-Feature-Shadowing-Disaster-Recovery-Enterprise'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -200,7 +200,7 @@
 **** xref:manage:disaster-recovery/shadowing/overview.adoc[Overview]
 **** xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing]
 **** xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing]
-**** xref:manage:disaster-recovery/shadowing/failover.adoc[Configure Failover]
+**** xref:manage:disaster-recovery/shadowing/failover.adoc[Failover]
 **** xref:manage:disaster-recovery/shadowing/failover-runbook.adoc[Failover Runbook]
 *** xref:manage:disaster-recovery/whole-cluster-restore.adoc[Whole Cluster Restore]
 *** xref:manage:disaster-recovery/topic-recovery.adoc[Topic Recovery]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -5,6 +5,7 @@
 :page-categories: Management, High Availability, Disaster Recovery, Emergency Response
 // tag::single-source[]
 
+
 ifndef::env-cloud[]
 [NOTE]
 ====
@@ -19,6 +20,10 @@ This guide provides step-by-step procedures for emergency failover when your pri
 ====
 This is an emergency procedure. For planned failover testing or day-to-day shadow link management, see xref:./failover.adoc[]. Ensure you have completed the xref:manage:disaster-recovery/shadowing/overview.adoc#disaster-readiness-checklist[disaster readiness checklist] before an emergency occurs.
 ====
+
+ifdef::env-cloud[]
+NOTE: Shadowing is supported on BYOC and Dedicated clusters running Redpanda version 25.3 and later. 
+endif::[]
 
 == Emergency failover procedure
 

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -132,9 +132,9 @@ Name: <topic-name>, State: ACTIVE
 
 The partition information shows:
 
-* **SRC_LSO**: Source partition Last Stable Offset
-* **SRC_HWM**: Source partition High Watermark  
-* **DST_HWM**: Shadow (destination) partition High Watermark
+* **SRC_LSO**: Source partition last stable offset
+* **SRC_HWM**: Source partition high watermark  
+* **DST_HWM**: Shadow (destination) partition high watermark
 * **Lag**: Message count difference between source and shadow partitions
 
 [IMPORTANT]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -3,14 +3,16 @@
 :page-aliases: deploy:redpanda/manual/resilience/shadowing-guide.adoc, deploy:redpanda/manual/disaster-recovery/shadowing/failover-runbook.adoc
 :env-linux: true
 :page-categories: Management, High Availability, Disaster Recovery, Emergency Response
+// tag::single-source[]
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 This guide provides step-by-step procedures for emergency failover when your primary Redpanda cluster becomes unavailable. Follow these procedures only during active disasters when immediate failover is required.
-
 // TODO: All command output examples in this guide need verification by running actual commands in test environment
 
 [IMPORTANT]
@@ -291,3 +293,5 @@ After successful failover, focus on recovery planning and process improvement. B
 2. **Update runbooks**: Improve procedures based on what you learned
 3. **Test regularly**: Schedule regular disaster recovery drills
 4. **Review monitoring**: Ensure monitoring caught the issue appropriately
+
+// end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -93,7 +93,7 @@ Verify that the following conditions exist before proceeding with failover:
 * Topics should be in `ACTIVE` state (not `FAULTED`).
 * Replication lag should be reasonable for your RPO requirements.
 
-**Understanding replication lag**
+==== Understanding replication lag
 
 Use xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] to check lag, which shows the message count difference between source and shadow partitions:
 
@@ -135,7 +135,7 @@ Name: <topic-name>, State: ACTIVE
  1          2345     2579     2568     11
 ----
 
-The partition information shows:
+The partition information shows the following:
 
 * **SRC_LSO**: Source partition last stable offset
 * **SRC_HWM**: Source partition high watermark  

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -88,7 +88,7 @@ Verify that the following conditions exist before proceeding with failover:
 * Topics should be in `ACTIVE` state (not `FAULTED`).
 * Replication lag should be reasonable for your RPO requirements.
 
-**Understanding replication lag:**
+**Understanding replication lag**
 
 Use xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] to check lag, which shows the message count difference between source and shadow partitions:
 

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -1,4 +1,4 @@
-= Configure Failover
+= Failover
 :description: Learn how failover can transform shadow topics into fully writable resources during disasters.
 :page-categories: Management, High Availability, Disaster Recovery
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/failover.adoc
@@ -14,11 +14,11 @@ endif::[]
 Failover is the process of modifying shadow topics or an entire shadow cluster from read-only replicas to fully writable resources, and ceasing replication from the source cluster. You can fail over individual topics for selective workload migration or fail over the entire cluster for comprehensive disaster recovery. This critical operation transforms your shadow resources into operational production assets, allowing you to redirect application traffic when the source cluster becomes unavailable.
 
 ifdef::env-cloud[]
-You can configure failover using the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
+You can failover topics using the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
 endif::[]
 
 ifndef::env-cloud[]
-You can configure failover using Redpanda Console, `rpk`, or the Admin API. 
+You can failover topics using Redpanda Console, `rpk`, or the Admin API. 
 endif::[]
 
 include::shared:partial$emergency-shadowing-callout.adoc[]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -2,14 +2,16 @@
 :description: Learn how failover can transform shadow topics into fully writable resources during disasters.
 :page-categories: Management, High Availability, Disaster Recovery
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/failover.adoc
+// tag::single-source[]
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 Failover is the process of modifying shadow topics or an entire shadow cluster from read-only replicas to fully writable resources, and ceasing replication from the source cluster. You can fail over individual topics for selective workload migration or fail over the entire cluster for comprehensive disaster recovery. This critical operation transforms your shadow resources into operational production assets, allowing you to redirect application traffic when the source cluster becomes unavailable.
-
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Failover behavior
@@ -152,3 +154,5 @@ After completing failover:
 * Consider deleting the shadow link if failover was successful and permanent
 
 For emergency situations, see xref:./failover-runbook.adoc[Failover Runbook].
+
+// end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -12,6 +12,7 @@ include::shared:partial$enterprise-license.adoc[]
 endif::[]
 
 Failover is the process of modifying shadow topics or an entire shadow cluster from read-only replicas to fully writable resources, and ceasing replication from the source cluster. You can fail over individual topics for selective workload migration or fail over the entire cluster for comprehensive disaster recovery. This critical operation transforms your shadow resources into operational production assets, allowing you to redirect application traffic when the source cluster becomes unavailable.
+
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Failover behavior

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -13,6 +13,14 @@ endif::[]
 
 Failover is the process of modifying shadow topics or an entire shadow cluster from read-only replicas to fully writable resources, and ceasing replication from the source cluster. You can fail over individual topics for selective workload migration or fail over the entire cluster for comprehensive disaster recovery. This critical operation transforms your shadow resources into operational production assets, allowing you to redirect application traffic when the source cluster becomes unavailable.
 
+ifdef::env-cloud[]
+You can configure failover using the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
+endif::[]
+
+ifndef::env-cloud[]
+You can configure failover using Redpanda Console, `rpk`, or the Admin API. 
+endif::[]
+
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
 ifdef::env-cloud[]

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -15,6 +15,10 @@ Failover is the process of modifying shadow topics or an entire shadow cluster f
 
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
+ifdef::env-cloud[]
+NOTE: Shadowing is supported on BYOC and Dedicated clusters running Redpanda version 25.3 and later. 
+endif::[]
+
 == Failover behavior
 
 When you initiate failover, Redpanda performs the following operations:

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -37,13 +37,15 @@ When you initiate failover, Redpanda performs the following operations:
 
 Topic failover is irreversible. Once failed over, topics cannot return to shadow mode, and automatic fallback to the original source cluster is not supported.
 
+NOTE: To avoid a split-brain scenario after failover, ensure that all clients are reconfigured to point to the shadow cluster before resuming write activity. 
+
 == Failover commands
 
 You can perform failover at different levels of granularity to match your disaster recovery needs:
 
 === Individual topic failover
 
-To fail over a specific shadow topic while leaving other topics in the shadow link still replicating:
+To fail over a specific shadow topic while leaving other topics in the shadow link still replicating, run:
 
 [,bash]
 ----
@@ -54,7 +56,7 @@ Use this approach when you need to selectively failover specific workloads or wh
 
 === Complete shadow link failover (cluster failover)
 
-To fail over all shadow topics associated with the shadow link simultaneously:
+To fail over all shadow topics associated with the shadow link simultaneously, run:
 
 [,bash]
 ----
@@ -82,6 +84,7 @@ Force deleting a shadow link is irreversible and immediately fails over all topi
 The shadow link itself has a simple state model:
 
 * **`ACTIVE`**: Shadow link is operating normally, replicating data
+* **`PAUSED`**: Shadow link replication is temporarily halted by user action
 
 Shadow links do not have dedicated failover states. Instead, the link's operational status is determined by the collective state of its shadow topics.
 
@@ -93,10 +96,11 @@ Individual shadow topics progress through specific states during failover:
 * **`FAULTED`**: Shadow topic has encountered an error and is not replicating
 * **`FAILING_OVER`**: Failover initiated, replication stopping
 * **`FAILED_OVER`**: Failover completed successfully, topic fully writable
+* **`PAUSED`**: Replication temporarily halted by user action
 
 == Monitor failover progress
 
-Monitor failover progress using the status command:
+To monitor failover progress using the status command, run:
 
 [,bash]
 ----
@@ -105,7 +109,7 @@ rpk shadow status <shadow-link-name>
 
 The output shows individual topic states and any issues encountered during the failover process. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`].
 
-**Task states during monitoring:**
+Task states during monitoring:
 
 * **`ACTIVE`**: Task is operating normally and replicating data
 * **`FAULTED`**: Task encountered an error and requires attention
@@ -139,6 +143,8 @@ After successful failover, your shadow cluster exhibits the following characteri
 * Audit log history from the source cluster is not available (new audit logs begin immediately).
 
 == Failover considerations and limitations
+
+Before implementing failover procedures, understand these key considerations that affect your disaster recovery strategy and operational planning.
 
 **Data consistency:**
 

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -14,11 +14,11 @@ endif::[]
 Failover is the process of modifying shadow topics or an entire shadow cluster from read-only replicas to fully writable resources, and ceasing replication from the source cluster. You can fail over individual topics for selective workload migration or fail over the entire cluster for comprehensive disaster recovery. This critical operation transforms your shadow resources into operational production assets, allowing you to redirect application traffic when the source cluster becomes unavailable.
 
 ifdef::env-cloud[]
-You can failover topics using the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
+You can failover a shadow link using the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
 endif::[]
 
 ifndef::env-cloud[]
-You can failover topics using Redpanda Console, `rpk`, or the Admin API. 
+You can failover a shadow link using Redpanda Console, `rpk`, or the Admin API. 
 endif::[]
 
 include::shared:partial$emergency-shadowing-callout.adoc[]

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -12,6 +12,7 @@ include::shared:partial$enterprise-license.adoc[]
 endif::[]
 
 Monitor your shadow links to ensure proper replication performance and understand your disaster recovery readiness. Use `rpk` commands, metrics, and status information to track shadow link health and troubleshoot issues.
+
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Status commands
@@ -52,10 +53,10 @@ For troubleshooting specific issues, you can use command options to show individ
 
 The status output includes:
 
-* **Shadow link state**: Overall operational state (`ACTIVE`)
-* **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`)
+* **Shadow link state**: Overall operational state (`ACTIVE`).
+* **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`).
 * **Task status**: Health of replication tasks across brokers (`ACTIVE`, `FAULTED`, `NOT_RUNNING`, `LINK_UNAVAILABLE`). For details about shadow link tasks, see xref:manage:disaster-recovery/shadowing/setup.adoc#shadow-link-tasks[Shadow link tasks].
-* **Lag information**: Replication lag per partition showing source vs shadow high watermarks (HWM)
+* **Lag information**: Replication lag per partition showing source vs shadow high watermarks (HWM).
 
 [[shadow-link-metrics]]
 == Metrics

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -2,14 +2,16 @@
 :description: Monitor Shadowing health with status commands, metrics, and best practices for tracking replication performance.
 :page-categories: Management, Monitoring, Disaster Recovery
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/monitor.adoc
+// tag::single-source[]
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 Monitor your shadow links to ensure proper replication performance and understand your disaster recovery readiness. Use `rpk` commands, metrics, and status information to track shadow link health and troubleshoot issues.
-
 include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Status commands
@@ -122,3 +124,5 @@ Configure monitoring alerts for:
 * **Link unavailability**: When tasks show `LINK_UNAVAILABLE` indicating source cluster connectivity issues
 +
 For more information about shadow link tasks and their states, see xref:manage:disaster-recovery/shadowing/setup.adoc#shadow-link-tasks[Shadow link tasks].
+
+// end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -33,14 +33,14 @@ rpk shadow describe <my-disaster-recovery-link>
 
 For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-list.adoc[`rpk shadow list`] and xref:reference:rpk/rpk-shadow/rpk-shadow-describe.adoc[`rpk shadow describe`]. This command shows the complete configuration of the shadow link, including connection settings, filters, and synchronization options.
 
-To check your shadow link status to ensure proper operation, run:
+To check your shadow link status and ensure proper operation, run:
 
 [,bash]
 ----
 rpk shadow status <shadow-link-name>
 ----
 
-For troubleshooting specific issues, you can use command options to show individual status sections. See xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] for available status options. The status output includes:
+For troubleshooting specific issues, you can use command options to show individual status sections. See xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] for available status options. The status output includes the following:
 
 * **Shadow link state**: Overall operational state (`ACTIVE`, `PAUSED`).
 * **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`, `PAUSED`).
@@ -104,7 +104,7 @@ rpk shadow status <shadow-link-name> | grep -E "LAG|Lag"
 
 === Alert conditions
 
-Configure monitoring alerts for following conditions, which indicate problems with Shadowing:
+Configure monitoring alerts for the following conditions, which indicate problems with Shadowing:
 
 * **High replication lag**: When `redpanda_shadow_link_shadow_lag` exceeds your RPO requirements
 * **Connection errors**: When `redpanda_shadow_link_client_errors` increases rapidly

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -17,41 +17,30 @@ include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Status commands
 
-List existing shadow links:
+To list existing shadow links, run:
 
 [,bash]
 ----
 rpk shadow list
 ----
 
-View shadow link configuration details:
+To view shadow link configuration details, run:
 
 [,bash]
 ----
 rpk shadow describe <my-disaster-recovery-link>
 ----
 
-For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-list.adoc[`rpk shadow list`] and xref:reference:rpk/rpk-shadow/rpk-shadow-describe.adoc[`rpk shadow describe`].
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-list.adoc[`rpk shadow list`] and xref:reference:rpk/rpk-shadow/rpk-shadow-describe.adoc[`rpk shadow describe`]. This command shows the complete configuration of the shadow link, including connection settings, filters, and synchronization options.
 
-This command shows the complete configuration of the shadow link, including connection settings, filters, and synchronization options.
-
-Check your shadow link status to ensure proper operation:
+To check your shadow link status to ensure proper operation, run:
 
 [,bash]
 ----
 rpk shadow status <shadow-link-name>
 ----
 
-**Status command options:**
-
-[,bash]
-----
-rpk shadow status <shadow-link-name>
-----
-
-For troubleshooting specific issues, you can use command options to show individual status sections. See xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] for available status options.
-
-The status output includes:
+For troubleshooting specific issues, you can use command options to show individual status sections. See xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] for available status options. The status output includes:
 
 * **Shadow link state**: Overall operational state (`ACTIVE`).
 * **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`).
@@ -61,7 +50,7 @@ The status output includes:
 [[shadow-link-metrics]]
 == Metrics
 
-Shadowing provides comprehensive metrics to track replication performance and health:
+Shadowing provides comprehensive metrics to track replication performance and health with the xref:reference:public-metrics-reference.adoc[`public_metrics`] endpoint.
 
 [cols="1,1,2"]
 |===
@@ -113,9 +102,9 @@ rpk shadow list | grep -v "ACTIVE" || echo "All shadow links healthy"
 rpk shadow status <shadow-link-name> | grep -E "LAG|Lag"
 ----
 
-=== Alert thresholds
+=== Alert conditions
 
-Configure monitoring alerts for:
+Configure monitoring alerts for following conditions, which indicate problems with Shadowing:
 
 * **High replication lag**: When `redpanda_shadow_link_shadow_lag` exceeds your RPO requirements
 * **Connection errors**: When `redpanda_shadow_link_client_errors` increases rapidly

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -42,8 +42,8 @@ rpk shadow status <shadow-link-name>
 
 For troubleshooting specific issues, you can use command options to show individual status sections. See xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] for available status options. The status output includes:
 
-* **Shadow link state**: Overall operational state (`ACTIVE`).
-* **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`).
+* **Shadow link state**: Overall operational state (`ACTIVE`, `PAUSED`).
+* **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`, `PAUSED`).
 * **Task status**: Health of replication tasks across brokers (`ACTIVE`, `FAULTED`, `NOT_RUNNING`, `LINK_UNAVAILABLE`). For details about shadow link tasks, see xref:manage:disaster-recovery/shadowing/setup.adoc#shadow-link-tasks[Shadow link tasks].
 * **Lag information**: Replication lag per partition showing source vs shadow high watermarks (HWM).
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -210,16 +210,6 @@ include::shared:partial$shadow-link-cloud-tip.adoc[]
 ====
 endif::[]
 
-== Disaster readiness checklist
-
-Before a disaster occurs, ensure you have:
-
-[%interactive]
-* [ ] Access to shadow cluster administrative credentials
-* [ ] Shadow link names and configuration details, and networking documented
-* [ ] Application connection strings for the shadow cluster prepared
-* [ ] Tested failover procedures in a non-production environment
-
 == Next steps
 
 After setting up Shadowing for your Redpanda clusters, consider these additional steps:

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -5,6 +5,10 @@
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/overview.adoc
 // tag::single-source[]
 
+ifdef::env-cloud[]
+NOTE: Shadowing is supported on BYOC and Dedicated clusters running Redpanda version 25.3 and later. 
+endif::[]
+
 ifndef::env-cloud[]
 [NOTE]
 ====

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -52,7 +52,7 @@ Shadowing for disaster recovery currently has the following limitations:
 * During a disaster, xref:manage:audit-logging.adoc[audit log] history from the source cluster is lost, though the shadow cluster begins generating new audit logs immediately after the failover.
 * After you failover shadow topics, automatic fallback to the original source cluster is not supported.
 
-== Best Practices
+== Best practices
 
 To ensure reliable disaster recovery with Shadowing:
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -34,10 +34,9 @@ Shadowing replicates:
 
 Shadowing addresses enterprise disaster recovery requirements driven by regulatory compliance and business continuity needs. Organizations typically want to minimize both recovery time objective (RTO) and recovery point objective (RPO), and Shadowing asynchronous replication helps you achieve both goals by reducing data loss during regional outages and enabling rapid application recovery.
 
-The architecture follows an active-passive pattern. The source cluster processes all production traffic while the shadow cluster remains in read-only mode, continuously receiving updates. If a disaster occurs, you can failover the shadow topics using the 
-ifndef::env-cloud[Admin API] 
-ifdef::env-cloud[Data Plane API] 
-or `rpk`, making them fully writable. At that point, you can redirect your applications to the shadow cluster, which becomes the new production cluster.
+The architecture follows an active-passive pattern. The source cluster processes all production traffic while the shadow cluster remains in read-only mode, continuously receiving updates. If a disaster occurs, you can failover the shadow topics, making them fully writable. At that point, you can redirect your applications to the shadow cluster, which becomes the new production cluster.
+
+NOTE: To avoid a split-brain scenario after failover, ensure that all clients are reconfigured to point to the shadow cluster before resuming write activity. 
 
 
 ifdef::env-cloud[]
@@ -138,40 +137,30 @@ Partition count is always replicated to ensure the shadow topic matches the sour
 
 The <<shadow-link-tasks,Source Topic Sync task>> handles topic property replication. For topic properties, Redpanda follows these replication rules:
 
-[cols="1,1,1"]
+**Never replicated**
 
-|===
-|Never replicated |Always replicated |Always replicated +
-(unless `exclude_default` is `true`)
+* `redpanda.remote.readreplica`
+* `redpanda.remote.recovery`
+* `redpanda.remote.allowgaps`
+* `redpanda.virtual.cluster.id`
+* `redpanda.leaders.preference`
+* `redpanda.cloud_topic.enabled`
 
-|`redpanda.remote.readreplica`
-|`max.message.bytes`
-|`compression.type`
+**Always replicated**
 
-|`redpanda.remote.recovery`
-|`cleanup.policy`
-|`retention.bytes`
+* `max.message.bytes`
+* `cleanup.policy`
+* `message.timestamp.type`
 
-|`redpanda.remote.allowgaps`
-|`message.timestamp.type`
-|`retention.ms`
+**Always replicated (unless `exclude_default` is `true`)**
 
-|`redpanda.virtual.cluster.id`
-|
-|`delete.retention.ms`
-
-|`redpanda.leaders.preference`
-|
-|`replication.factor`
-
-|`redpanda.cloud_topic.enabled`
-|
-|`min.compaction.lag.ms`
-
-|
-|
-|`max.compaction.lag.ms`
-|===
+* `compression.type`
+* `retention.bytes`
+* `retention.ms`
+* `delete.retention.ms`
+* `replication.factor`
+* `min.compaction.lag.ms`
+* `max.compaction.lag.ms`
 
 To replicate additional topic properties, explicitly list them in `synced_shadow_topic_properties`.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -52,6 +52,123 @@ Shadowing for disaster recovery currently has the following limitations:
 * During a disaster, xref:manage:audit-logging.adoc[audit log] history from the source cluster is lost, though the shadow cluster begins generating new audit logs immediately after the failover.
 * After you failover shadow topics, automatic fallback to the original source cluster is not supported.
 
+== Shadow link tasks
+
+Shadow linking operates through specialized tasks that handle different aspects of replication. Each task corresponds to a configuration section in your shadow link setup and runs continuously to maintain synchronization with the source cluster.
+
+[tabs]
+====
+Source Topic Sync::
++
+--
+[#source-topic-sync-task]
+The **Source Topic Sync task** manages topic discovery and metadata synchronization. This task periodically queries the source cluster to discover available topics, applies your configured topic filters to determine which topics should become shadow topics, and synchronizes topic properties between clusters.
+
+The task is controlled by the `topic_metadata_sync_options` configuration section, which includes:
+
+* **Auto-creation filters**: Determines which source topics automatically become shadow topics
+* **Property synchronization**: Controls which topic properties replicate from source to shadow
+* **Starting offset**: Sets where new shadow topics begin replication (earliest, latest, or timestamp-based)
+* **Sync interval**: How frequently to check for new topics and property changes
+
+When this task discovers a new topic that matches your filters, it creates the corresponding shadow topic and begins replication from your configured starting offset.
+--
+
+Consumer Group Shadowing::
++
+--
+[#consumer-group-shadowing-task]
+The **Consumer Group Shadowing task** replicates consumer group offsets and membership information from the source cluster. This ensures that consumer applications can resume processing from the correct position after failover.
+
+The task is controlled by the `consumer_offset_sync_options` configuration section, which includes:
+
+* **Group filters**: Determines which consumer groups have their offsets replicated
+* **Sync interval**: How frequently to synchronize consumer group offsets
+* **Offset clamping**: Automatically adjusts replicated offsets to valid ranges on the shadow cluster
+
+This task runs on brokers that host the `__consumer_offsets` topic and continuously tracks consumer group coordinators to optimize offset synchronization.
+--
+
+Security Migrator::
++
+--
+[#security-migrator-task]
+The **Security Migrator task** replicates security policies, primarily ACLs (access control lists), from the source cluster to maintain consistent authorization across both environments.
+
+The task is controlled by the `security_sync_options` configuration section, which includes:
+
+* **ACL filters**: Determines which security policies replicate
+* **Sync interval**: How frequently to synchronize security settings
+
+By default, all ACLs replicate to ensure your shadow cluster maintains the same security posture as your source cluster.
+--
+====
+
+=== Task status and monitoring
+
+Each task reports its status through the shadow link status API. Task states include:
+
+* **`ACTIVE`**: Task is running normally and performing synchronization
+* **`PAUSED`**: Task has been manually paused through configuration
+* **`FAULTED`**: Task encountered an error and requires attention
+* **`NOT_RUNNING`**: Task is not currently executing
+* **`LINK_UNAVAILABLE`**: Task cannot communicate with the source cluster
+
+You can pause individual tasks by setting the `paused` field to `true` in the corresponding configuration section. This allows you to selectively disable parts of the replication process without affecting the entire shadow link.
+
+For monitoring task health and troubleshooting task issues, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadow Links].
+
+== What gets replicated
+
+Shadowing replicates your topic data with complete fidelity, preserving all message records with their original offsets, timestamps, headers, and metadata. The partition structure remains identical between source and shadow clusters, ensuring applications can resume processing from the exact same position after failover.
+
+Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters. Schema Registry data synchronizes schema definitions, versions, and compatibility settings.
+
+Partition count is always replicated to ensure the shadow topic matches the source topic's partition structure.
+
+=== Topic properties replication
+
+The <<shadow-link-tasks,Source Topic Sync task>> handles topic property replication. For topic properties, Redpanda follows these replication rules:
+
+[cols="1,1,1"]
+
+|===
+|Never replicated |Always replicated |Always replicated +
+(unless `exclude_default` is `true`)
+
+|`redpanda.remote.readreplica`
+|`max.message.bytes`
+|`compression.type`
+
+|`redpanda.remote.recovery`
+|`cleanup.policy`
+|`retention.bytes`
+
+|`redpanda.remote.allowgaps`
+|`message.timestamp.type`
+|`retention.ms`
+
+|`redpanda.virtual.cluster.id`
+|
+|`delete.retention.ms`
+
+|`redpanda.leaders.preference`
+|
+|`replication.factor`
+
+|`redpanda.cloud_topic.enabled`
+|
+|`min.compaction.lag.ms`
+
+|
+|
+|`max.compaction.lag.ms`
+|===
+
+To replicate additional topic properties, explicitly list them in `synced_shadow_topic_properties`.
+
+The filtering system you configure determines the precise scope of replication across all components, allowing you to balance comprehensive disaster recovery with operational efficiency.
+
 == Best practices
 
 To ensure reliable disaster recovery with Shadowing:
@@ -66,10 +183,10 @@ endif::[]
 
 Choose your implementation approach:
 
-* **xref:./setup.adoc[Setup and Configuration]** - Initial shadow configuration, authentication, and topic selection
-* **xref:./monitor.adoc[Monitoring and Operations]** - Health checks, lag monitoring, and operational procedures
-* **xref:./failover.adoc[Planned Failover]** - Controlled disaster recovery testing and migrations
-* **xref:./failover-runbook.adoc[Failover Runbook]** - Rapid disaster response procedures
+* **xref:./setup.adoc[Setup and Configuration]**: Initial shadow configuration, authentication, and topic selection
+* **xref:./monitor.adoc[Monitoring and Operations]**: Health checks, lag monitoring, and operational procedures
+* **xref:./failover.adoc[Planned Failover]**: Controlled disaster recovery testing and migrations
+* **xref:./failover-runbook.adoc[Failover Runbook]**: Rapid disaster response procedures
 
 ifndef::env-cloud[]
 [TIP]

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -21,7 +21,7 @@ Unlike traditional replication tools that re-produce messages, Shadowing copies 
 Shadowing replicates:
 
 * **Topic data**: All records with preserved offsets and timestamps
-* **Topic configurations**: Partition counts, retention policies, and other xref:reference:properties/topic-properties.adoc[topic properties]
+* **Topic configurations**: Partition counts, retention policies, and other topic properties
 * **Consumer group offsets**: Enables seamless consumer resumption after failover
 * **Access control lists (ACLs)**: User permissions and security policies
 * **Schema Registry data**: Schema definitions and compatibility settings
@@ -56,7 +56,9 @@ Shadowing for disaster recovery currently has the following limitations:
 
 To ensure reliable disaster recovery with Shadowing:
 
+ifndef::env-cloud[]
 * **Avoid write caching on source topics**: Do not shadow source topics that have xref:develop:config-topics.adoc#configure-write-caching[write caching] enabled. Write caching can result in data loss on the source cluster during broker resets, causing cluster divergence if shadow links replicate data before it's lost on the source.
+endif::[]
 
 * **Do not modify shadow topic properties**: Avoid modifying synced topic properties on shadow topics, as these properties automatically revert to source topic values.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -34,7 +34,11 @@ Shadowing replicates:
 
 Shadowing addresses enterprise disaster recovery requirements driven by regulatory compliance and business continuity needs. Organizations typically want to minimize both recovery time objective (RTO) and recovery point objective (RPO), and Shadowing asynchronous replication helps you achieve both goals by reducing data loss during regional outages and enabling rapid application recovery.
 
-The architecture follows an active-passive pattern. The source cluster processes all production traffic while the shadow cluster remains in read-only mode, continuously receiving updates. If a disaster occurs, you can failover the shadow topics using the Admin API or `rpk`, making them fully writable. At that point, you can redirect your applications to the shadow cluster, which becomes the new production cluster.
+The architecture follows an active-passive pattern. The source cluster processes all production traffic while the shadow cluster remains in read-only mode, continuously receiving updates. If a disaster occurs, you can failover the shadow topics using the 
+ifndef::env-cloud[Admin API] 
+ifdef::env-cloud[Data Plane API] 
+or `rpk`, making them fully writable. At that point, you can redirect your applications to the shadow cluster, which becomes the new production cluster.
+
 
 ifdef::env-cloud[]
 Shadowing complements Redpanda's existing availability and recovery capabilities. High availability actively protects your day-to-day operations, handling reads and writes seamlessly during node or availability zone failures within a region. Shadowing is your safety net for catastrophic regional disasters. Shadowing delivers near real-time, cross-region replication for mission-critical applications that require rapid failover with minimal data loss.
@@ -120,7 +124,7 @@ Each task reports its status through the shadow link status API. Task states inc
 
 You can pause individual tasks by setting the `paused` field to `true` in the corresponding configuration section. This allows you to selectively disable parts of the replication process without affecting the entire shadow link.
 
-For monitoring task health and troubleshooting task issues, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadow Links].
+For monitoring task health and troubleshooting task issues, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing].
 
 == What gets replicated
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -3,11 +3,14 @@
 :env-linux: true
 :page-categories: Management, High Availability, Disaster Recovery
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/overview.adoc
+// tag::single-source[]
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 Shadowing is Redpanda's enterprise-grade disaster recovery solution that establishes asynchronous, offset-preserving replication between two distinct Redpanda clusters. A cluster is able to create a dedicated client that continuously replicates source cluster data, including offsets, timestamps, and cluster metadata. This creates a read-only shadow cluster that you can quickly failover to handle production traffic during a disaster.
 
@@ -29,7 +32,13 @@ Shadowing addresses enterprise disaster recovery requirements driven by regulato
 
 The architecture follows an active-passive pattern. The source cluster processes all production traffic while the shadow cluster remains in read-only mode, continuously receiving updates. If a disaster occurs, you can failover the shadow topics using the Admin API or `rpk`, making them fully writable. At that point, you can redirect your applications to the shadow cluster, which becomes the new production cluster.
 
+ifdef::env-cloud[]
+Shadowing complements Redpanda's existing availability and recovery capabilities. High availability actively protects your day-to-day operations, handling reads and writes seamlessly during node or availability zone failures within a region. Shadowing is your safety net for catastrophic regional disasters. Shadowing delivers near real-time, cross-region replication for mission-critical applications that require rapid failover with minimal data loss.
+endif::[]
+
+ifndef::env-cloud[]
 Shadowing complements Redpanda's existing availability and recovery capabilities. xref:deploy:redpanda/manual/high-availability.adoc[High availability] actively protects your day-to-day operations, handling reads and writes seamlessly during node or availability zone failures within a region. Shadowing is your safety net for catastrophic regional disasters. While xref:deploy:redpanda/manual/disaster-recovery/whole-cluster-restore.adoc[Whole Cluster Restore] provides point-in-time recovery from xref:manage:tiered-storage.adoc[Tiered Storage], Shadowing delivers near real-time, cross-region replication for mission-critical applications that require rapid failover with minimal data loss.
+endif::[]
 
 // TODO: insert diagram. Possibly with a .gif animation showing cluster Cluster A being written and cluster B being replicated with a data flow arrow and geo-separation. Diagram must show Icons or labels for topics, configurations, offsets, ACLs, schemas that are being copied
 
@@ -60,10 +69,19 @@ Choose your implementation approach:
 * **xref:./failover.adoc[Planned Failover]** - Controlled disaster recovery testing and migrations
 * **xref:./failover-runbook.adoc[Failover Runbook]** - Rapid disaster response procedures
 
+ifndef::env-cloud[]
 [TIP]
 ====
 include::shared:partial$shadow-link-management-tip.adoc[]
 ====
+endif::[]
+
+ifdef::env-cloud[]
+[TIP]
+====
+include::shared:partial$shadow-link-cloud-tip.adoc[]
+====
+endif::[]
 
 == Disaster readiness checklist
 
@@ -88,3 +106,5 @@ After setting up Shadowing for your Redpanda clusters, consider these additional
 * **Review security policies**: Ensure your ACL filters replicate the appropriate security settings for your disaster recovery environment.
 
 * **Document your configuration**: Maintain up-to-date documentation of your shadow link configuration, including network settings, authentication details, and filter definitions.
+
+// end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -13,6 +13,11 @@ ifdef::env-cloud[]
 include::shared:partial$shadow-link-cloud-tip.adoc[]
 endif::[]
 
+[TIP]
+====
+Deploy clusters in different geographic regions to protect against regional disasters.
+====
+
 == Prerequisites
 
 ifndef::env-cloud[]
@@ -24,17 +29,16 @@ endif::[]
 
 === License and cluster requirements
 
-- Both clusters must be running Redpanda v25.3 or later. 
+ifdef::env-cloud[]
+Shadowing is supported on BYOC and Dedicated clusters running Redpanda version 25.3 and later. 
+endif::[]
+
 ifndef::env-cloud[]
+- Both clusters must be running Redpanda v25.3 or later. 
 - If you use Redpanda Console, ensure that it is running v3.30 or later.
 
 - You must have xref:get-started:licensing/overview.adoc[Enterprise Edition] licenses on both clusters. 
 endif::[]
-
-[TIP]
-====
-Deploy clusters in different geographic regions to protect against regional disasters.
-====
 
 === Cluster properties
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -200,7 +200,7 @@ security_sync_options:
   acl_filters:                        # Filters for ACLs to sync
   - resource_filter:
       resource_type: TOPIC            # Resource type: "TOPIC", "GROUP", "CLUSTER"
-      pattern_type: PREFIXED          # Pattern type: "LITERAL", "PREFIX", "PREFIXED"
+      pattern_type: PREFIXED          # Pattern type: "LITERAL", "PREFIXED"
       name: <resource-pattern>        # Examples: "prod-", "app-data-"
     access_filter:
       principal: User:<username>      # Principal name, example: "User:app-service"

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -3,23 +3,33 @@
 :env-linux: true
 :page-categories: Management, High Availability, Disaster Recovery
 :page-aliases: deploy:redpanda/manual/disaster-recovery/shadowing/setup.adoc
+// tag::single-source[]
 
+ifndef::env-cloud[]
 include::shared:partial$shadow-link-management-tip.adoc[]
+endif::[]
+
+ifndef::env-cloud[]
+include::shared:partial$shadow-link-cloud-tip.adoc[]
+endif::[]
 
 == Prerequisites
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 include::shared:partial$enterprise-license.adoc[]
 ====
+endif::[]
 
 === License and cluster requirements
 
 - Both clusters must be running Redpanda v25.3 or later. 
-
+ifndef::env-cloud[]
 - If you use Redpanda Console, ensure that it is running v3.30 or later.
 
 - You must have xref:get-started:licensing/overview.adoc[Enterprise Edition] licenses on both clusters. 
+endif::[]
 
 [TIP]
 ====
@@ -41,11 +51,17 @@ rpk cluster config set enable_shadow_linking true
 This cluster property must be configured using `rpk` or the Admin API v1 before you can create shadow links through any interface.
 ====
 
+ifdef::env-cloud[]
+To learn more about configuring cluster properties, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+endif::[]
+
+ifndef::env-cloud[]
 To learn more about configuring cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[].
 
 === Administrative access
 
 Superuser access is required on both clusters through xref:get-started:rpk/index.adoc[`rpk`], the Admin API, or xref:console:index.adoc[Redpanda Console] to create and manage shadow links.
+endif::[]
 
 === Replication service permissions
 
@@ -63,7 +79,13 @@ This service account authenticates from the shadow cluster to the source cluster
 
 You must configure network connectivity between clusters with appropriate firewall rules to allow the shadow cluster to connect to the source cluster for data replication. Shadowing uses a pull-based architecture where the shadow cluster fetches data from the source cluster. For detailed networking configuration, see <<networking>>.
 
+ifndef::env-cloud[]
 If using xref:manage:security/authentication.adoc[authentication] for the shadow link connection, configure the source cluster with your chosen authentication method (SASL/SCRAM, TLS, mTLS) and ensure the shadow cluster has the proper credentials to authenticate to the source cluster.
+endif::[]
+
+ifdef::env-cloud[]
+If using xref:security:cloud-authentication.adoc[authentication] for the shadow link connection, configure the source cluster with your chosen authentication method (SASL/SCRAM, TLS, mTLS) and ensure the shadow cluster has the proper credentials to authenticate to the source cluster.
+endif::[]
 
 == Set up Shadowing
 
@@ -587,5 +609,7 @@ schema_registry_sync_options:         # Schema Registry synchronization options
   shadow_schema_registry_topic: {}    # Enable byte-for-byte _schemas topic replication
 ----
 ====
+
+// end::single-source[]
 
 See also: link:/api/doc/admin/[Admin API v2 reference^]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -114,16 +114,7 @@ endif::[]
 
 == Create a shadow link
 
-To create a shadow link with the source cluster using `rpk`, run the following command from the shadow cluster:
-
-[,bash]
-----
-rpk shadow create --config-file shadow-config.yaml
-----
-
-For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
-
-==== Sample configuration file
+Any cluster can create a shadow link to a source cluster. When you create a shadow link with `rpk` or the API, you provide a YAML configuration file that defines connection settings, filters, and synchronization options.
 
 .Explore the configuration file
 [%collapsible]
@@ -205,6 +196,15 @@ schema_registry_sync_options:         # Schema Registry synchronization options
   shadow_schema_registry_topic: {}    # Enable byte-for-byte _schemas topic replication
 ----
 ====
+
+To create a shadow link with the source cluster using `rpk`, run the following command from the shadow cluster:
+
+[,bash]
+----
+rpk shadow create --config-file shadow-config.yaml
+----
+
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
 
 == Set filters
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -40,6 +40,14 @@ Deploy clusters in different geographic regions to protect against regional disa
 
 Both source and shadow clusters must have the xref:reference:properties/cluster-properties.adoc#enable_shadow_linking[`enable_shadow_linking`] cluster property set to `true`. 
 
+ifdef::env-cloud[]
+[NOTE]
+====
+Starting with Redpanda v25.3, this cluster property is enabled by default on new Redpanda Cloud clusters. Existing clusters created before v25.3 must enable this property manually. See xref:manage:cluster-maintenance/config-cluster.adoc[].
+====
+endif::[]
+
+ifndef::env-cloud[]
 To enable this property, run: 
 [,bash]
 ----
@@ -51,11 +59,6 @@ rpk cluster config set enable_shadow_linking true
 This cluster property must be configured using `rpk` or the Admin API v1 before you can create shadow links through any interface.
 ====
 
-ifdef::env-cloud[]
-To learn more about configuring cluster properties, see xref:manage:cluster-maintenance/config-cluster.adoc[].
-endif::[]
-
-ifndef::env-cloud[]
 To learn more about configuring cluster properties, see xref:manage:cluster-maintenance/cluster-property-configuration.adoc[].
 
 === Administrative access
@@ -114,7 +117,7 @@ This creates a complete YAML configuration file that you can customize for your 
 To set up Shadowing:
 
 * **Configure filters**: Define which topics, consumer groups, and ACLs should replicate by creating include/exclude patterns that match your disaster recovery requirements. See <<set-filters>>.
-* **Create a shadow link**: Establish the connection between clusters using `rpk`, the Admin API, or Redpanda Console with authentication and network settings. See <<create-a-shadow-link>>.
+* **Create a shadow link**: Establish the connection between clusters using `rpk`, the API, or Redpanda Console with authentication and network settings. See <<create-a-shadow-link>>.
 
 == Shadow link tasks
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -118,7 +118,7 @@ Any cluster can create a shadow link to a source cluster. When you create a shad
 
 [TIP]
 ====
-You can use `rpk` to generate a configuration template:
+You can use `rpk` to generate a sample configuration file with common filter patterns:
 
 [,bash]
 ----
@@ -129,7 +129,7 @@ rpk shadow config generate -o shadow-config.yaml
 rpk shadow config generate --print-template -o shadow-config-template.yaml
 ----
 
-This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose.
+This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-config-generate.adoc[`rpk shadow config generate`].
 ====
 
 .Explore the configuration file
@@ -412,17 +412,6 @@ topic_metadata_sync_options:
 ====
 The starting offset only affects **new shadow topics**. After a shadow topic exists and has data, changing this setting has no effect on that topic's replication.
 ====
-
-=== Generate a sample configuration
-
-Use `rpk` to generate a sample configuration file with common filter patterns:
-
-[,bash]
-----
-rpk shadow config generate -o shadow-config.yaml
-----
-
-This creates a template configuration file that you can customize for your environment. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-config-generate.adoc[`rpk shadow config generate`].
 
 === Networking
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -114,7 +114,23 @@ endif::[]
 
 == Create a shadow link
 
-Any cluster can create a shadow link to a source cluster. When you create a shadow link with `rpk` or the API, you provide a YAML configuration file that defines connection settings, filters, and synchronization options.
+Any cluster can create a shadow link to a source cluster. When you create a shadow link with `rpk` or the API, you need to provide a YAML configuration file that defines connection settings, filters, and synchronization options.
+
+[TIP]
+====
+You can use `rpk` to generate a configuration template:
+
+[,bash]
+----
+# Generate a sample configuration file with placeholder values
+rpk shadow config generate -o shadow-config.yaml
+
+# Or generate a template with detailed field documentation
+rpk shadow config generate --print-template -o shadow-config-template.yaml
+----
+
+This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose.
+====
 
 .Explore the configuration file
 [%collapsible]
@@ -213,22 +229,6 @@ Filters determine which resources Shadowing automatically creates when establish
 Topic filters select which topics Shadowing automatically creates as shadow topics when they appear on the source cluster. After Shadowing creates a shadow topic, it continues replicating until you failover the topic, delete it, or delete the entire shadow link.
 
 Consumer group and ACL filters control which groups and security policies replicate to maintain application functionality.
-
-[TIP]
-====
-You can use `rpk` to generate a configuration template:
-
-[,bash]
-----
-# Generate a sample configuration file with placeholder values
-rpk shadow config generate -o shadow-config.yaml
-
-# Or generate a template with detailed field documentation
-rpk shadow config generate --print-template -o shadow-config-template.yaml
-----
-
-This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose.
-====
 
 === Filter types and patterns
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -98,6 +98,118 @@ endif::[]
 
 == Set up Shadowing
 
+To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, and ACLs to replicate. 
+
+ifdef::env-cloud[]
+You can use the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
+endif::[]
+
+ifndef::env-cloud[]
+You can use Redpanda Console, `rpk`, or the Admin API. 
+endif::[]
+
+== Create a shadow link
+
+To create a shadow link with the source cluster using `rpk`, run the following command from the shadow cluster:
+
+[,bash]
+----
+rpk shadow create --config-file shadow-config.yaml
+----
+
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
+
+==== Sample configuration file
+
+.Explore the configuration file
+[%collapsible]
+====
+[,yaml]
+----
+# Sample ShadowLinkConfig YAML with all fields
+name: <shadow-link-name>              # Unique name for this shadow link, example: "production-dr"
+client_options:
+  bootstrap_servers:                  # Source cluster brokers to connect to
+  - <source-broker-1>:<port>          # Example: "prod-kafka-1.example.com:9092"
+  - <source-broker-2>:<port>          # Example: "prod-kafka-2.example.com:9092"
+  - <source-broker-3>:<port>          # Example: "prod-kafka-3.example.com:9092"
+  source_cluster_id: <cluster-id>     # Optional: Expected source cluster ID for validation, example: "prod-cluster-123"
+  
+  # TLS settings using file paths
+  tls_settings:
+    enabled: true                     # Enable TLS
+    tls_file_settings:
+      ca_path: <ca-cert-path>         # Path to CA certificate, example: "/etc/ssl/certs/ca.crt"
+      key_path: <client-key-path>     # Optional: Path to client private key, example: "/etc/ssl/private/client.key"
+      cert_path: <client-cert-path>   # Optional: Path to client certificate, example: "/etc/ssl/certs/client.crt"
+    do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
+  
+  authentication_configuration:
+    scram_configuration:
+      username: <sasl-username>       # SASL/SCRAM username, example: "shadow-replication-user"
+      password: <sasl-password>       # SASL/SCRAM password, example: "secure-password-123"
+      scram_mechanism: SCRAM_SHA_256  # SCRAM mechanism: "SCRAM_SHA_256" or "SCRAM_SHA_512"
+  
+  # Connection tuning - adjust based on network characteristics
+  metadata_max_age_ms: 10000          # How often to refresh cluster metadata (default: 10000ms)
+  connection_timeout_ms: 1000         # Connection timeout (default: 1000ms, increase for high latency)
+  retry_backoff_ms: 100               # Backoff between retries (default: 100ms)
+  fetch_wait_max_ms: 500              # Max time to wait for fetch requests (default: 500ms)
+  fetch_min_bytes: 5242880            # Min bytes per fetch (default: 5MB)
+  fetch_max_bytes: 20971520           # Max bytes per fetch (default: 20MB)
+  fetch_partition_max_bytes: 1048576  # Max bytes per partition fetch (default: 1MB)
+
+topic_metadata_sync_options:
+  interval: 30s                       # How often to sync topic metadata (examples: "30s", "1m", "5m")
+  auto_create_shadow_topic_filters:   # Filters for automatic topic creation
+  - pattern_type: LITERAL             # Include all topics (wildcard)
+    filter_type: INCLUDE
+    name: '*'
+  - pattern_type: PREFIX              # Exclude topics with specific prefix
+    filter_type: EXCLUDE
+    name: <topic-prefix-to-exclude>   # Examples: "temp-", "test-", "debug-"
+  synced_shadow_topic_properties:     # Additional topic properties to sync (beyond defaults)
+  - retention.ms                      # Topic retention time
+  - segment.ms                        # Segment roll time
+  exclude_default: false              # Include default properties (compression, retention, etc.)
+  start_at_earliest: {}               # Start from the beginning of source topics (default)
+  paused: false                       # Enable topic metadata synchronization
+
+consumer_offset_sync_options:
+  interval: 30s                       # How often to sync consumer group offsets
+  paused: false                       # Enable consumer offset synchronization
+  group_filters:                      # Filters for consumer groups to sync
+  - pattern_type: LITERAL
+    filter_type: INCLUDE
+    name: '*'                         # Include all consumer groups
+
+security_sync_options:
+  interval: 30s                       # How often to sync security settings
+  paused: false                       # Enable security settings synchronization
+  acl_filters:                        # Filters for ACLs to sync
+  - resource_filter:
+      resource_type: TOPIC            # Resource type: "TOPIC", "GROUP", "CLUSTER"
+      pattern_type: PREFIXED          # Pattern type: "LITERAL", "PREFIX", "PREFIXED"
+      name: <resource-pattern>        # Examples: "prod-", "app-data-"
+    access_filter:
+      principal: User:<username>      # Principal name, example: "User:app-service"
+      operation: ANY                  # Operation: "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE", "ANY"
+      permission_type: ALLOW          # Permission: "ALLOW" or "DENY"
+      host: '*'                       # Host pattern, examples: "*", "10.0.0.0/8", "app-server.example.com"
+
+schema_registry_sync_options:         # Schema Registry synchronization options
+  shadow_schema_registry_topic: {}    # Enable byte-for-byte _schemas topic replication
+----
+====
+
+== Set filters
+
+Filters determine which resources Shadowing automatically creates when establishing your shadow link.
+
+Topic filters select which topics Shadowing automatically creates as shadow topics when they appear on the source cluster. After Shadowing creates a shadow topic, it continues replicating until you failover the topic, delete it, or delete the entire shadow link.
+
+Consumer group and ACL filters control which groups and security policies replicate to maintain application functionality.
+
 [TIP]
 ====
 You can use `rpk` to generate a configuration template:
@@ -114,19 +226,6 @@ rpk shadow config generate --print-template -o shadow-config-template.yaml
 This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose.
 ====
 
-To set up Shadowing:
-
-* **Configure filters**: Define which topics, consumer groups, and ACLs should replicate by creating include/exclude patterns that match your disaster recovery requirements. See <<set-filters>>.
-* **Create a shadow link**: Establish the connection between clusters using `rpk`, the API, or Redpanda Console with authentication and network settings. See <<create-a-shadow-link>>.
-
-== Set filters
-
-Filters determine which resources Shadowing automatically creates when establishing your shadow link.
-
-Topic filters select which topics Shadowing automatically creates as shadow topics when they appear on the source cluster. After Shadowing creates a shadow topic, it continues replicating until you failover the topic, delete it, or delete the entire shadow link.
-
-Consumer group and ACL filters control which groups and security policies replicate to maintain application functionality.
-
 === Filter types and patterns
 
 Each filter uses two key settings:
@@ -142,9 +241,9 @@ Each filter uses two key settings:
 
 Redpanda processes filters in the order you define them with EXCLUDE filters taking precedence. Design your filter lists carefully:
 
-1. **Exclude filters win**: If any EXCLUDE filter matches a resource, it is excluded regardless of INCLUDE filters
-2. **Order matters for INCLUDE filters**: Among INCLUDE filters, the first match determines the result
-3. **Default behavior**: Items that don't match any filter are excluded from replication
+1. **Exclude filters win**: If any EXCLUDE filter matches a resource, it is excluded regardless of INCLUDE filters.
+2. **Order matters for INCLUDE filters**: Among INCLUDE filters, the first match determines the result.
+3. **Default behavior**: Items that don't match any filter are excluded from replication.
 
 === Common filtering patterns
 
@@ -219,7 +318,7 @@ Redpanda system topics have the following specific filtering restrictions:
 
 === ACL filtering
 
-ACLs are replicated by the <<security-migrator-task,Security Migrator task>>. This is recommended to ensure that your shadow cluster has the same permissions as your source cluster. To configure ACL filters:
+ACLs are replicated by the xref:manage:disaster-recovery/shadowing/overview.adoc#shadow-link-tasks[Security Migrator task]. This is recommended to ensure that your shadow cluster has the same permissions as your source cluster. To configure ACL filters:
 
 [,yaml]
 ----
@@ -249,7 +348,7 @@ security_sync_options:
 
 === Consumer group filtering and behavior
 
-Consumer group filters determine which consumer groups have their offsets replicated to the shadow cluster by the <<consumer-group-shadowing-task,Consumer Group Shadowing task>>. 
+Consumer group filters determine which consumer groups have their offsets replicated to the shadow cluster by the xref:manage:disaster-recovery/shadowing/overview.adoc#shadow-link-tasks[Consumer Group Shadowing task]. 
 
 Offset replication operates selectively within each consumer group. Only committed offsets for active shadow topics are synchronized, even if the consumer group has offsets for additional topics that aren't being shadowed. For example, if consumer group "app-consumers" has committed offsets for "orders", "payments", and "inventory" topics, but only "orders" is an active shadow topic, then only the "orders" offsets will be replicated to the shadow cluster.
 
@@ -267,7 +366,7 @@ consumer_offset_sync_options:
     name: test-consumer-group         # Exclude specific test groups
 ----
 
-**Important consumer group considerations:**
+**Important consumer group considerations**
 
 **Avoid name conflicts:** If you plan to consume data from the shadow cluster, do not use the same consumer group names as those used on the source cluster. While this won't break shadow linking, it can impact your RPO/RTO because conflicting group names may interfere with offset replication and consumer resumption during disaster recovery.
 
@@ -275,7 +374,7 @@ consumer_offset_sync_options:
 
 === Starting offset for new shadow topics
 
-When the <<source-topic-sync-task,Source Topic Sync task>> creates a shadow topic for the first time, you can control where replication begins on the source topic. This setting only applies to empty shadow partitions and is crucial for disaster recovery planning. Changing this configuration only affects new shadow topics, existing shadow topics continue replicating from their current position.
+When the xref:manage:disaster-recovery/shadowing/overview.adoc#shadow-link-tasks[Source Topic Sync task] creates a shadow topic for the first time, you can control where replication begins on the source topic. This setting only applies to empty shadow partitions and is crucial for disaster recovery planning. Changing this configuration only affects new shadow topics, existing shadow topics continue replicating from their current position.
 
 [,yaml]
 ----
@@ -409,24 +508,6 @@ client_options:
   fetch_partition_max_bytes: 1048576  # Default 1MB, maximum bytes to fetch per partition
 ----
 
-== Create a shadow link
-
-ifdef::env-cloud[]
-You can establish a shadow link using either `rpk`, the Data Plane API, or the Redpanda Cloud UI. 
-
-To create a shadow link with the source cluster using `rpk`, run the following command from the shadow cluster:
-endif::[]
-
-ifndef::env-cloud[]
-You can establish a shadow link using either xref:get-started:rpk/index.adoc[`rpk`], the Admin API, or xref:console:index.adoc[Redpanda Console]. For example, to create a shadow link with the source cluster, run the following `rpk` command from the shadow cluster:
-endif::[]
-
-[,bash]
-----
-rpk shadow create --config-file shadow-config.yaml
-----
-
-For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
 
 == Update an existing shadow link
 
@@ -443,90 +524,7 @@ This opens your default editor to modify the shadow link configuration. Only cha
 
 [TIP]
 ====
-Use xref:get-started:config-rpk-profile.adoc[`rpk profile`] to save your cluster connection details and credentials for both source and shadow clusters, allowing you to easily switch between the two configurations.
-====
-
-==== Sample configuration file
-
-.Explore the configuration file
-[%collapsible]
-====
-[,yaml]
-----
-# Sample ShadowLinkConfig YAML with all fields
-name: <shadow-link-name>              # Unique name for this shadow link, example: "production-dr"
-client_options:
-  bootstrap_servers:                  # Source cluster brokers to connect to
-  - <source-broker-1>:<port>          # Example: "prod-kafka-1.example.com:9092"
-  - <source-broker-2>:<port>          # Example: "prod-kafka-2.example.com:9092"
-  - <source-broker-3>:<port>          # Example: "prod-kafka-3.example.com:9092"
-  source_cluster_id: <cluster-id>     # Optional: Expected source cluster ID for validation, example: "prod-cluster-123"
-  
-  # TLS settings using file paths
-  tls_settings:
-    enabled: true                     # Enable TLS
-    tls_file_settings:
-      ca_path: <ca-cert-path>         # Path to CA certificate, example: "/etc/ssl/certs/ca.crt"
-      key_path: <client-key-path>     # Optional: Path to client private key, example: "/etc/ssl/private/client.key"
-      cert_path: <client-cert-path>   # Optional: Path to client certificate, example: "/etc/ssl/certs/client.crt"
-    do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
-  
-  authentication_configuration:
-    scram_configuration:
-      username: <sasl-username>       # SASL/SCRAM username, example: "shadow-replication-user"
-      password: <sasl-password>       # SASL/SCRAM password, example: "secure-password-123"
-      scram_mechanism: SCRAM_SHA_256  # SCRAM mechanism: "SCRAM_SHA_256" or "SCRAM_SHA_512"
-  
-  # Connection tuning - adjust based on network characteristics
-  metadata_max_age_ms: 10000          # How often to refresh cluster metadata (default: 10000ms)
-  connection_timeout_ms: 1000         # Connection timeout (default: 1000ms, increase for high latency)
-  retry_backoff_ms: 100               # Backoff between retries (default: 100ms)
-  fetch_wait_max_ms: 500              # Max time to wait for fetch requests (default: 500ms)
-  fetch_min_bytes: 5242880            # Min bytes per fetch (default: 5MB)
-  fetch_max_bytes: 20971520           # Max bytes per fetch (default: 20MB)
-  fetch_partition_max_bytes: 1048576  # Max bytes per partition fetch (default: 1MB)
-
-topic_metadata_sync_options:
-  interval: 30s                       # How often to sync topic metadata (examples: "30s", "1m", "5m")
-  auto_create_shadow_topic_filters:   # Filters for automatic topic creation
-  - pattern_type: LITERAL             # Include all topics (wildcard)
-    filter_type: INCLUDE
-    name: '*'
-  - pattern_type: PREFIX              # Exclude topics with specific prefix
-    filter_type: EXCLUDE
-    name: <topic-prefix-to-exclude>   # Examples: "temp-", "test-", "debug-"
-  synced_shadow_topic_properties:     # Additional topic properties to sync (beyond defaults)
-  - retention.ms                      # Topic retention time
-  - segment.ms                        # Segment roll time
-  exclude_default: false              # Include default properties (compression, retention, etc.)
-  start_at_earliest: {}               # Start from the beginning of source topics (default)
-  paused: false                       # Enable topic metadata synchronization
-
-consumer_offset_sync_options:
-  interval: 30s                       # How often to sync consumer group offsets
-  paused: false                       # Enable consumer offset synchronization
-  group_filters:                      # Filters for consumer groups to sync
-  - pattern_type: LITERAL
-    filter_type: INCLUDE
-    name: '*'                         # Include all consumer groups
-
-security_sync_options:
-  interval: 30s                       # How often to sync security settings
-  paused: false                       # Enable security settings synchronization
-  acl_filters:                        # Filters for ACLs to sync
-  - resource_filter:
-      resource_type: TOPIC            # Resource type: "TOPIC", "GROUP", "CLUSTER"
-      pattern_type: PREFIXED          # Pattern type: "LITERAL", "PREFIX", "PREFIXED"
-      name: <resource-pattern>        # Examples: "prod-", "app-data-"
-    access_filter:
-      principal: User:<username>      # Principal name, example: "User:app-service"
-      operation: ANY                  # Operation: "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE", "ANY"
-      permission_type: ALLOW          # Permission: "ALLOW" or "DENY"
-      host: '*'                       # Host pattern, examples: "*", "10.0.0.0/8", "app-server.example.com"
-
-schema_registry_sync_options:         # Schema Registry synchronization options
-  shadow_schema_registry_topic: {}    # Enable byte-for-byte _schemas topic replication
-----
+Use xref:get-started:config-rpk-profile.adoc[`rpk profile`] to save your cluster connection details and credentials for both source and shadow clusters. This allows you to easily switch between the two configurations.
 ====
 
 // end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -504,7 +504,7 @@ client_options:
   fetch_partition_max_bytes: 1048576  # Default 1MB, maximum bytes to fetch per partition
 ----
 
-=== Create a shadow link
+== Create a shadow link
 
 ifdef::env-cloud[]
 You can establish a shadow link using either `rpk`, the Data Plane API, or the Redpanda Cloud UI. For example, to create a shadow link with the source cluster, run the following `rpk` command from the shadow cluster:
@@ -521,7 +521,7 @@ rpk shadow create --config-file shadow-config.yaml
 
 For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
 
-=== Update an existing shadow link
+== Update an existing shadow link
 
 If you need to modify a shadow link configuration after creation, use the update command:
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -402,11 +402,11 @@ topic_metadata_sync_options:
 
 **Starting offset options:**
 
-* **`earliest`** (default): Replicates all existing data from the source topic. Use this for complete disaster recovery where you need full data history.
+* **`earliest`** (default): This replicates all existing data from the source topic. Use this for complete disaster recovery where you need full data history.
 
-* **`latest`**: Starts replication from the current end of the source topic, skipping existing data. Use this when you only need new data for disaster recovery and want to minimize initial replication time.
+* **`latest`**: This starts replication from the current end of the source topic, skipping existing data. Use this when you only need new data for disaster recovery and want to minimize initial replication time.
 
-* **`timestamp`**: Starts replication from the first record with a timestamp at or after the specified time. Use this for point-in-time disaster recovery scenarios.
+* **`timestamp`**: This starts replication from the first record with a timestamp at or after the specified time. Use this for point-in-time disaster recovery scenarios.
 
 [IMPORTANT]
 ====

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -119,104 +119,6 @@ To set up Shadowing:
 * **Configure filters**: Define which topics, consumer groups, and ACLs should replicate by creating include/exclude patterns that match your disaster recovery requirements. See <<set-filters>>.
 * **Create a shadow link**: Establish the connection between clusters using `rpk`, the API, or Redpanda Console with authentication and network settings. See <<create-a-shadow-link>>.
 
-== Shadow link tasks
-
-Shadow linking operates through specialized tasks that handle different aspects of replication. Each task corresponds to a configuration section in your shadow link setup and runs continuously to maintain synchronization with the source cluster.
-
-[#source-topic-sync-task]
-=== Source Topic Sync task
-
-The **Source Topic Sync task** manages topic discovery and metadata synchronization. This task periodically queries the source cluster to discover available topics, applies your configured topic filters to determine which topics should become shadow topics, and synchronizes topic properties between clusters.
-
-The task is controlled by the `topic_metadata_sync_options` configuration section, which includes:
-
-* **Auto-creation filters**: Determines which source topics automatically become shadow topics
-* **Property synchronization**: Controls which topic properties replicate from source to shadow
-* **Starting offset**: Sets where new shadow topics begin replication (earliest, latest, or timestamp-based)
-* **Sync interval**: How frequently to check for new topics and property changes
-
-When this task discovers a new topic that matches your filters, it creates the corresponding shadow topic and begins replication from your configured starting offset.
-
-[#consumer-group-shadowing-task]
-=== Consumer Group Shadowing task
-
-The **Consumer Group Shadowing task** replicates consumer group offsets and membership information from the source cluster. This ensures that consumer applications can resume processing from the correct position after failover.
-
-The task is controlled by the `consumer_offset_sync_options` configuration section, which includes:
-
-* **Group filters**: Determines which consumer groups have their offsets replicated
-* **Sync interval**: How frequently to synchronize consumer group offsets
-* **Offset clamping**: Automatically adjusts replicated offsets to valid ranges on the shadow cluster
-
-This task runs on brokers that host the `__consumer_offsets` topic and continuously tracks consumer group coordinators to optimize offset synchronization.
-
-[#security-migrator-task]
-=== Security Migrator task
-
-The **Security Migrator task** replicates security policies, primarily ACLs (access control lists), from the source cluster to maintain consistent authorization across both environments.
-
-The task is controlled by the `security_sync_options` configuration section, which includes:
-
-* **ACL filters**: Determines which security policies replicate
-* **Sync interval**: How frequently to synchronize security settings
-
-By default, all ACLs replicate to ensure your shadow cluster maintains the same security posture as your source cluster.
-
-=== Task status and monitoring
-
-Each task reports its status through the shadow link status API. Task states include:
-
-* **`ACTIVE`**: Task is running normally and performing synchronization
-* **`PAUSED`**: Task has been manually paused through configuration
-* **`FAULTED`**: Task encountered an error and requires attention
-* **`NOT_RUNNING`**: Task is not currently executing
-* **`LINK_UNAVAILABLE`**: Task cannot communicate with the source cluster
-
-You can pause individual tasks by setting the `paused` field to `true` in the corresponding configuration section. This allows you to selectively disable parts of the replication process without affecting the entire shadow link.
-
-For monitoring task health and troubleshooting task issues, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadow Links].
-
-== What gets replicated
-
-Shadowing replicates your topic data with complete fidelity, preserving all message records with their original offsets, timestamps, headers, and metadata. The partition structure remains identical between source and shadow clusters, ensuring applications can resume processing from the exact same position after failover.
-
-Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters. Schema Registry data synchronizes schema definitions, versions, and compatibility settings.
-
-Partition count is always replicated to ensure the shadow topic matches the source topic's partition structure.
-
-=== Topic properties replication
-
-The <<source-topic-sync-task,Source Topic Sync task>> handles topic property replication. For topic properties, Redpanda follows these replication rules:
-
-**Never replicated:**
-
-* `redpanda.remote.readreplica`
-* `redpanda.remote.recovery`
-* `redpanda.remote.allowgaps`
-* `redpanda.virtual.cluster.id`
-* `redpanda.leaders.preference`
-* `redpanda.cloud_topic.enabled`
-
-**Always replicated:**
-
-* `max.message.bytes`
-* `cleanup.policy`
-* `message.timestamp.type`
-
-**Always replicated, unless you set `exclude_default` to `true`:**
-
-* `compression.type`
-* `retention.bytes`
-* `retention.ms`
-* `delete.retention.ms`
-* `replication.factor`
-* `min.compaction.lag.ms`
-* `max.compaction.lag.ms`
-
-To replicate additional topic properties, explicitly list them in `synced_shadow_topic_properties`.
-
-The filtering system you configure determines the precise scope of replication across all components, allowing you to balance comprehensive disaster recovery with operational efficiency.
-
 == Set filters
 
 Filters determine which resources Shadowing automatically creates when establishing your shadow link.
@@ -510,7 +412,9 @@ client_options:
 == Create a shadow link
 
 ifdef::env-cloud[]
-You can establish a shadow link using either `rpk`, the Data Plane API, or the Redpanda Cloud UI. For example, to create a shadow link with the source cluster, run the following `rpk` command from the shadow cluster:
+You can establish a shadow link using either `rpk`, the Data Plane API, or the Redpanda Cloud UI. 
+
+To create a shadow link with the source cluster using `rpk`, run the following command from the shadow cluster:
 endif::[]
 
 ifndef::env-cloud[]
@@ -526,7 +430,7 @@ For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-creat
 
 == Update an existing shadow link
 
-If you need to modify a shadow link configuration after creation, use the update command:
+To modify a shadow link configuration after creation, run:
 
 [,bash]
 ----

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -105,11 +105,11 @@ endif::[]
 To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, and ACLs to replicate. 
 
 ifdef::env-cloud[]
-You can use the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
+You can set up Shadowing with the Redpanda Cloud UI, `rpk`, or the Data Plane API. 
 endif::[]
 
 ifndef::env-cloud[]
-You can use Redpanda Console, `rpk`, or the Admin API. 
+You can set up Shadowing with Redpanda Console, `rpk`, or the Admin API. 
 endif::[]
 
 == Create a shadow link

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -65,7 +65,13 @@ endif::[]
 
 === Replication service permissions
 
+ifdef::env-cloud[]
+You must configure a service account on the source cluster with the following xref:security:authorization/acl.adoc[ACL] permissions for shadow link replication:
+endif::[]
+
+ifndef::env-cloud[]
 You must configure a service account on the source cluster with the following xref:manage:security/authorization/acl.adoc[ACL] permissions for shadow link replication:
+endif::[]
 
 * **Topics**: `read` permission on all topics you want to replicate
 * **Topic configurations**: `describe_configs` permission on topics for configuration synchronization
@@ -500,7 +506,13 @@ client_options:
 
 === Create a shadow link
 
+ifdef::env-cloud[]
+You can establish a shadow link using either `rpk`, the Data Plane API, or the Redpanda Cloud UI. For example, to create a shadow link with the source cluster, run the following `rpk` command from the shadow cluster:
+endif::[]
+
+ifndef::env-cloud[]
 You can establish a shadow link using either xref:get-started:rpk/index.adoc[`rpk`], the Admin API, or xref:console:index.adoc[Redpanda Console]. For example, to create a shadow link with the source cluster, run the following `rpk` command from the shadow cluster:
+endif::[]
 
 [,bash]
 ----

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -9,7 +9,7 @@ ifndef::env-cloud[]
 include::shared:partial$shadow-link-management-tip.adoc[]
 endif::[]
 
-ifndef::env-cloud[]
+ifdef::env-cloud[]
 include::shared:partial$shadow-link-cloud-tip.adoc[]
 endif::[]
 
@@ -116,14 +116,14 @@ To set up Shadowing:
 * **Configure filters**: Define which topics, consumer groups, and ACLs should replicate by creating include/exclude patterns that match your disaster recovery requirements. See <<set-filters>>.
 * **Create a shadow link**: Establish the connection between clusters using `rpk`, the Admin API, or Redpanda Console with authentication and network settings. See <<create-a-shadow-link>>.
 
-== Shadow Link Tasks
+== Shadow link tasks
 
 Shadow linking operates through specialized tasks that handle different aspects of replication. Each task corresponds to a configuration section in your shadow link setup and runs continuously to maintain synchronization with the source cluster.
 
 [#source-topic-sync-task]
-=== Source Topic Sync Task
+=== Source Topic Sync task
 
-The **Source Topic Sync Task** manages topic discovery and metadata synchronization. This task periodically queries the source cluster to discover available topics, applies your configured topic filters to determine which topics should become shadow topics, and synchronizes topic properties between clusters.
+The **Source Topic Sync task** manages topic discovery and metadata synchronization. This task periodically queries the source cluster to discover available topics, applies your configured topic filters to determine which topics should become shadow topics, and synchronizes topic properties between clusters.
 
 The task is controlled by the `topic_metadata_sync_options` configuration section, which includes:
 
@@ -135,7 +135,7 @@ The task is controlled by the `topic_metadata_sync_options` configuration sectio
 When this task discovers a new topic that matches your filters, it creates the corresponding shadow topic and begins replication from your configured starting offset.
 
 [#consumer-group-shadowing-task]
-=== Consumer Group Shadowing Task
+=== Consumer Group Shadowing task
 
 The **Consumer Group Shadowing task** replicates consumer group offsets and membership information from the source cluster. This ensures that consumer applications can resume processing from the correct position after failover.
 
@@ -148,9 +148,9 @@ The task is controlled by the `consumer_offset_sync_options` configuration secti
 This task runs on brokers that host the `__consumer_offsets` topic and continuously tracks consumer group coordinators to optimize offset synchronization.
 
 [#security-migrator-task]
-=== Security Migrator Task
+=== Security Migrator task
 
-The **Security Migrator task** replicates security policies, primarily ACLs (Access Control Lists), from the source cluster to maintain consistent authorization across both environments.
+The **Security Migrator task** replicates security policies, primarily ACLs (access control lists), from the source cluster to maintain consistent authorization across both environments.
 
 The task is controlled by the `security_sync_options` configuration section, which includes:
 
@@ -159,7 +159,7 @@ The task is controlled by the `security_sync_options` configuration section, whi
 
 By default, all ACLs replicate to ensure your shadow cluster maintains the same security posture as your source cluster.
 
-=== Task Status and Monitoring
+=== Task status and monitoring
 
 Each task reports its status through the shadow link status API. Task states include:
 
@@ -218,7 +218,7 @@ The filtering system you configure determines the precise scope of replication a
 
 Filters determine which resources Shadowing automatically creates when establishing your shadow link.
 
-Topic filters select which topics Shadowing automatically creates as shadow topics when they appear on the source cluster. Once Shadowing creates a shadow topic, it continues replicating until you failover the topic, delete it, or delete the entire shadow link.
+Topic filters select which topics Shadowing automatically creates as shadow topics when they appear on the source cluster. After Shadowing creates a shadow topic, it continues replicating until you failover the topic, delete it, or delete the entire shadow link.
 
 Consumer group and ACL filters control which groups and security policies replicate to maintain application functionality.
 
@@ -300,7 +300,7 @@ schema_registry_sync_options:
 - The `_schemas` topic must not exist on the shadow cluster, or must be empty
 - Once enabled, the `_schemas` topic will be replicated completely
 
-**Important:** Once the `_schemas` topic becomes a shadow topic, it cannot be stopped without either failing over the topic or deleting it entirely.
+**Important:** After the `_schemas` topic becomes a shadow topic, it cannot be stopped without either failing over the topic or deleting it entirely.
 
 
 === System topic filtering rules
@@ -402,7 +402,7 @@ topic_metadata_sync_options:
 
 [IMPORTANT]
 ====
-The starting offset only affects **new shadow topics**. Once a shadow topic exists and has data, changing this setting has no effect on that topic's replication.
+The starting offset only affects **new shadow topics**. After a shadow topic exists and has data, changing this setting has no effect on that topic's replication.
 ====
 
 === Generate a sample configuration

--- a/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
+++ b/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
@@ -1,4 +1,5 @@
 = rpk shadow
+:description: These commands let you manage shadow links for disaster recovery.
 // tag::single-source[]
 
 Manage Redpanda shadow links.
@@ -13,6 +14,7 @@ rpk shadow [command] [flags]
 ----
 
 == Flags
+
 
 [cols="1m,1a,2a"]
 |===

--- a/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
+++ b/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
@@ -1,4 +1,5 @@
 = rpk shadow
+// tag::single-source[]
 
 Manage Redpanda shadow links.
 
@@ -27,3 +28,5 @@ rpk shadow [command] [flags]
 
 |-v, --verbose |- |Enable verbose logging.
 |===
+
+// end::single-source[]

--- a/modules/shared/partials/emergency-shadowing-callout.adoc
+++ b/modules/shared/partials/emergency-shadowing-callout.adoc
@@ -1,6 +1,6 @@
 :important-caption: Experiencing an active disaster?
 [IMPORTANT]
 ====
-See xref:deploy:redpanda/manual/disaster-recovery/shadowing/failover-runbook.adoc[] for immediate step-by-step disaster procedures.
+See xref:manage:disaster-recovery/shadowing/failover-runbook.adoc[] for immediate step-by-step disaster procedures.
 ====
 :important-caption: Important

--- a/modules/shared/partials/shadow-link-cloud-tip.adoc
+++ b/modules/shared/partials/shadow-link-cloud-tip.adoc
@@ -1,0 +1,1 @@
+You can create and manage shadow links using `rpk`, the Redpanda Cloud UI, or the Data Plane API, giving you flexibility in how you interact with your disaster recovery infrastructure.

--- a/modules/shared/partials/shadow-link-cloud-tip.adoc
+++ b/modules/shared/partials/shadow-link-cloud-tip.adoc
@@ -1,1 +1,1 @@
-You can create and manage shadow links using `rpk`, the Redpanda Cloud UI, or the Data Plane API, giving you flexibility in how you interact with your disaster recovery infrastructure.
+You can create and manage shadow links with the Redpanda Cloud UI, the Data Plane API, or `rpk`, giving you flexibility in how you interact with your disaster recovery infrastructure.

--- a/modules/shared/partials/shadow-link-management-tip.adoc
+++ b/modules/shared/partials/shadow-link-management-tip.adoc
@@ -1,1 +1,1 @@
-You can create and manage shadow links using xref:get-started:rpk/index.adoc[`rpk`], xref:console:index.adoc[Redpanda Console], or the link:https://docs.redpanda.com/api/doc/admin/v2/[Admin API v2^], giving you flexibility in how you interact with your disaster recovery infrastructure.
+You can create and manage shadow links with the xref:console:index.adoc[Redpanda Console], the link:https://docs.redpanda.com/api/doc/admin/v2/[Admin API v2^], or xref:get-started:rpk/index.adoc[`rpk`], giving you flexibility in how you interact with your disaster recovery infrastructure.


### PR DESCRIPTION
## Description
This pull request single sources and conditionalizes Shadowing content for Cloud. 

It also restructures the configuration page, moving conceptual content into the overview & moving **Create shadow link** section toward the top of the config page.

(Single sourcing for this in `cloud-docs` repo is done in https://github.com/redpanda-data/cloud-docs/pull/462. That one will merge Dec 12, to make Shadowing visible in Cloud docs.)

* Added `// tag::single-source[]` and `// end::single-source[]` markers to support reuse and conditional rendering across cloud and self-hosted documentation. [[1]](diffhunk://#diff-4b8d4bcdaa909a433d1efbc5cf3ea6d613666bc3172d11863fa32e9908677d76R5-L12) [[2]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR6-L13) [[3]](diffhunk://#diff-088a4519e87e79d8409ccc68d47c11f470716be741575467fdd0ee22c0dac706R5-L12) [[4]](diffhunk://#diff-794c9a00985adf6bf3d0d06a0e6b716aadc1f3fbe4f6f2629474ac86682909d0R6-R13) [[5]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R6-R32)
* Introduced `ifdef::env-cloud[]` and `ifndef::env-cloud[]` blocks for environment-specific notes, requirements, and tips—such as licensing, authentication, and cluster property configuration. [[1]](diffhunk://#diff-794c9a00985adf6bf3d0d06a0e6b716aadc1f3fbe4f6f2629474ac86682909d0R35-R41) [[2]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R54-R64) [[3]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R82-R88)
* Added cloud-specific tips for shadow link management and clarified the flexibility of shadow link creation and management in Redpanda Cloud. [[1]](diffhunk://#diff-794c9a00985adf6bf3d0d06a0e6b716aadc1f3fbe4f6f2629474ac86682909d0R72-R84) [[2]](diffhunk://#diff-cbbe0edadd9c64604b7afd94d48fee56d85550a987d6d61b6c3fd6321df1315eR1)

Resolves https://redpandadata.atlassian.net/browse/DOC-1667
Review deadline: Dec 10

## Page previews
[What's New in Redpanda Cloud](https://deploy-preview-1491--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[Shadowing](https://deploy-preview-1491--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/) in Cloud
[`rpk shadow`](https://deploy-preview-1491--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/rpk/rpk-shadow/rpk-shadow/) in Cloud

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
