### PR TITLE
auto-docs: Update K8s acceptance tests

### DIFF
--- a/modules/manage/examples/kubernetes/multicluster.feature
+++ b/modules/manage/examples/kubernetes/multicluster.feature
@@ -1,0 +1,16 @@
+@operator:none
+Feature: Multicluster Operator
+
+  @skip:gke @skip:aks @skip:eks @skip:k3d
+  Scenario: Multicluster finalizers
+    Given I create a multicluster operator named "multicluster" with 3 nodes
+    And I apply a multicluster Kubernetes manifest to "multicluster":
+    """
+    ---
+    apiVersion: cluster.redpanda.com/v1alpha2
+    kind: StretchCluster
+    metadata:
+      name: cluster
+      namespace: default
+    """
+    Then in "multicluster" the Kubernetes object "cluster" in namespace "default" of type "StretchCluster.v1alpha2.cluster.redpanda.com" should have finalizer "operator.redpanda.com/finalizer"

--- a/modules/manage/examples/kubernetes/shadow-links.feature
+++ b/modules/manage/examples/kubernetes/shadow-links.feature
@@ -29,7 +29,6 @@ Feature: ShadowLink CRDs
     When I apply Kubernetes manifest:
     """
     ---
-# tag::basic-shadowlink-example[]
     apiVersion: cluster.redpanda.com/v1alpha2
     kind: ShadowLink
     metadata:
@@ -47,7 +46,6 @@ Feature: ShadowLink CRDs
           - name: topic1
             filterType: include
             patternType: literal
-# end::basic-shadowlink-example[]
     """
     And shadow link "link" is successfully synced
     Then I should find topic "topic1" in cluster "sasl"


### PR DESCRIPTION
This PR auto-updates the acceptance tests we use as examples in our Kubernetes docs.