### PR TITLE
updates for UI

### DIFF
--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -98,7 +98,7 @@ Cloud UI::
 +
 --
 . From the *Shadow Link* page, select the shadow link you want to view. 
-. The Overview tab shows the state of the shadow link and its topics.
+. The *Overview* tab shows the state of the shadow link and its topics.
 --
 
 rpk::

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -97,7 +97,8 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+. From the *Shadow Link* page, select the shadow link you want to view. 
+. The Overview tab shows the state of the shadow link and its topics.
 --
 
 rpk::
@@ -168,7 +169,7 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+Capture the status from the *Shadow Link* page. 
 --
 
 rpk::
@@ -266,7 +267,8 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+. On your *Shadow Link* page, click *Failover All Topics*.
+. Click to confirm the failover action. The failover process promotes all topics to writable status.
 --
 
 rpk::
@@ -308,7 +310,8 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+. On your *Shadow Link* page, click the *Failover* button for the topics you want to failover. 
+. Click to confirm the failover action. The failover process promotes the selected topics to writable status.
 --
 
 rpk::
@@ -386,7 +389,8 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+. From the *Shadow Link* page, select the shadow link you want to view. 
+. Click the *Tasks* tab to view all tasks and their status. 
 --
 
 rpk::
@@ -460,7 +464,7 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+On your *Shadow Link* page, click *Delete*. 
 --
 
 rpk::
@@ -519,7 +523,7 @@ ifdef::env-cloud[]
 Cloud UI::
 +
 --
-<!-- Content to be added later -->
+All failover actions in the Cloud UI include force delete functionality by default. When you failover a shadow link, all topics are immediately promoted to writable status.
 --
 
 rpk::

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -94,6 +94,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -159,6 +165,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -251,6 +263,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -287,6 +305,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -359,6 +383,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -427,6 +457,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --
@@ -480,6 +516,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+<!-- Content to be added later -->
+--
+
 rpk::
 +
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover.adoc
@@ -72,6 +72,14 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. On the *Shadow Link* page, select your shadow link. 
+. For any of the topics you want to failover, click the corresponding *Failover* button.
+. Click to confirm the failover action. The failover process promotes the selected topics to writable status.
+--
+
 rpk::
 +
 --
@@ -114,6 +122,14 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. On the *Shadow Link* page, select your shadow link. 
+. Click *Failover All Topics*.
+. Click to confirm the failover action. The failover process promotes all topics to writable status.
+--
+
 rpk::
 +
 --
@@ -156,6 +172,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+All failover actions in the Cloud UI include force delete functionality by default. When you failover a shadow link, all topics are immediately promoted to writable status.
+--
+
 rpk::
 +
 --
@@ -223,6 +245,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+Track the progress of failover operations from the *Shadow Link* page in the Cloud UI.
+--
+
 rpk::
 +
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -17,7 +17,7 @@ include::shared:partial$emergency-shadowing-callout.adoc[]
 
 == Status commands
 
-To list existing shadow links, run:
+To list existing shadow links:
 
 ifndef::env-cloud[]
 // tag::rpk-tab-list-links[]
@@ -31,6 +31,12 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+At the organization level of the Cloud UI, navigate to *Shadow Link*.
+--
+
 rpk::
 +
 --
@@ -50,7 +56,7 @@ curl 'https://api.redpanda.com/v1/shadow-links' \
 ======
 endif::[]
 
-To view shadow link configuration details, run:
+To view shadow link configuration details:
 
 ifndef::env-cloud[]
 // tag::rpk-tab-view-link-details[]
@@ -66,6 +72,13 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. From the *Shadow Link* page, select the shadow link you want to view. 
+. Click the *Tasks* tab to view all tasks and their status. 
+--
+
 rpk::
 +
 --
@@ -85,7 +98,7 @@ curl 'https://api.redpanda.com/v1/shadow-links/<shadow-link-id>' \
 ======
 endif::[]
 
-To check your shadow link status and ensure proper operation, run:
+To check your shadow link status and ensure proper operation:
 
 ifndef::env-cloud[]
 // tag::rpk-tab-shadow-status[]
@@ -99,6 +112,15 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. From the *Shadow Link* page, select the shadow link you want to view. 
+. Click the *Tasks* tab to view all tasks and their status. 
+
+The response includes the following:
+--
+
 rpk::
 +
 --
@@ -197,6 +219,13 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. From the *Shadow Link* page, select the shadow link you want to view. 
+. Click the *Tasks* tab to view all tasks and their status. 
+--
+
 rpk::
 +
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -147,7 +147,7 @@ curl "https://$DATAPLANE_API_URL/v1/shadowlinks/<shadow-link-name>/topic" \
 --
 ======
 
-The responses include the following:
+The status includes the following:
 endif::[]
 
 * **Shadow link state**: Overall operational state (`ACTIVE`, `PAUSED`).

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -117,8 +117,6 @@ Cloud UI::
 --
 . From the *Shadow Link* page, select the shadow link you want to view. 
 . Click the *Tasks* tab to view all tasks and their status. 
-
-The response includes the following:
 --
 
 rpk::

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -16,7 +16,7 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 endif::[]
 
-Shadowing is Redpanda's enterprise-grade disaster recovery solution that establishes asynchronous, offset-preserving replication between two distinct Redpanda clusters. A cluster is able to create a dedicated client that continuously replicates source cluster data, including offsets, timestamps, and cluster metadata. This creates a read-only shadow cluster that you can quickly failover to handle production traffic during a disaster.
+Shadowing is Redpanda's enterprise-grade disaster recovery solution that establishes asynchronous, offset-preserving replication between two distinct Redpanda clusters. A cluster is able to create a dedicated client that continuously replicates source cluster data, including offsets, timestamps, and cluster metadata. This creates a read-only shadow cluster that you can quickly failover to handle production traffic during a disaster. Shadowing keeps data flowing, even during regional outages. 
 
 include::shared:partial$emergency-shadowing-callout.adoc[]
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -61,7 +61,7 @@ Shadowing for disaster recovery currently has the following limitations:
 
 == Shadow link tasks
 
-Shadow linking operates through specialized tasks that handle different aspects of replication. Each task corresponds to a configuration section in your shadow link setup and runs continuously to maintain synchronization with the source cluster.
+Shadow linking operates through specialized tasks that handle different aspects of replication. If you use a `shadow-config.yaml` configuration file to create the shadow link, each task corresponds to a section in the file. Tasks run continuously to maintain synchronization with the source cluster.
 
 [tabs]
 ====
@@ -71,7 +71,7 @@ Source Topic Sync::
 [#source-topic-sync-task]
 The **Source Topic Sync task** manages topic discovery and metadata synchronization. This task periodically queries the source cluster to discover available topics, applies your configured topic filters to determine which topics should become shadow topics, and synchronizes topic properties between clusters.
 
-The task is controlled by the `topic_metadata_sync_options` configuration section, which includes:
+The task is controlled by the `topic_metadata_sync_options` section in the configuration file. It includes:
 
 * **Auto-creation filters**: Determines which source topics automatically become shadow topics
 * **Property synchronization**: Controls which topic properties replicate from source to shadow
@@ -87,7 +87,7 @@ Consumer Group Shadowing::
 [#consumer-group-shadowing-task]
 The **Consumer Group Shadowing task** replicates consumer group offsets and membership information from the source cluster. This ensures that consumer applications can resume processing from the correct position after failover.
 
-The task is controlled by the `consumer_offset_sync_options` configuration section, which includes:
+The task is controlled by the `consumer_offset_sync_options` section in the configuration file. It includes:
 
 * **Group filters**: Determines which consumer groups have their offsets replicated
 * **Sync interval**: How frequently to synchronize consumer group offsets
@@ -102,7 +102,7 @@ Security Migrator::
 [#security-migrator-task]
 The **Security Migrator task** replicates security policies, primarily ACLs (access control lists), from the source cluster to maintain consistent authorization across both environments.
 
-The task is controlled by the `security_sync_options` configuration section, which includes:
+The task is controlled by the `security_sync_options` section in the configuration file. It includes:
 
 * **ACL filters**: Determines which security policies replicate
 * **Sync interval**: How frequently to synchronize security settings

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -137,7 +137,13 @@ rpk shadow config generate --for-cloud -o shadow-config.yaml
 endif::[]
 ----
 
+ifndef::env-cloud[]
 This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-config-generate.adoc[`rpk shadow config generate`].
+endif::[]
+
+ifdef::env-cloud[]
+This creates a complete YAML configuration file that you can customize for your environment. The template includes all available fields with comments explaining their purpose. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-config-generate.adoc[`rpk shadow config generate --for-cloud`].
+endif::[]
 ====
 
 .Explore the configuration file
@@ -146,19 +152,47 @@ This creates a complete YAML configuration file that you can customize for your 
 [,yaml]
 ----
 # Sample ShadowLinkConfig YAML with all fields
-name: <shadow-link-name>              # Unique name for this shadow link, example: "production-dr"
+ 
+name: <shadow-link-name>            # Unique name for this shadow link, example: "production-dr"
+
 ifdef::env-cloud[]
 cloud_options:
-  source_redpanda_id: <source-cluster-id>   # Source cluster ID in Redpanda Cloud
-  shadow_redpanda_id: <shadow-cluster-id>   # Shadow cluster ID in Redpanda Cloud
+# Use either source_redpanda_id or bootstrap_servers: only one is required.
+  source_redpanda_id: <source-cluster-id>    # Optional: 20 character lowercase ID of the cluster 
+                                             # Example: m7xtv2qq5njbhwruk88f
+  shadow_redpanda_id: <shadow-cluster-id>    # 20 character lowercase ID of the cluster
+                                             # Example: m7xtv2qq5njbhwruk88f
 endif::[]
 client_options:
-  bootstrap_servers:                  # Source cluster brokers to connect to
-  - <source-broker-1>:<port>          # Example: "prod-kafka-1.example.com:9092"
-  - <source-broker-2>:<port>          # Example: "prod-kafka-2.example.com:9092"
-  - <source-broker-3>:<port>          # Example: "prod-kafka-3.example.com:9092"
-  source_cluster_id: <cluster-id>     # Optional: Expected source cluster ID for validation, example: "prod-cluster-123"
-  
+  bootstrap_servers:                         # Source cluster brokers to connect to
+  - <source-broker-1>:<port>                 # Example: "prod-kafka-1.example.com:9092"
+  - <source-broker-2>:<port>                 # Example: "prod-kafka-2.example.com:9092"
+  - <source-broker-3>:<port>                 # Example: "prod-kafka-3.example.com:9092"
+  source_cluster_id: <cluster-id>            # Optional: UUID assigned by Redpanda 
+                                             # Example: a882bc98-7aca-40f6-a657-36a0b4daf1fd
+ifndef::env-cloud[]
+# To get source_cluster_id, run `rpk cluster config get cluster_id`.
+endif::[]
+ifdef::env-cloud[]
+# This UUID is not available in Redpanda Cloud. 
+endif::[]  
+
+ifdef::env-cloud[]
+  # TLS settings using PEM strings
+  tls_settings:
+    enabled: true
+    tls_pem_settings:
+      ca: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: ${secrets.KEY_FROM_SHADOW_CLUSTER_SECRET_STORE} # dataplane secret in the shadow cluster
+      cert: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+endif::[]
+ifndef::env-cloud[]
   # TLS settings using file paths
   tls_settings:
     enabled: true                     # Enable TLS
@@ -167,10 +201,11 @@ client_options:
       key_path: <client-key-path>     # Optional: Path to client private key, example: "/etc/ssl/private/client.key"
       cert_path: <client-cert-path>   # Optional: Path to client certificate, example: "/etc/ssl/certs/client.crt"
     do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
-  
-  # Create SASL credentials in the source cluster.
-  # Then, with this configuration, ensure the shadow cluster uses the credentials 
-  # to authenticate to the source cluster.
+endif::[]
+
+# Create SASL credentials in the source cluster.
+# Then, with this configuration, ensure the shadow cluster uses the credentials 
+# to authenticate to the source cluster.
   authentication_configuration:
     # SASL/SCRAM authentication
     scram_configuration:
@@ -269,7 +304,7 @@ endif::[]
 
 // Use tabs and display the tagged content above inside the rpk tab
 ifdef::env-cloud[]
-Because the shadow cluster pulls from the source cluster, the shadow cluster requires credentials to connect to the source cluster. And because you cannot store plaintext passwords in Redpanda Cloud, you must create a secret to hold the password for the user on the source cluster.
+Because the shadow cluster pulls from the source cluster, the shadow cluster requires credentials to connect to the source cluster. And because you cannot store plaintext passwords in Redpanda Cloud, you must create a secret to hold the password for the user on the source cluster. If using mTLS, you must also create a secret to hold the key of the client certificate for the client to authenticate. Reference that secret in `client_options.tls_settings.key_file` in the configuration file.
 
 . In the shadow cluster, create the secret:
 +
@@ -278,7 +313,7 @@ Because the shadow cluster pulls from the source cluster, the shadow cluster req
 Cloud UI::
 +
 --
-In the shadow cluster, go to the *Secrets Store* page and create a secret for the source cluster user, scoped to Redpanda Cluster.
+In the shadow cluster, go to the [*Secrets Store*] page and create a secret for the source cluster user, scoped to Redpanda Cluster.
 
 If necessary, first create the user with all ACLs enabled in the source cluster.
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -278,8 +278,8 @@ Use one of the following to create a secret:
 Cloud UI::
 +
 --
-. The user creating the shadow link must have all ACLs enabled. If necessary, create a new user on the *Security* page.
-. Go to the *Secrets Store* page of your shadow cluster to create the secret.
+. The user creating the shadow link must have all ACLs enabled. If necessary, create a new user on the shadow cluster's *Security* page.
+. Go to the shadow cluster's *Secrets Store* page to create the secret.
 --
 
 rpk::
@@ -305,7 +305,7 @@ Cloud UI::
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
 . Click *Create shadow link*. 
 . Enter a name for the shadow link.
-. Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. 
+. Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. If you select an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
 . Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
 . Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -102,7 +102,7 @@ endif::[]
 
 == Set up Shadowing
 
-To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, and ACLs to replicate. 
+To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, ACLs, and Schema Registry data to replicate. 
 
 ifdef::env-cloud[]
 If using the Cloud API to set up Shadowing, you must link:/api/doc/cloud-controlplane/authentication[authenticate] to the API by including an access token in your requests.
@@ -309,7 +309,7 @@ Cloud UI::
 -- 
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
 . Click *Create shadow link*. 
-. Enter a name for the shadow link.
+. Enter a unique name for the shadow link. The name must start and end with lowercase alphanumeric characters, hyphens allowed.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. For an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
 . Enter the authorization and authentication details for the source cluster, including the user and the name of the secret containing the password created in the previous step.
 . Optionally, expand *Advanced options* to configure client connection properties. 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -313,7 +313,7 @@ Because the shadow cluster pulls from the source cluster, the shadow cluster req
 Cloud UI::
 +
 --
-In the shadow cluster, go to the [*Secrets Store*] page and create a secret for the source cluster user, scoped to Redpanda Cluster.
+In the shadow cluster, go to the *Secrets Store* page and create a secret for the source cluster user, scoped to Redpanda Cluster.
 
 If necessary, first create the user with all ACLs enabled in the source cluster.
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -713,7 +713,7 @@ Cloud UI::
 --
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
 . Select the shadow link you want to modify, and click *Edit*.
-. Make any changes to the source cluster settings or the content shadowed (topics, ACLs, consumer groups, Schema Registry). You can also enable additional topic properties or disable optional topic properties from being shadowed. 
+. Edit the shadow link settings or the shadowing behavior by specifying which content from the source cluster to shadow (topics, ACLs, consumer groups, Schema Registry). You can also enable additional topic properties to be shadowed or disable optional topic properties from being included in the shadowing.
 . Click *Save* to apply changes. 
 --
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -104,14 +104,9 @@ endif::[]
 
 To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, and ACLs to replicate. 
 
-[NOTE] 
-====
-Not all topic properties are configurable in {ui}. For advanced configuration, use `rpk` or the API. 
-
 ifdef::env-cloud[]
 If using the Cloud API to set up Shadowing, you must link:/api/doc/cloud-controlplane/authentication[authenticate] to the API by including an access token in your requests.
 endif::[]
-====
 
 === Create a shadow link
 
@@ -312,7 +307,7 @@ Cloud UI::
 . Enter a name for the shadow link.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. 
 . Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
-. Optionally, expand *Advanced settings* to configure topic properties. Not all topic properties are configurable in the Cloud UI. For advanced configuration, use `rpk` or the Control Plane API.
+. Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 
 --
 
@@ -718,7 +713,7 @@ Cloud UI::
 --
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
 . Select the shadow link you want to modify, and click *Edit*.
-. Make any changes to the source cluster settings, the content shadowed (topics, ACLs, consumer groups, and Schema Registry), or whether the topic properties are shadowed.
+. Make any changes to the source cluster settings or the content shadowed (topics, ACLs, consumer groups, Schema Registry). You can also enable additional topic properties or disable optional topic properties from being shadowed. 
 . Click *Save* to apply changes. 
 --
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -106,7 +106,7 @@ To set up Shadowing, you need to create a shadow link and configure filters to s
 
 [NOTE] 
 ====
-Not all filters are available in {ui}. For full filter configuration, use `rpk` or the API. 
+Not all topic properties are configurable in {ui}. For advanced configuration, use `rpk` or the API. 
 
 ifdef::env-cloud[]
 If using the Cloud API to set up Shadowing, you must link:/api/doc/cloud-controlplane/authentication[authenticate] to the API by including an access token in your requests.
@@ -312,7 +312,7 @@ Cloud UI::
 . Enter a name for the shadow link.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. 
 . Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
-. Optionally, expand Advanced settings to configure topic filters. Not all filters are available in the Cloud UI. For full filter configuration, use `rpk` or the Control Plane API.
+. Optionally, expand Advanced settings to configure topic properties. Not all topic properties are configurable in the Cloud UI. For advanced configuration, use `rpk` or the Control Plane API.
 . Click *Save* to apply changes. 
 --
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -186,7 +186,7 @@ ifdef::env-cloud[]
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----
-      key: ${secrets.KEY_FROM_SHADOW_CLUSTER_SECRET_STORE} # dataplane secret in the shadow cluster
+      key: ${secrets.KEY_FROM_SHADOW_CLUSTER_SECRET_STORE}
       cert: |-
         -----BEGIN CERTIFICATE-----
         ...
@@ -346,7 +346,7 @@ Cloud UI::
 . Click *Create shadow link*. 
 . Enter a unique name for the shadow link. The name must start and end with lowercase alphanumeric characters, hyphens allowed.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. For an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
-. Enter the authorization and authentication details for the source cluster, including the user and the name of the secret containing the password created in the previous step.
+. Enter the authorization and authentication details from the source cluster, including the user and the name of the secret containing the password created in the previous step.
 . Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 
 --
@@ -669,6 +669,7 @@ The shadow cluster uses these addresses to discover all brokers in the source cl
 
 For production deployments, secure the network connection between clusters:
 
+ifndef::env-cloud[]
 .TLS encryption:
 [,yaml]
 ----
@@ -681,6 +682,28 @@ client_options:
       cert_path: <client-cert-path>   # Optional: Path to client certificate, example: "/etc/ssl/certs/client.crt"
     do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
 ----
+endif::[]
+
+ifdef::env-cloud[]
+.TLS encryption:
+[,yaml]
+----
+client_options:
+  tls_settings:
+    enabled: true                     # Enable TLS
+    tls_pem_settings:
+      ca: |-                          # CA certificate in PEM format
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: ${secrets.KEY_FROM_SHADOW_CLUSTER_SECRET_STORE}  # Client private key (can use secrets reference)
+      cert: |-                        # Optional: Client certificate in PEM format for mutual TLS
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+    do_not_set_sni_hostname: false   # Optional: Skip SNI hostname when using TLS (default: false)
+----
+endif::[]
 
 .Authentication:
 [,yaml]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -312,7 +312,7 @@ Cloud UI::
 . Enter a name for the shadow link.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. 
 . Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
-. Optionally, expand Advanced settings to configure topic properties. Not all topic properties are configurable in the Cloud UI. For advanced configuration, use `rpk` or the Control Plane API.
+. Optionally, expand *Advanced settings* to configure topic properties. Not all topic properties are configurable in the Cloud UI. For advanced configuration, use `rpk` or the Control Plane API.
 . Click *Save* to apply changes. 
 --
 
@@ -717,8 +717,7 @@ Cloud UI::
 +
 --
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
-. Select the shadow link you want to edit. 
-. Click *Edit*.
+. Select the shadow link you want to modify, and click *Edit*.
 . Make any changes to the source cluster settings, the content shadowed (topics, ACLs, consumer groups, and Schema Registry), or whether the topic properties are shadowed.
 . Click *Save* to apply changes. 
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -278,8 +278,9 @@ Use one of the following to create a secret:
 Cloud UI::
 +
 --
-. The user creating the shadow link must have all ACLs enabled. If necessary, create a new user on the shadow cluster's *Security* page.
+. A user on the shadow cluster must have all ACLs enabled. If necessary, create a new user on the shadow cluster's *Security* page.
 . Go to the shadow cluster's *Secrets Store* page to create the secret.
+. Set *Scopes* to Redpanda Cluster.
 --
 
 rpk::
@@ -306,7 +307,7 @@ Cloud UI::
 . Click *Create shadow link*. 
 . Enter a name for the shadow link.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. For an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
-. Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
+. Enter the authorization and authentication details for the source cluster, including the user with all ACLs enabled and the name of the secret containing the password.
 . Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -305,7 +305,7 @@ Cloud UI::
 . At the organization level of the Cloud UI, navigate to *Shadow Link*.
 . Click *Create shadow link*. 
 . Enter a name for the shadow link.
-. Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. If you select an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
+. Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. For an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
 . Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
 . Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -104,18 +104,23 @@ endif::[]
 
 To set up Shadowing, you need to create a shadow link and configure filters to select which topics, consumer groups, and ACLs to replicate. 
 
+[NOTE] 
+====
+Not all filters are available in {ui}. For full filter configuration, use `rpk` or the API. 
+
 ifdef::env-cloud[]
 If using the Cloud API to set up Shadowing, you must link:/api/doc/cloud-controlplane/authentication[authenticate] to the API by including an access token in your requests.
 endif::[]
+====
 
 === Create a shadow link
 
 ifndef::env-cloud[]
-Any cluster can create a shadow link to a source cluster. When you create a shadow link with `rpk` or the API, you need to provide a YAML configuration that defines connection settings, filters, and synchronization options.
+Any cluster can create a shadow link to a source cluster. 
 endif::[]
 
 ifdef::env-cloud[]
-Any BYOC or Dedicated cluster can create a shadow link to a source cluster. When you create a shadow link with `rpk` or the API, you need to provide a YAML configuration that defines connection settings, filters, and synchronization options.
+Any BYOC or Dedicated cluster can create a shadow link to a source cluster. 
 endif::[]
 
 [TIP]
@@ -273,14 +278,44 @@ ifdef::env-cloud[]
 +
 Use one of the following to create a secret:
 +
-- In the Redpanda Cloud UI, the *Secrets Store* page of your cluster
-- xref:reference:rpk/rpk-security/rpk-security-secret-create.adoc[`rpk security secret create`]
-- The xref:manage:api/cloud-dataplane-api.adoc[Data Plane API]
+[tabs]
+======
+Cloud UI::
++
+--
+. The user creating the shadow link must have all ACLs enabled. If necessary, create a new user on the *Security* page.
+. Go to the *Secrets Store* page of your shadow cluster to create the secret.
+--
+
+rpk::
++
+--
+Use xref:reference:rpk/rpk-security/rpk-security-secret-create.adoc[`rpk security secret create`] to create the secret from the command line.
+--
+
+Data Plane API::
++
+--
+Use the xref:manage:api/cloud-dataplane-api.adoc[Data Plane API] to programmatically create the secret.
+--
+======
 
 . In the shadow cluster, create a shadow link to the source cluster.
 +
 [tabs]
 ======
+Cloud UI::
++
+-- 
+. At the organization level of the Cloud UI, navigate to *Shadow Link*.
+. Click *Create shadow link*. 
+. Enter a name for the shadow link.
+. Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. 
+. Enter the authorization and authentication details for the source cluster, including the username and the name of the secret containing the password.
+. Optionally, expand Advanced settings to configure topic filters. Not all filters are available in the Cloud UI. For full filter configuration, use `rpk` or the Control Plane API.
+. Click *Save* to apply changes. 
+--
+
 rpk::
 +
 --
@@ -678,6 +713,16 @@ endif::[]
 ifdef::env-cloud[]
 [tabs]
 ======
+Cloud UI::
++
+--
+. At the organization level of the Cloud UI, navigate to *Shadow Link*.
+. Select the shadow link you want to edit. 
+. Click *Edit*.
+. Make any changes to the source cluster settings, the content shadowed (topics, ACLs, consumer groups, and Schema Registry), or whether the topic properties are shadowed.
+. Click *Save* to apply changes. 
+--
+
 rpk::
 +
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -785,5 +785,5 @@ For the full API reference, see link:/api/doc/cloud-controlplane/v1/operation/op
 ======
 endif::[]
 // end::single-source[]
-
+ 
 See also: link:/api/doc/admin/v2/[Admin API v2 reference^]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -116,8 +116,6 @@ endif::[]
 
 ifdef::env-cloud[]
 Any BYOC or Dedicated cluster can create a shadow link to a source cluster. 
-
-Because the shadow cluster pulls from the source cluster, the shadow cluster requires credentials to connect to the source cluster. And because you cannot store plaintext passwords in Redpanda Cloud, you must create a secret to hold the password for the user on the source cluster.
 endif::[]
 
 [TIP]
@@ -271,6 +269,8 @@ endif::[]
 
 // Use tabs and display the tagged content above inside the rpk tab
 ifdef::env-cloud[]
+Because the shadow cluster pulls from the source cluster, the shadow cluster requires credentials to connect to the source cluster. And because you cannot store plaintext passwords in Redpanda Cloud, you must create a secret to hold the password for the user on the source cluster.
+
 . In the shadow cluster, create the secret:
 +
 [tabs]

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -116,6 +116,8 @@ endif::[]
 
 ifdef::env-cloud[]
 Any BYOC or Dedicated cluster can create a shadow link to a source cluster. 
+
+Because the shadow cluster pulls from the source cluster, the shadow cluster requires credentials to connect to the source cluster. And because you cannot store plaintext passwords in Redpanda Cloud, you must create a secret to hold the password for the user on the source cluster.
 endif::[]
 
 [TIP]
@@ -269,29 +271,31 @@ endif::[]
 
 // Use tabs and display the tagged content above inside the rpk tab
 ifdef::env-cloud[]
-. In the shadow cluster, create a secret to store the authentication credential that the cluster will use (`"scram_configuration": "password"` in the example configuration in the next step). Your secret must be scoped to "Redpanda Cluster".
-+
-Use one of the following to create a secret:
+. In the shadow cluster, create the secret:
 +
 [tabs]
 ======
 Cloud UI::
 +
 --
-. A user on the shadow cluster must have all ACLs enabled. If necessary, create a new user on the shadow cluster's *Security* page.
-. Go to the shadow cluster's *Secrets Store* page to create the secret.
-. Set *Scopes* to Redpanda Cluster.
+In the shadow cluster, go to the *Secrets Store* page and create a secret for the source cluster user, scoped to Redpanda Cluster.
+
+If necessary, first create the user with all ACLs enabled in the source cluster.
 --
 
 rpk::
 +
 --
+In the shadow cluster, create a secret to store the authentication credential that the cluster will use (`"scram_configuration": "password"` in the example configuration in the next step). Your secret must be scoped to "Redpanda Cluster".
+
 Use xref:reference:rpk/rpk-security/rpk-security-secret-create.adoc[`rpk security secret create`] to create the secret from the command line.
 --
 
 Data Plane API::
 +
 --
+In the shadow cluster, create a secret to store the authentication credential that the cluster will use (`"scram_configuration": "password"` in the example configuration in the next step). Your secret must be scoped to "Redpanda Cluster".
+
 Use the xref:manage:api/cloud-dataplane-api.adoc[Data Plane API] to programmatically create the secret.
 --
 ======
@@ -307,7 +311,7 @@ Cloud UI::
 . Click *Create shadow link*. 
 . Enter a name for the shadow link.
 . Select the source cluster from which data will be replicated. You can select an existing Redpanda Cloud cluster, or you can enter a bootstrap server URL to connect to any Kafka-compatible cluster. For an existing Redpanda Cloud cluster, you select the specific cluster on the next page. 
-. Enter the authorization and authentication details for the source cluster, including the user with all ACLs enabled and the name of the secret containing the password.
+. Enter the authorization and authentication details for the source cluster, including the user and the name of the secret containing the password created in the previous step.
 . Optionally, expand *Advanced options* to configure client connection properties. 
 . Click *Save* to apply changes. 
 --

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -704,7 +704,7 @@ ifndef::env-cloud[]
     # SASL/PLAIN authentication
     plain_configuration:
       username: <sasl-username>       # SASL/PLAIN username, example: "shadow-replication-user"
-      password: <sasl-password>       # SASL/PLAIN password, example: "secure-password-123"
+      password: <sasl-password>       # SASL/PLAIN password, example: ${secrets.SASL_SECRET}
 endif::[]
 ----
 


### PR DESCRIPTION
## Description
This pull request adds Cloud UI workflows to the disaster recovery shadowing guides. It introduces Cloud UI instructions alongside existing `rpk` and API steps using tabs, plus some general improvements to wording and organization.

* Added Cloud UI instructions as a tabbed option in multiple locations. [[1]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR97-R102) [[2]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR168-R173) [[3]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR249-R254) [[4]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR291-R296) [[5]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR369-R374) [[6]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR443-R448) [[7]](diffhunk://#diff-2caaee7a7fdd71e6bc315efcdee281499136240f8c84211e6ee8bc58042bf23cR496-R501)
* Clarifyied property limitations in the Cloud UI and directed users to `rpk` or the API for full configuration in `setup.adoc`.
* Refactored secret creation instructions to use tabs for Cloud UI, `rpk`, and API methods, and added step-by-step Cloud UI guidance for shadow link creation and editing. [[1]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7L265-R307) [[2]](diffhunk://#diff-11f9a8ee158683c0fea693d9138ed1e0f4891e9e9c165538a081786b1f1c28d7R698-R707)
* Improved wording for listing and viewing shadow links and configuration details, making instructions clearer and more consistent. [[1]](diffhunk://#diff-088a4519e87e79d8409ccc68d47c11f470716be741575467fdd0ee22c0dac706L20-R20) [[2]](diffhunk://#diff-088a4519e87e79d8409ccc68d47c11f470716be741575467fdd0ee22c0dac706L53-R59) [[3]](diffhunk://#diff-088a4519e87e79d8409ccc68d47c11f470716be741575467fdd0ee22c0dac706L88-R101)

## Page previews
[Configure](https://deploy-preview-1511--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/setup/)
[Monitor](https://deploy-preview-1511--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/monitor/)
[Failover](https://deploy-preview-1511--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/failover/)
[Failover Runbook](https://deploy-preview-1511--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/disaster-recovery/shadowing/failover-runbook/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
