### PR TITLE
DOC-1855 SR support for SASL/PLAIN in SM

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1621-Document-Cloud-Feature-Shadowing-Disaster-Recovery-Enterprise'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -17,7 +17,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1621-Document-Cloud-Feature-Shadowing-Disaster-Recovery-Enterprise'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -93,7 +93,7 @@ This service account authenticates from the shadow cluster to the source cluster
 You must configure network connectivity between clusters with appropriate firewall rules to allow the shadow cluster to connect to the source cluster for data replication. Shadowing uses a pull-based architecture where the shadow cluster fetches data from the source cluster. For detailed networking configuration, see <<networking>>.
 
 ifndef::env-cloud[]
-If using xref:manage:security/authentication.adoc[authentication] for the shadow link connection, configure the source cluster with your chosen authentication method (SASL/SCRAM, TLS, mTLS) and ensure the shadow cluster has the proper credentials to authenticate to the source cluster.
+If using xref:manage:security/authentication.adoc[authentication] for the shadow link connection, configure the source cluster with your chosen authentication method (SASL/SCRAM, SASL/PLAIN, TLS, mTLS) and ensure the shadow cluster has the proper credentials to authenticate to the source cluster.
 endif::[]
 
 ifdef::env-cloud[]
@@ -156,10 +156,17 @@ client_options:
     do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
   
   authentication_configuration:
+    # SASL/SCRAM authentication
     scram_configuration:
       username: <sasl-username>       # SASL/SCRAM username, example: "shadow-replication-user"
       password: <sasl-password>       # SASL/SCRAM password, example: "secure-password-123"
       scram_mechanism: SCRAM_SHA_256  # SCRAM mechanism: "SCRAM_SHA_256" or "SCRAM_SHA_512"
+ifndef::env-cloud[]
+    # SASL/PLAIN authentication
+    plain_configuration:
+      username: <sasl-username>       # SASL/PLAIN username, example: "shadow-replication-user"
+      password: <sasl-password>       # SASL/PLAIN password, example: "secure-password-123"
+endif::[]
   
   # Connection tuning - adjust based on network characteristics
   metadata_max_age_ms: 10000          # How often to refresh cluster metadata (default: 10000ms)
@@ -476,10 +483,17 @@ client_options:
 ----
 client_options:
   authentication_configuration:
+    # SASL/SCRAM authentication
     scram_configuration:
       username: <sasl-username>       # SASL/SCRAM username, example: "shadow-replication-user"
       password: <sasl-password>       # SASL/SCRAM password, example: "secure-password-123"
       scram_mechanism: SCRAM_SHA_256  # SCRAM mechanism: "SCRAM_SHA_256" or "SCRAM_SHA_512"
+ifndef::env-cloud[]
+    # SASL/PLAIN authentication
+    plain_configuration:
+      username: <sasl-username>       # SASL/PLAIN username, example: "shadow-replication-user"
+      password: <sasl-password>       # SASL/PLAIN password, example: "secure-password-123"
+endif::[]
 ----
 
 ==== Connection tuning


### PR DESCRIPTION
## Description
This pull request adds support for SASL/PLAIN authentication alongside existing methods for Self-Managed.

* Explicitly add SASL/PLAIN as a supported authentication method for the shadow link connection, updating instructions to mention SASL/SCRAM, SASL/PLAIN, TLS, and mTLS.
* Add configuration examples for SASL/PLAIN authentication (`plain_configuration`) in the `client_options` sections, alongside existing SASL/SCRAM examples, and ensure these are documented for non-cloud environments. [[1]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R159-R169) [[2]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R486-R496)
* Temporarily changed the referenced branch for `cloud-docs` in `local-antora-playbook.yml` from `main` to `DOC-1621-Document-Cloud-Feature-Shadowing-Disaster-Recovery-Enterprise` to show preview docs in Cloud don't contain this.

Resolves https://redpandadata.atlassian.net/browse/DOC-1855
Review deadline:

## Page previews
[Configure Shadowing: SM](https://deploy-preview-1510--redpanda-docs-preview.netlify.app/current/manage/disaster-recovery/shadowing/setup/) (search for PLAIN)
[Configure Shadowing: Cloud](https://deploy-preview-1510--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/setup/) (search for PLAIN)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
