### PR TITLE
Add serverless metrics

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -32,6 +32,10 @@ Total number of fully commissioned brokers configured in the cluster.
 
 *Usage*: Create an alert if this gauge falls below a steady-state threshold, which may indicate that a broker has become unresponsive.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_controller_log_limit_requests_available_rps
@@ -43,6 +47,10 @@ The upper limit on the requests per second (RPS) that the cluster controller log
 *Labels*:
 
 * `redpanda_cmd_group=("move_operations" | "topic_operations" | "configuration_operations" | "node_management_operations" | "acls_and_users_operations")`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -57,6 +65,10 @@ The cumulative number of requests dropped by the controller log because the inco
 * `redpanda_cmd_group=("move_operations" | "topic_operations" | "configuration_operations" | "node_management_operations" | "acls_and_users_operations")`
 
 *Usage*: A rising counter indicates that requests are being dropped, which could signal overload or misconfiguration.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -74,6 +86,10 @@ Number of seconds remaining until the Enterprise Edition license expires.
 
 Use this metric to proactively monitor license status and trigger alerts for timely renewal.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_latest_cluster_metadata_manifest_age
@@ -85,6 +101,10 @@ When performing a whole cluster restore operation, metadata for new clusters wil
 *Type*: gauge
 
 *Usage*: On a healthy system, this should not exceed the value set for `cloud_storage_cluster_metadata_upload_interval_ms`. You may consider setting an alert if this remains `0` for longer than 1.5 * `cloud_storage_cluster_metadata_upload_interval_ms` as that may indicate a configuration issue.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ifndef::env-cloud[]
 *Related topics*:
@@ -104,6 +124,10 @@ The number of node operations queued per shard that are awaiting processing by t
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_non_homogenous_fips_mode
@@ -113,6 +137,10 @@ Count of brokers whose FIPS mode configuration differs from the rest of the clus
 *Type*: gauge
 
 *Usage*: Indicates inconsistencies in security configurations that might affect compliance or interoperability.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -124,6 +152,10 @@ Number of partition replicas that are in the process of being removed from a bro
 
 *Usage*: A non-zero value can indicate ongoing or unexpected partition reassignments. Investigate if this metric remains elevated.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_partition_moving_to_node
@@ -133,6 +165,10 @@ Number of partition replicas in the cluster currently being added or moved to a 
 *Type*: gauge
 
 *Usage*: When this gauge is non-zero, determine whether there is an expected or unexpected reassignment of partitions causing partition replicas movement.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -144,6 +180,10 @@ During a partition movement cancellation operation, the number of partition repl
 
 *Usage*: Track this metric to verify that partition reassignments are proceeding as expected; persistent non-zero values may warrant further investigation.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_partition_num_with_broken_rack_constraint
@@ -154,6 +194,10 @@ During a partition movement cancellation operation, the number of partition repl
 
 *Usage*: A non-zero value may indicate issues in the partition reassignment process that need attention.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_partitions
@@ -162,6 +206,10 @@ Total number of logical partitions managed by the cluster. This includes partiti
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_cluster_topics
@@ -169,6 +217,10 @@ Total number of logical partitions managed by the cluster. This includes partiti
 The total number of topics configured within the cluster.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -179,6 +231,10 @@ Number of partitions that are unavailable due to a lack of quorum among their re
 *Type*: gauge
 
 *Usage*: A non-zero value indicates that some partitions do not have an active leader. Consider increasing the number of brokers or the replication factor if this persists.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Debug bundle metrics
 
@@ -192,6 +248,10 @@ Running count of debug bundle generation failures, reported per shard.
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_debug_bundle_last_failed_bundle_timestamp_seconds
@@ -203,6 +263,10 @@ Unix epoch timestamp of the last failed debug bundle generation, per shard.
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -216,6 +280,10 @@ Unix epoch timestamp of the last successfully generated debug bundle, per shard.
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_debug_bundle_successful_generation_count
@@ -227,6 +295,10 @@ Running count of successfully generated debug bundles, reported per shard.
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Iceberg metrics
 
@@ -240,6 +312,10 @@ Number of active GET requests.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_active_puts
@@ -251,6 +327,10 @@ Number of active PUT requests.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -264,6 +344,10 @@ Number of active HTTP requests (includes PUT and GET).
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_commit_table_update_requests
@@ -275,6 +359,10 @@ Total number of requests sent to the `commit_table_update` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -288,6 +376,10 @@ Number of requests sent to the `commit_table_update` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_create_namespace_requests
@@ -299,6 +391,10 @@ Total number of requests sent to the `create_namespace` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -312,6 +408,10 @@ Number of requests sent to the `create_namespace` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_create_table_requests
@@ -323,6 +423,10 @@ Total number of requests sent to the `create_table` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -336,6 +440,10 @@ Number of requests sent to the `create_table` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_drop_table_requests
@@ -347,6 +455,10 @@ Total number of requests sent to the `drop_table` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -360,6 +472,10 @@ Number of requests sent to the `drop_table` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_get_config_requests
@@ -371,6 +487,10 @@ Total number of requests sent to the `config` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -384,6 +504,10 @@ Number of requests sent to the `config` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_load_table_requests
@@ -395,6 +519,10 @@ Total number of requests sent to the `load_table` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -408,6 +536,10 @@ Number of requests sent to the `load_table` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_oauth_token_requests
@@ -419,6 +551,10 @@ Total number of requests sent to the `oauth_token` endpoint.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -432,6 +568,10 @@ Number of requests sent to the `oauth_token` endpoint that failed.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_num_request_timeouts
@@ -443,6 +583,10 @@ Total number of catalog requests that could no longer be retried because they ti
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -456,6 +600,10 @@ Total number of transport errors (TCP and TLS).
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_total_gets
@@ -467,6 +615,10 @@ Number of completed GET requests.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -480,6 +632,10 @@ Total number of bytes received from the Iceberg REST catalog.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_total_outbound_bytes
@@ -491,6 +647,10 @@ Total number of bytes sent to the Iceberg REST catalog.
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -504,6 +664,10 @@ Number of completed PUT requests.
 
 - `role`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_rest_client_total_requests
@@ -515,6 +679,10 @@ Number of completed HTTP requests (includes PUT and GET).
 *Labels*:
 
 - `role`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -529,6 +697,10 @@ Number of bytes consumed post-decompression for processing that may or may not s
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_translation_dlq_files_created
@@ -542,6 +714,10 @@ Number of created Parquet files for the dead letter queue (DLQ) table.
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_translation_files_created
@@ -554,6 +730,10 @@ Number of created Parquet files (not counting the DLQ table).
 
 - `redpanda_namespace`
 - `redpanda_topic`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -569,6 +749,10 @@ Number of invalid records handled by translation.
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_translation_parquet_bytes_added
@@ -581,6 +765,10 @@ Number of bytes in created Parquet files (not counting the DLQ table).
 
 - `redpanda_namespace`
 - `redpanda_topic`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -595,6 +783,10 @@ Number of rows in created Parquet files (not counting the DLQ table).
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_translation_raw_bytes_processed
@@ -608,6 +800,10 @@ Number of raw, potentially compressed bytes, consumed for processing that may or
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_iceberg_translation_translations_finished
@@ -620,6 +816,10 @@ Number of finished translator executions.
 
 - `redpanda_namespace`
 - `redpanda_topic`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -636,6 +836,10 @@ Total time (in seconds) the CPU has been actively processing tasks.
 *Labels*:
 
 * `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -655,6 +859,10 @@ Cumulative count of read operations processed by the I/O queue.
 
 * `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_io_queue_total_write_ops
@@ -673,6 +881,10 @@ Cumulative count of write operations processed by the I/O queue.
 
 * `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_memory_allocated_memory
@@ -686,6 +898,10 @@ Total memory allocated (in bytes) per CPU shard.
 * `shard`
 
 *Usage*: This metric includes reclaimable memory from the batch cache. For monitoring memory pressure, consider using `redpanda_memory_available_memory` instead, which provides a more accurate picture of memory that can be immediately reallocated.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -701,6 +917,10 @@ Total memory (in bytes) available to a CPU shard—including both free and recla
 
 *Usage*: This metric is more useful than `redpanda_memory_allocated_memory` for monitoring memory pressure, as it accounts for reclaimable memory in the batch cache. A low value indicates the system is approaching memory exhaustion.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_memory_available_memory_low_water_mark
@@ -715,6 +935,10 @@ The lowest recorded available memory (in bytes) per CPU shard since the process 
 
 *Usage*: This metric helps identify the closest the system has come to memory exhaustion. Useful for capacity planning and understanding historical memory pressure patterns.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_memory_free_memory
@@ -727,6 +951,10 @@ Total unallocated (free) memory in bytes available for each CPU shard.
 
 * `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_rpc_active_connections
@@ -738,6 +966,10 @@ Current number of active RPC client connections on a shard.
 *Labels*:
 
 * `redpanda_server=("kafka" | "internal")`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -757,6 +989,10 @@ The `redpanda_server` label supports the following options for this metric:
 
 - `redpanda_server`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_rpc_request_errors_total
@@ -771,6 +1007,10 @@ Cumulative count of RPC errors encountered, segmented by server type.
 
 *Usage*: Use this metric to diagnose potential issues in RPC communication.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_rpc_request_latency_seconds
@@ -782,6 +1022,10 @@ Histogram capturing the latency (in seconds) for RPC requests.
 *Labels*:
 
 * `redpanda_server=("kafka" | "internal")`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -801,6 +1045,10 @@ The `redpanda_server` label supports the following options for this metric:
 
 - `redpanda_server`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_scheduler_runtime_seconds_total
@@ -815,6 +1063,10 @@ Total accumulated runtime (in seconds) for the task queue associated with each s
 
 * `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_storage_cache_disk_free_bytes
@@ -824,6 +1076,10 @@ Amount of free disk space (in bytes) available on the cache storage.
 *Type*: gauge
 
 *Usage*: Monitor this to ensure sufficient cache storage capacity.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -839,6 +1095,10 @@ Alert indicator for cache storage free space, where:
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_storage_cache_disk_total_bytes
@@ -847,6 +1107,10 @@ Total size of attached storage, in bytes.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_storage_disk_free_bytes
@@ -854,6 +1118,10 @@ Total size of attached storage, in bytes.
 Amount of free disk space (in bytes) available on attached storage.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 [[redpanda_storage_disk_free_space_alert]]
 === redpanda_storage_disk_free_space_alert
@@ -868,6 +1136,10 @@ Alert indicator for overall disk storage free space, where:
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_storage_disk_total_bytes
@@ -875,6 +1147,10 @@ Alert indicator for overall disk storage free space, where:
 Total capacity (in bytes) of the attached storage.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -884,6 +1160,10 @@ Total system uptime (in seconds) representing the overall CPU runtime.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 == Raft metrics
 
 === redpanda_node_status_rpcs_received
@@ -891,6 +1171,10 @@ Total system uptime (in seconds) representing the overall CPU runtime.
 Total count of node status RPCs received by a broker.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -900,6 +1184,10 @@ Total count of node status RPCs sent by a broker.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_node_status_rpcs_timed_out
@@ -908,13 +1196,21 @@ Total count of node status RPCs that timed out on a broker.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 == Redpanda Connect metrics
 
 === input_connection_failed
 
-Number of input connections to the Redpanda Connect pipeline that have failed. 
+Number of input connections to the Redpanda Connect pipeline that have failed.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -924,13 +1220,21 @@ Benthos Counter metric.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === input_connection_up
 
-Number of active input connections to the Redpanda Connect pipeline. 
+Number of active input connections to the Redpanda Connect pipeline.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -940,6 +1244,10 @@ Input latency for the Redpanda Connect pipeline.
 
 *Type*: summary
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === input_received
@@ -947,6 +1255,10 @@ Input latency for the Redpanda Connect pipeline.
 Number of records received by the Redpanda Connect pipeline.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -956,13 +1268,21 @@ Benthos Counter metric.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === output_connection_failed
 
-Number of output connections from the Redpanda Connect pipeline that have failed. 
+Number of output connections from the Redpanda Connect pipeline that have failed.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -972,13 +1292,21 @@ Benthos Counter metric.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === output_connection_up
 
-Number of active output connections from the Redpanda Connect pipeline. 
+Number of active output connections from the Redpanda Connect pipeline.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -988,6 +1316,10 @@ Number of errors encountered in the Redpanda Connect pipeline output.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === output_latency_ns
@@ -995,6 +1327,10 @@ Number of errors encountered in the Redpanda Connect pipeline output.
 Output latency for the Redpanda Connect pipeline.
 
 *Type*: summary
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1004,6 +1340,10 @@ Records sent by the Redpanda Connect pipeline.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === processor_batch_received
@@ -1011,6 +1351,10 @@ Records sent by the Redpanda Connect pipeline.
 Benthos Counter metric.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1020,6 +1364,10 @@ Benthos Counter metric.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === processor_error
@@ -1027,6 +1375,10 @@ Benthos Counter metric.
 Benthos Counter metric.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1036,6 +1388,10 @@ Benthos Timing metric.
 
 *Type*: summary
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === processor_received
@@ -1043,6 +1399,10 @@ Benthos Timing metric.
 Benthos Counter metric.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1053,6 +1413,10 @@ Benthos Counter metric.
 *Type*: counter
 
 ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
+ifdef::env-cloud[]
 == Serverless metrics
 
 === redpanda_serverless_ingress_bytes_total
@@ -1060,6 +1424,8 @@ ifdef::env-cloud[]
 Total raw bytes sent by clients to the Serverless cluster.
 
 *Type*: counter
+
+*Available in Serverless*: Yes
 
 ---
 
@@ -1069,6 +1435,8 @@ Total raw bytes sent by the Serverless cluster to clients.
 
 *Type*: counter
 
+*Available in Serverless*: Yes
+
 ---
 
 === redpanda_serverless_connections_active
@@ -1076,6 +1444,8 @@ Total raw bytes sent by the Serverless cluster to clients.
 Number of active client connections.
 
 *Type*: gauge
+
+*Available in Serverless*: Yes
 
 ---
 
@@ -1085,6 +1455,8 @@ Total number of client connections created.
 
 *Type*: counter
 
+*Available in Serverless*: Yes
+
 ---
 
 === redpanda_serverless_connections_duration_seconds
@@ -1092,6 +1464,8 @@ Total number of client connections created.
 Total duration (in seconds) of client connections.
 
 *Type*: summary
+
+*Available in Serverless*: Yes
 
 ---
 
@@ -1109,6 +1483,8 @@ To increase resource limits, contact https://support.redpanda.com/hc/en-us/reque
 
 *Type*: gauge
 
+*Available in Serverless*: Yes
+
 endif::[]
 
 == Service metrics
@@ -1123,6 +1499,10 @@ Cumulative count of authorization results, categorized by result type.
 
 - `type`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_kafka_rpc_sasl_session_expiration_total
@@ -1130,6 +1510,10 @@ Cumulative count of authorization results, categorized by result type.
 Total number of SASL session expirations observed.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1139,6 +1523,10 @@ Total number of SASL reauthentication attempts made by clients.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_kafka_rpc_sasl_session_revoked_total
@@ -1146,6 +1534,10 @@ Total number of SASL reauthentication attempts made by clients.
 Total number of SASL sessions that have been revoked.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1155,6 +1547,10 @@ Histogram capturing the latency (in seconds) for REST proxy requests. The measur
 
 *Type*: histogram
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_schema_registry_cache_schema_count
@@ -1163,6 +1559,10 @@ Total number of schemas currently stored in the Schema Registry cache.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_schema_registry_cache_schema_memory_bytes
@@ -1170,6 +1570,10 @@ Total number of schemas currently stored in the Schema Registry cache.
 Memory usage (in bytes) by schemas stored in the Schema Registry cache.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1182,6 +1586,10 @@ Count of subjects stored in the Schema Registry cache.
 *Labels*:
 
 - `deleted`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1196,6 +1604,10 @@ Count of versions available for each subject in the Schema Registry cache.
 - `deleted`
 - `subject`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_schema_registry_inflight_requests_memory_usage_ratio
@@ -1207,6 +1619,10 @@ Ratio of memory used by in-flight requests in the Schema Registry, reported per 
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1220,6 +1636,10 @@ Usage ratio for in-flight Schema Registry requests, reported per shard.
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_schema_registry_queued_requests_memory_blocked
@@ -1231,6 +1651,10 @@ Count of Schema Registry requests queued due to memory constraints, reported per
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1244,6 +1668,10 @@ Total number of errors encountered by the Schema Registry, categorized by status
 
 * `redpanda_status=("5xx" | "4xx" | "3xx")`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_schema_registry_request_latency_seconds
@@ -1251,6 +1679,10 @@ Total number of errors encountered by the Schema Registry, categorized by status
 Histogram capturing the latency (in seconds) for Schema Registry requests.
 
 *Type*: histogram
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 == Partition metrics
 
@@ -1272,6 +1704,10 @@ High watermark offset for a partition, used to calculate consumer group lag.
 
 - xref:manage:monitoring.adoc#consumer-group-lag[Consumer group lag]
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_kafka_request_bytes_total
@@ -1289,6 +1725,10 @@ The total may include fetched bytes that are not returned to the client.
 
 * `redpanda_request=("produce" | "consume")`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_kafka_under_replicated_replicas
@@ -1305,6 +1745,10 @@ Number of partition replicas that are live yet lag behind the latest offset, <<r
 
 * `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_raft_leadership_changes
@@ -1319,6 +1763,10 @@ Total count of leadership changes (such as successful leader elections) across a
 
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_raft_learners_gap_bytes
@@ -1331,6 +1779,10 @@ Total number of bytes that must be delivered to learner replicas to bring them u
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_raft_recovery_offsets_pending
@@ -1338,6 +1790,10 @@ Total number of bytes that must be delivered to learner replicas to bring them u
 Sum of offsets across partitions on a broker that still need to be recovered.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1351,6 +1807,10 @@ Available network bandwidth (in bytes per second) for partition movement operati
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_raft_recovery_partition_movement_consumed_bandwidth
@@ -1363,6 +1823,10 @@ Network bandwidth (in bytes per second) currently being consumed for partition m
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_raft_recovery_partitions_active
@@ -1370,6 +1834,10 @@ Network bandwidth (in bytes per second) currently being consumed for partition m
 Number of partition replicas currently undergoing recovery on a broker.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1379,6 +1847,10 @@ Total count of partition replicas that are pending recovery on a broker.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 == Topic metrics
 
 === redpanda_cluster_partition_schema_id_validation_records_failed
@@ -1386,6 +1858,10 @@ Total count of partition replicas that are pending recovery on a broker.
 Count of records that failed schema ID validation during ingestion.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1401,6 +1877,10 @@ Configured number of partitions for a topic.
 
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_kafka_records_fetched_total
@@ -1414,6 +1894,10 @@ Total number of records fetched from a topic.
 * `redpanda_namespace`
 * `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_kafka_records_produced_total
@@ -1426,6 +1910,10 @@ Total number of records produced to a topic.
 
 * `redpanda_namespace`
 * `redpanda_topic`
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1441,6 +1929,10 @@ Configured number of replicas for a topic.
 
 * `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_security_audit_errors_total
@@ -1448,6 +1940,10 @@ Configured number of replicas for a topic.
 Cumulative count of errors encountered when creating or publishing audit event log entries.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1457,6 +1953,10 @@ Unix epoch timestamp of the last successful audit log event publication.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 == Broker metrics
 
 === redpanda_kafka_handler_latency_seconds
@@ -1464,6 +1964,10 @@ Unix epoch timestamp of the last successful audit log event publication.
 Histogram capturing the latency for processing Kafka requests at the broker level.
 
 *Type*: histogram
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1476,6 +1980,10 @@ Histogram capturing the latency (in seconds) for produce/consume requests at the
 *Labels*:
 
 * `redpanda_request=("produce" | "consume")`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1491,6 +1999,10 @@ Histogram of client quota throttling delays (in seconds) per quota rule and type
 
 * `quota_type=("produce_quota" | "fetch_quota" | "partition_mutation_quota")`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_kafka_quotas_client_quota_throughput
@@ -1504,6 +2016,10 @@ Histogram of client quota throughput per quota rule and type.
 * `quota_rule=("not_applicable" | "kafka_client_default" | "cluster_client_default" | "kafka_client_prefix" | "cluster_client_prefix" | "kafka_client_id")`
 
 * `quota_type=("produce_quota" | "fetch_quota" | "partition_mutation_quota")`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Consumer group metrics
 
@@ -1522,6 +2038,10 @@ To enable this metric, you must include the `partition` option in the xref:refer
 - `redpanda_topic`
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_kafka_consumer_group_consumers
@@ -1537,6 +2057,10 @@ To enable this metric, you must include the `group` option in the xref:reference
 - `redpanda_group`
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 ---
 
 === redpanda_kafka_consumer_group_lag_max
@@ -1550,6 +2074,10 @@ To enable this metric, you must include the `consumer_lag` option in the xref:re
 *Labels*:
 
 - `redpanda_group`
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 *Related topics*:
 
@@ -1568,6 +2096,10 @@ To enable this metric, you must include the `consumer_lag` option in the xref:re
 *Labels*:
 
 - `redpanda_group`
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 *Related topics*:
 
@@ -1588,6 +2120,10 @@ To enable this metric, you must include the `group` option in the xref:reference
 - `redpanda_group`
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
+
 == REST proxy metrics
 
 === redpanda_rest_proxy_inflight_requests_memory_usage_ratio
@@ -1599,6 +2135,10 @@ Ratio of memory used by in-flight REST proxy requests, measured per shard.
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1612,6 +2152,10 @@ Usage ratio for in-flight REST proxy requests, measured per shard.
 
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_rest_proxy_queued_requests_memory_blocked
@@ -1623,6 +2167,10 @@ Count of REST proxy requests queued due to memory limitations, measured per shar
 *Labels*:
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1636,6 +2184,10 @@ Cumulative count of REST proxy errors, categorized by HTTP status code.
 
 * `redpanda_status("5xx" | "4xx" | "3xx")`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_rest_proxy_request_latency_seconds_bucket
@@ -1643,6 +2195,10 @@ Cumulative count of REST proxy errors, categorized by HTTP status code.
 Histogram representing the internal latency buckets for REST proxy requests.
 
 *Type*: histogram
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Application metrics
 
@@ -1656,6 +2212,10 @@ Build information for Redpanda, including the revision and version details.
 
 * `redpanda_revision`
 * `redpanda_version`
+
+ifdef::env-cloud[]
+*Available in Serverless*: Yes
+endif::[]
 
 ---
 
@@ -1671,6 +2231,10 @@ Indicates whether Redpanda is running in FIPS mode. Possible values:
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_application_uptime_seconds_total
@@ -1678,6 +2242,10 @@ Indicates whether Redpanda is running in FIPS mode. Possible values:
 Total runtime (in seconds) of the Redpanda application.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Cloud metrics
 
@@ -1705,6 +2273,10 @@ Total number of object storage requests that experienced backoff delays.
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_client_pool_utilization
@@ -1718,6 +2290,10 @@ Utilization of the object storage pool(0 - unused, 100 - fully utilized).
 - `redpanda_endpoint`
 - `redpanda_region`
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1745,6 +2321,10 @@ Total number of object storage download requests that experienced backoff delays
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_downloads
@@ -1771,6 +2351,10 @@ Total number of successful download requests from object storage.
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_lease_duration
@@ -1779,11 +2363,15 @@ Histogram representing the lease duration for object storage clients.
 
 *Type*: histogram
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_not_found
 
-Total number of object storage requests that resulted in a “not found” error.
+Total number of object storage requests that resulted in a "not found" error.
 
 *Type*: counter
 
@@ -1805,6 +2393,10 @@ Total number of object storage requests that resulted in a “not found” error
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_num_borrows
@@ -1820,6 +2412,10 @@ Count of instances where a shard borrowed a object storage client from another s
 - `redpanda_region`
 
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1847,6 +2443,10 @@ Total number of object storage upload requests that experienced backoff delays.
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_client_uploads
@@ -1873,6 +2473,10 @@ Total number of successful upload requests to object storage.
 
 - `redpanda_storage_account`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 [[tls_metrics]]
@@ -1892,6 +2496,10 @@ Unix epoch timestamp for the expiration of the shortest-lived installed TLS cert
 
 *Usage*: Useful for proactive certificate renewal by indicating the next certificate set to expire.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_tls_certificate_serial
@@ -1907,6 +2515,10 @@ The least significant 4 bytes of the serial number for the certificate that will
 * `detail`
 
 *Usage*: Provides a quick reference to identify the certificate in question.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1924,6 +2536,10 @@ Indicator of whether a resource has at least one valid TLS certificate installed
 
 *Usage*: Aids in continuous monitoring of certificate validity across resources.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_tls_loaded_at_timestamp_seconds
@@ -1939,6 +2555,10 @@ Unix epoch timestamp marking the last time a TLS certificate was loaded for a re
 * `detail`
 
 *Usage*: Indicates recent certificate updates across resources.
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1956,6 +2576,10 @@ Unix epoch timestamp representing the expiration time of the shortest-lived cert
 
 *Usage*: Helps identify when any CA in the chain is nearing expiration.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_trust_file_crc32c
@@ -1970,6 +2594,10 @@ CRC32C checksum calculated from the contents of the trust file. This value is ca
 - `detail`
 - `shard`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_truststore_expires_at_timestamp_seconds
@@ -1983,6 +2611,10 @@ Expiry time of the shortest-lived CA in the truststore, measured in seconds sinc
 - `area`
 - `detail`
 - `shard`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -1999,6 +2631,10 @@ Counter for the number of errors encountered during the invocation of data trans
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_transform_execution_latency_sec
@@ -2010,6 +2646,10 @@ Histogram tracking the execution latency (in seconds) for processing a single re
 *Labels*:
 
 * `function_name`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2023,6 +2663,10 @@ Counter for each failure encountered by a data transform processor.
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_transform_processor_lag
@@ -2035,6 +2679,10 @@ Number of records pending processing in the input topic for a data transform.
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_transform_read_bytes
@@ -2046,6 +2694,10 @@ Cumulative count of bytes read as input to data transforms.
 *Labels*:
 
 * `function_name`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2061,6 +2713,10 @@ Current count of transform processors in a specific state (running, inactive, or
 
 * `state=("running" | "inactive" | "errored")`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_transform_write_bytes
@@ -2073,6 +2729,10 @@ Cumulative count of bytes output from data transforms.
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_wasm_binary_executable_memory_usage
@@ -2080,6 +2740,10 @@ Cumulative count of bytes output from data transforms.
 Number of bytes (memory) used by executable WebAssembly binaries.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2093,6 +2757,10 @@ Total CPU time (in seconds) consumed by WebAssembly functions.
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_wasm_engine_max_memory
@@ -2105,6 +2773,10 @@ Maximum allowed memory (in bytes) allocated for a WebAssembly function.
 
 * `function_name`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_wasm_engine_memory_usage
@@ -2116,6 +2788,10 @@ Current memory usage (in bytes) by a WebAssembly function.
 *Labels*:
 
 * `function_name`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Object storage metrics
 
@@ -2136,6 +2812,10 @@ Number of remote log segments that are currently hydrated and available for read
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_anomalies
@@ -2143,6 +2823,10 @@ Number of remote log segments that are currently hydrated and available for read
 Count of missing partition manifest anomalies detected for the topic.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2152,6 +2836,10 @@ Total number of successful get requests that found the requested object in the c
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_op_in_progress_files
@@ -2159,6 +2847,10 @@ Total number of successful get requests that found the requested object in the c
 Number of files currently being written to the cache.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2168,6 +2860,10 @@ Total count of get requests that did not find the requested object in the cache.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_op_put
@@ -2175,6 +2871,10 @@ Total count of get requests that did not find the requested object in the cache.
 Total number of objects successfully written into the cache.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2184,6 +2884,10 @@ Current number of objects stored in the cache.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_space_hwm_files
@@ -2191,6 +2895,10 @@ Current number of objects stored in the cache.
 High watermark for the number of objects stored in the cache.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2200,6 +2908,10 @@ High watermark for the total size (in bytes) of cached objects.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_space_size_bytes
@@ -2207,6 +2919,10 @@ High watermark for the total size (in bytes) of cached objects.
 Total size (in bytes) of objects currently stored in the cache.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2216,6 +2932,10 @@ Current count of entries in the cache access tracker.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_space_tracker_syncs
@@ -2223,6 +2943,10 @@ Current count of entries in the cache access tracker.
 Total number of times the cache access tracker was synchronized with disk data.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2232,6 +2956,10 @@ Count of times the cache trim operation was invoked using a carryover strategy.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_trim_exhaustive_trims
@@ -2239,6 +2967,10 @@ Count of times the cache trim operation was invoked using a carryover strategy.
 Count of instances where a fast cache trim was insufficient and an exhaustive trim was required.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2248,6 +2980,10 @@ Count of cache trim operations that failed to free the expected amount of space,
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_trim_fast_trims
@@ -2256,6 +2992,10 @@ Count of successful fast cache trim operations.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_cache_trim_in_mem_trims
@@ -2263,6 +3003,10 @@ Count of successful fast cache trim operations.
 Count of cache trim operations performed using the in-memory access tracker.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2274,6 +3018,10 @@ Total size (in bytes) of user-visible log data stored in Tiered Storage. This va
 
 *Usage*: Segmented by `redpanda_namespace` (e.g., `kafka`, `kafka_internal`, or `redpanda`), `redpanda_topic`, and `redpanda_partition`.
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_deleted_segments
@@ -2281,6 +3029,10 @@ Total size (in bytes) of user-visible log data stored in Tiered Storage. This va
 Count of log segments that have been deleted from object storage due to retention policies or compaction processes.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2294,6 +3046,10 @@ Cumulative count of errors encountered during object storage operations, segment
 
 - `redpanda_direction`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_housekeeping_drains
@@ -2301,6 +3057,10 @@ Cumulative count of errors encountered during object storage operations, segment
 Count of times the object storage upload housekeeping queue was fully drained.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2310,6 +3070,10 @@ Total number of successfully executed object storage housekeeping jobs.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_housekeeping_jobs_failed
@@ -2317,6 +3081,10 @@ Total number of successfully executed object storage housekeeping jobs.
 Total number of object storage housekeeping jobs that failed.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2326,6 +3094,10 @@ Count of object storage housekeeping jobs that were skipped during execution.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_housekeeping_pauses
@@ -2333,6 +3105,10 @@ Count of object storage housekeeping jobs that were skipped during execution.
 Count of times object storage upload housekeeping was paused.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2342,6 +3118,10 @@ Average rate (per shard) of requests that were throttled during object storage o
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_housekeeping_resumes
@@ -2349,6 +3129,10 @@ Average rate (per shard) of requests that were throttled during object storage o
 Count of instances when object storage upload housekeeping resumed after a pause.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2358,6 +3142,10 @@ Total number of rounds executed by the object storage upload housekeeping proces
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_jobs_cloud_segment_reuploads
@@ -2365,6 +3153,10 @@ Total number of rounds executed by the object storage upload housekeeping proces
 Count of log segments reuploaded from object storage sources (either from the cache or via direct download).
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2374,6 +3166,10 @@ Count of log segments reuploaded from the local data directory.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_jobs_manifest_reuploads
@@ -2381,6 +3177,10 @@ Count of log segments reuploaded from the local data directory.
 Total number of partition manifest reuploads performed by housekeeping jobs.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2390,6 +3190,10 @@ Total number of archival configuration updates (metadata synchronizations) execu
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_jobs_segment_deletions
@@ -2397,6 +3201,10 @@ Total number of archival configuration updates (metadata synchronizations) execu
 Total count of log segments deleted by housekeeping jobs.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2406,6 +3214,10 @@ Total cumulative time (in milliseconds) during which downloads were throttled.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_partition_manifest_uploads_total
@@ -2413,6 +3225,10 @@ Total cumulative time (in milliseconds) during which downloads were throttled.
 Total number of successful partition manifest uploads to object storage.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2422,6 +3238,10 @@ Number of active partition reader instances (fetch/timequery operations) reading
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_partition_readers_delayed
@@ -2429,6 +3249,10 @@ Number of active partition reader instances (fetch/timequery operations) reading
 Count of partition read operations delayed due to reaching the reader limit, suggesting potential saturation of Tiered Storage reads.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2443,6 +3267,10 @@ Number of paused archivers.
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_readers
@@ -2450,6 +3278,10 @@ Number of paused archivers.
 Total number of segment read cursors for hydrated remote log segments.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2459,6 +3291,10 @@ Total number of successful segment index uploads to object storage.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_segment_materializations_delayed
@@ -2466,6 +3302,10 @@ Total number of successful segment index uploads to object storage.
 Count of segment materialization operations that were delayed because of reader limit constraints.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2475,6 +3315,10 @@ Count of segment reader operations delayed due to reaching the reader limit. Thi
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_segment_uploads_total
@@ -2482,6 +3326,10 @@ Count of segment reader operations delayed due to reaching the reader limit. Thi
 Total number of successful data segment uploads to object storage.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2496,6 +3344,10 @@ Total number of log segments accounted for in object storage for the topic.
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_segments_pending_deletion
@@ -2509,6 +3361,10 @@ Total number of log segments pending deletion from object storage for the topic.
 - `redpanda_namespace`
 - `redpanda_topic`
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_spillover_manifest_uploads_total
@@ -2516,6 +3372,10 @@ Total number of log segments pending deletion from object storage for the topic.
 Total number of successful spillover manifest uploads to object storage.
 
 *Type*: counter
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2525,6 +3385,10 @@ Total bytes of memory used by spilled manifests that are currently cached in mem
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cloud_storage_spillover_manifests_materialized_count
@@ -2532,6 +3396,10 @@ Total bytes of memory used by spilled manifests that are currently cached in mem
 Count of spilled manifests currently held in memory cache.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -2545,6 +3413,10 @@ Total number of bytes uploaded for the topic to object storage.
 
 - `redpanda_namespace`
 - `redpanda_topic`
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 == Related topics
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1288,7 +1288,7 @@ endif::[]
 
 === output_connection_lost
 
-Benthos Counter metric.
+Number of times the connection to the downstream system is lost in a Redpanda Connect pipeline.
 
 *Type*: counter
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -908,6 +908,201 @@ Total count of node status RPCs that timed out on a broker.
 
 *Type*: gauge
 
+== Redpanda Connect metrics
+
+=== input_connection_failed
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== input_connection_lost
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== input_connection_up
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== input_latency_ns
+
+Benthos Timing metric.
+
+*Type*: summary
+
+---
+
+=== input_received
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_batch_sent
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_connection_failed
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_connection_lost
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_connection_up
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_error
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== output_latency_ns
+
+Benthos Timing metric.
+
+*Type*: summary
+
+---
+
+=== output_sent
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== processor_batch_received
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== processor_batch_sent
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== processor_error
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== processor_latency_ns
+
+Benthos Timing metric.
+
+*Type*: summary
+
+---
+
+=== processor_received
+
+Benthos Counter metric.
+
+*Type*: counter
+
+---
+
+=== processor_sent
+
+Benthos Counter metric.
+
+*Type*: counter
+
+ifdef::env-cloud[]
+== Serverless metrics
+
+=== redpanda_serverless_ingress_bytes_total
+
+Total raw bytes sent by clients to the Serverless cluster.
+
+*Type*: counter
+
+---
+
+=== redpanda_serverless_egress_bytes_total
+
+Total raw bytes sent by the Serverless cluster to clients.
+
+*Type*: counter
+
+---
+
+=== redpanda_serverless_connections_active
+
+Number of active client connections.
+
+*Type*: gauge
+
+---
+
+=== redpanda_serverless_connections_created_total
+
+Total number of client connections created.
+
+*Type*: counter
+
+---
+
+=== redpanda_serverless_connections_duration_seconds
+
+Total duration (in seconds) of client connections.
+
+*Type*: summary
+
+---
+
+=== redpanda_serverless_resource_limit
+
+Resource limits for the Serverless cluster. To increase resouce limits, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+
+*Type*: gauge
+
+endif::[]
+
 == Service metrics
 
 === redpanda_authorization_result

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1216,7 +1216,7 @@ endif::[]
 
 === input_connection_lost
 
-Benthos Counter metric.
+Number of times a connection to the upstream system is lost in a Redpanda Connect pipeline.
 
 *Type*: counter
 
@@ -1264,7 +1264,7 @@ endif::[]
 
 === output_batch_sent
 
-Benthos Counter metric.
+Number of batches produced by the Redpanda Connect pipeline.
 
 *Type*: counter
 
@@ -1348,7 +1348,7 @@ endif::[]
 
 === processor_batch_received
 
-Benthos Counter metric.
+Number of record batches received as input in a Redpanda Connect pipeline processor.
 
 *Type*: counter
 
@@ -1360,7 +1360,7 @@ endif::[]
 
 === processor_batch_sent
 
-Benthos Counter metric.
+Number of record batches produced as output by a Redpanda Connect pipeline processor.
 
 *Type*: counter
 
@@ -1372,7 +1372,7 @@ endif::[]
 
 === processor_error
 
-Benthos Counter metric.
+Number of errors encountered by a Redpanda Connect pipeline processor.
 
 *Type*: counter
 
@@ -1384,7 +1384,7 @@ endif::[]
 
 === processor_latency_ns
 
-Benthos Timing metric.
+Processing time in nanoseconds of a Redpanda Connect pipeline processor.
 
 *Type*: summary
 
@@ -1396,7 +1396,7 @@ endif::[]
 
 === processor_received
 
-Benthos Counter metric.
+Number of records received as input in a Redpanda Connect pipeline processor.
 
 *Type*: counter
 
@@ -1408,7 +1408,7 @@ endif::[]
 
 === processor_sent
 
-Benthos Counter metric.
+Number of records produced as output by a Redpanda Connect pipeline processor.
 
 *Type*: counter
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1105,7 +1105,7 @@ Resource limits for the Serverless cluster:
 - Egress quota
 - Connection quota
 
-To increase resouce limits, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+To increase resource limits, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 *Type*: gauge
 

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -912,7 +912,7 @@ Total count of node status RPCs that timed out on a broker.
 
 === input_connection_failed
 
-Benthos Counter metric.
+Number of input connections to the Redpanda Connect pipeline that have failed. 
 
 *Type*: counter
 
@@ -928,7 +928,7 @@ Benthos Counter metric.
 
 === input_connection_up
 
-Benthos Counter metric.
+Number of active input connections to the Redpanda Connect pipeline. 
 
 *Type*: counter
 
@@ -936,7 +936,7 @@ Benthos Counter metric.
 
 === input_latency_ns
 
-Benthos Timing metric.
+Input latency for the Redpanda Connect pipeline.
 
 *Type*: summary
 
@@ -944,7 +944,7 @@ Benthos Timing metric.
 
 === input_received
 
-Benthos Counter metric.
+Number of records received by the Redpanda Connect pipeline.
 
 *Type*: counter
 
@@ -960,7 +960,7 @@ Benthos Counter metric.
 
 === output_connection_failed
 
-Benthos Counter metric.
+Number of output connections from the Redpanda Connect pipeline that have failed. 
 
 *Type*: counter
 
@@ -976,7 +976,7 @@ Benthos Counter metric.
 
 === output_connection_up
 
-Benthos Counter metric.
+Number of active output connections from the Redpanda Connect pipeline. 
 
 *Type*: counter
 
@@ -984,7 +984,7 @@ Benthos Counter metric.
 
 === output_error
 
-Benthos Counter metric.
+Number of errors encountered in the Redpanda Connect pipeline output.
 
 *Type*: counter
 
@@ -992,7 +992,7 @@ Benthos Counter metric.
 
 === output_latency_ns
 
-Benthos Timing metric.
+Output latency for the Redpanda Connect pipeline.
 
 *Type*: summary
 
@@ -1000,7 +1000,7 @@ Benthos Timing metric.
 
 === output_sent
 
-Benthos Counter metric.
+Records sent by the Redpanda Connect pipeline.
 
 *Type*: counter
 
@@ -1097,7 +1097,15 @@ Total duration (in seconds) of client connections.
 
 === redpanda_serverless_resource_limit
 
-Resource limits for the Serverless cluster. To increase resouce limits, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+Resource limits for the Serverless cluster:
+
+- Partition quota
+- Topic quota
+- Ingress quota
+- Egress quota
+- Connection quota
+
+To increase resouce limits, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 *Type*: gauge
 

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate-grafana-dashboard.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate-grafana-dashboard.adoc
@@ -26,15 +26,19 @@ You can select one of the following dashboard types:
 |===
 |*Name* |*Description*
 
-|consumer-metrics |Allows for monitoring of Java Kafka consumers, using
+|consumer-metrics |Monitoring of Java Kafka consumers, using
 the Prometheus JMX Exporter and the Kafka Sample Configuration.
 
 |consumer-offsets |Metrics and KPIs that provide details of topic
 consumers and how far they are lagging behind the end of the log.
 
-|operations [default] |Provides an overview of KPIs for a Redpanda
+|operations (default) |Provides an overview of KPIs for a Redpanda
 cluster with health indicators. This is suitable for ops or SRE to
 monitor on a daily or continuous basis.
+
+ifdef::env-cloud[]
+|serverless |Monitoring dashboard for Redpanda Serverless clusters.
+endif::[]
 
 |topic-metrics |Provides throughput, read/write rates, and on-disk sizes
 of each/all topics.
@@ -58,7 +62,7 @@ rpk generate grafana-dashboard [flags]
 |*Value* |*Type* |*Description*
 
 |--dashboard |string |The name of the dashboard you wish to download.
-Use --dashboard help for more info (default "operations")
+Use --dashboard help for more info (default: `operations`).
 
 |-h, --help |- |Help for grafana-dashboard.
 


### PR DESCRIPTION
## Description

Related PR: https://github.com/redpanda-data/cloud-docs/pull/471

This pull request adds new Serverless and RPCN metrics to the `modules/reference/pages/public-metrics-reference.adoc` file, which is single-sourced across Self-managed and Cloud docs.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
