### PR TITLE
Generate docs from the correct tag

### DIFF
--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -3,8 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The Operator release tag for which to generate the docs'
+        description: 'The Operator release tag for which to generate the docs (such as operator/v2.3.8-25.3.1)'
         required: true
+        type: string
   repository_dispatch:
     types: [generate-crd-docs]
 jobs:
@@ -12,23 +13,30 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
-      - name: Determine operator tag
-        id: set_operator_tag
-        shell: bash
+      - name: Determine tag
+        id: tag
         run: |
           if [ -n "${{ github.event.inputs.tag }}" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.client_payload.tag }}" ]; then
+            echo "tag=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
           else
-            TAG="${{ github.event.release.tag_name }}"
+            echo "No tag provided as input or dispatch payload" >&2
+            exit 1
           fi
-          # Check if the tag has the expected prefix.
+
+      - name: Validate operator tag prefix
+        id: validate
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
           if [[ "$TAG" =~ ^operator/ ]]; then
             echo "OPERATOR_TAG=$TAG" >> $GITHUB_ENV
           else
-            echo "Tag does not have the operator/ prefix. Skipping workflow."
-            exit 0
+            echo "Tag does not have the operator/ prefix: $TAG" >&2
+            exit 1
           fi
 
       # Configure AWS credentials to get the secret for the Redpanda GitHub bot.


### PR DESCRIPTION
## Description

This pull request updates the `generate-crd.yml` GitHub Actions workflow to improve its robustness, input validation, and permissions. The changes clarify input expectations, strengthen tag validation, and adjust permissions to support pull request operations.

**Workflow input and validation improvements:**

* Enhanced the `tag` input description to specify the expected format and explicitly set its type to `string`.
* Improved tag determination logic to support both workflow dispatch and repository dispatch events, and to fail with an error message if no tag is provided.
* Added a dedicated step to validate that the provided tag starts with the `operator/` prefix, failing the workflow if the check does not pass.

**Permissions and job configuration:**

* Updated workflow permissions to allow writing to `contents` and `pull-requests`, enabling the workflow to create or update pull requests as needed.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
