### PR TITLE
Add MCP terms to glossary

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -1,13 +1,13 @@
 site:
   title: Redpanda Docs
-  start_page: home:ROOT:index.adoc
+  start_page: ROOT:get-started:intro-to-events.adoc
   url: http://localhost:5002
 content:
   sources:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [v/*,site-search, home, api]
+    branches: [main, v/*,site-search, home, api]
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/terms/partials/mcp-tool.adoc
+++ b/modules/terms/partials/mcp-tool.adoc
@@ -1,0 +1,12 @@
+=== MCP tool
+:term-name: MCP tool
+:hover-text: A function that an AI assistant can call to perform a specific task, such as fetching data from an API, querying a database, or processing streaming data. Each tool is defined using Redpanda Connect components and annotated with MCP metadata.
+:category: Redpanda Connect
+
+ifndef::env-cloud[]
+For more information, see xref:redpanda-connect:ai-agents:mcp-server/concepts.adoc[].
+endif::[]
+
+ifdef::env-cloud[]
+For more information, see xref:redpanda-cloud:ai-agents:mcp/remote/concepts.adoc[].
+endif::[]

--- a/modules/terms/partials/redpanda-connect-mcp-server.adoc
+++ b/modules/terms/partials/redpanda-connect-mcp-server.adoc
@@ -1,0 +1,6 @@
+=== Redpanda Connect MCP server
+:term-name: Redpanda Connect MCP server
+:hover-text: A process that exposes Redpanda Connect components to MCP clients. You write each tool's logic using Redpanda Connect configurations and annotate them with MCP metadata so clients can discover and invoke them.
+:category: Redpanda Connect
+
+For more information, see xref:redpanda-connect:ai-agents:mcp-server/overview.adoc[].

--- a/modules/terms/partials/redpanda-connect.adoc
+++ b/modules/terms/partials/redpanda-connect.adoc
@@ -1,0 +1,12 @@
+=== Redpanda Connect
+:term-name: Redpanda Connect
+:hover-text: A framework for building data streaming applications using declarative YAML configurations. Redpanda Connect provides components such as inputs, processors, outputs, and caches to define data flows and transformations.
+:category: Redpanda Connect
+
+ifndef::env-cloud[]
+For more information, see xref:redpanda-connect:ROOT:about.adoc[].
+endif::[]
+
+ifdef::env-cloud[]
+For more information, see xref:redpanda-cloud:develop:connect/about.adoc[].
+endif::[]

--- a/modules/terms/partials/remote-mcp.adoc
+++ b/modules/terms/partials/remote-mcp.adoc
@@ -1,0 +1,6 @@
+=== Remote MCP
+:term-name: Remote MCP
+:hover-text: An MCP server hosted in your Redpanda Cloud cluster. It exposes custom tools that AI assistants can call to access your data and workflows.
+:category: Redpanda Cloud
+
+For more information, see xref:redpanda-cloud:ai-agents:mcp/remote/overview.adoc[].


### PR DESCRIPTION
## Description

This pull request adds new glossary entries to document concepts related to Redpanda and MCP servers. The changes introduce clear definitions and context for terms such as "Redpanda Connect," "MCP tool," "Redpanda Connect MCP server," and "Remote MCP," each with relevant cross-references for further reading.

New glossary entries:

**Redpanda Connect concepts:**
* Added a glossary entry for `Redpanda Connect`, describing it as a framework for building data streaming applications with declarative YAML, and providing links to more information depending on the environment.
* Added a glossary entry for `MCP tool`, defining it as a function callable by AI assistants and explaining its implementation and annotation with MCP metadata. Environment-specific links are included.
* Added a glossary entry for `Redpanda Connect MCP server`, explaining its role in exposing Redpanda Connect components to MCP clients and providing a link to an overview.

**Cloud integration:**
* Added a glossary entry for `Remote MCP`, defining it as an MCP server hosted in Redpanda Cloud to expose custom tools for AI assistants, with a link to further documentation.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
