### PR TITLE
Fix Helm chart paths

### DIFF
--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -148,8 +148,8 @@ jobs:
       # Convert the generated Markdown Helm documentation to AsciiDoc format using pandoc.
       - name: Convert Markdown to AsciiDoc
         run: |
-          pandoc ./redpanda/charts/redpanda/README.md -t asciidoc -o ./redpanda-docs/modules/reference/pages/k-redpanda-helm-spec.adoc
-          pandoc ./redpanda/charts/console/README.md -t asciidoc -o ./redpanda-docs/modules/reference/pages/k-console-helm-spec.adoc
+          pandoc ./redpanda/charts/redpanda/chart/README.md -t asciidoc -o ./redpanda-docs/modules/reference/pages/k-redpanda-helm-spec.adoc
+          pandoc ./redpanda/charts/console/chart/README.md -t asciidoc -o ./redpanda-docs/modules/reference/pages/k-console-helm-spec.adoc
           pandoc ./redpanda/operator/chart/README.md -t asciidoc -o ./redpanda-docs/modules/reference/pages/k-operator-helm-spec.adoc
       - name: Modify third-level headings format
         run: |


### PR DESCRIPTION
## Description

This pull request updates the workflow for generating documentation by correcting the file paths used in the Markdown to AsciiDoc conversion step. The changes ensure that the `pandoc` commands reference the correct `README.md` files within the `chart` subdirectories for both the Redpanda and Console Helm charts.

Documentation generation fixes:

* Updated the `pandoc` commands in `.github/workflows/generate-crd.yml` to use the correct source paths: `./redpanda/charts/redpanda/chart/README.md` and `./redpanda/charts/console/chart/README.md`, ensuring the generated AsciiDoc files reflect the latest chart documentation.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
