### PR TITLE
fix link in rpk cloud

### DIFF
--- a/modules/reference/pages/rpk/rpk-shadow/rpk-shadow-create.adoc
+++ b/modules/reference/pages/rpk/rpk-shadow/rpk-shadow-create.adoc
@@ -10,7 +10,7 @@ Before you create a shadow link, generate a configuration file with xref:referen
 ifdef::env-cloud[]
 When creating a shadow link in Redpanda Cloud, use the `--for-cloud` flag.
 
-First log in and select the cluster where you want to create the shadow link before running this command. See xref:reference:rpk/rpk-cloud/rpk-cloud-login.adoc[`rpk cloud login`] and xref:reference:rpk/rpk-cloud/rpk-cloud-select.adoc[`rpk cloud select`]. For SCRAM authentication, store your password in the shadow cluster's secrets store (using either the cluster's secret store or xref:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]), then reference it in your configuration file using `${secrets.SECRET_NAME}` syntax.
+First log in and select the cluster where you want to create the shadow link before running this command. See xref:reference:rpk/rpk-cloud/rpk-cloud-login.adoc[`rpk cloud login`] and xref:reference:rpk/rpk-cloud/rpk-cloud-cluster-select.adoc[`rpk cloud cluster select`]. For SCRAM authentication, store your password in the shadow cluster's secrets store (using either the cluster's secret store or xref:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]), then reference it in your configuration file using `${secrets.SECRET_NAME}` syntax.
 endif::[]
 
 After you create the shadow link, use xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] to monitor the replication progress.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1876
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
