### PR TITLE
beta install: update instructions for macos

### DIFF
--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -153,7 +153,7 @@ macOS::
 
 Beta versions are not available through Homebrew. The Homebrew formula is only updated for general availability (GA) releases.
 
-For beta testing on macOS, use Docker as described in the Docker tab above.
+For beta testing on macOS, use Docker.
 
 --
 Kubernetes::

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -147,6 +147,15 @@ sudo apt-get install redpanda
 ====
 
 --
+macOS::
++
+--
+
+Beta versions are not available through Homebrew. The Homebrew formula is only updated for general availability (GA) releases.
+
+For beta testing on macOS, use Docker as described in the Docker tab above.
+
+--
 Kubernetes::
 +
 --


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1786
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
