### PR TITLE
DOC-1386 Add HSTS to Console

### DIFF
--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -148,6 +148,40 @@ If you want Redpanda Console to serve HTTPS on a non-standard port like 8081, bu
 
 NOTE: If you host Redpanda Console under a sub-path of your domain, such as `+https://my-company.com/redpanda/console+`, configure xref:console:config/http-path-rewrites.adoc[HTTP path rewrites] in Redpanda Console.
 
+=== HTTP Strict Transport Security (HSTS)
+
+When TLS is enabled, Redpanda Console server automatically adds the HTTP Strict Transport Security (HSTS) header to all responses:
+
+```
+Strict-Transport-Security: max-age=31536000
+``` 
+
+The HSTS header instructs web browsers to:
+
+* Always connect to Redpanda Console using HTTPS, never HTTP
+* Automatically upgrade any HTTP requests to HTTPS for the next 365 days (31536000 seconds)
+* Refuse connections if there are certificate errors or warnings
+
+This behavior begins after the browser's first successful HTTPS connection to Redpanda Console.
+
+HSTS provides protection against:
+
+* Protocol downgrade attacks: Prevents attackers from forcing connections to use insecure HTTP
+* Accidental insecure connections: Users typing `http://` in their browser are automatically redirected to HTTPS
+* Session hijacking: Eliminates the risk window where HTTP traffic could be intercepted before redirect
+
+You can verify that HSTS is enabled by checking the response headers:
+
+```
+curl -svk https://localhost:9091/ 2>&1 | grep -i strict
+```
+
+Expected output:
+
+```
+< strict-transport-security: max-age=31536000
+```
+
 == Use an upstream component for TLS termination
 
 When you use an upstream component for TLS termination, the upstream component handles the secure TLS connection, and Redpanda Console receives unencrypted HTTP traffic from this component. You can use various upstream components, including reverse proxies, such as NGINX and HAProxy, as well as cloud HTTPS load balancers. To use this option, you must:

--- a/modules/console/pages/config/security/tls-termination.adoc
+++ b/modules/console/pages/config/security/tls-termination.adoc
@@ -173,7 +173,7 @@ HSTS provides protection against:
 You can verify that HSTS is enabled by checking the response headers:
 
 ```
-curl -svk https://localhost:9091/ 2>&1 | grep -i strict
+curl -svk https://localhost:9091/ 2>&1 | grep -i strict-transport-security
 ```
 
 Expected output:


### PR DESCRIPTION
## Description
**Do not merge until next Console release**

This pull request adds new documentation to clarify Redpanda Console's behavior regarding HTTP Strict Transport Security (HSTS) when TLS is enabled. The update explains what HSTS is, how it works in the context of Redpanda Console, and how users can verify that it is enabled.

* Added a new section describing how Redpanda Console automatically sends the HSTS header (`Strict-Transport-Security: max-age=31536000`) when TLS is enabled, including its security benefits and browser behavior.
* Provided instructions and an example command for verifying the presence of the HSTS header in server responses.

Resolves https://redpandadata.atlassian.net/browse/DOC-1386
Review deadline:

## Page previews
[HTTP Strict Transport Security (HSTS)](https://deploy-preview-1512--redpanda-docs-preview.netlify.app/current/console/config/security/tls-termination/#http-strict-transport-security-hsts)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
