### PR TITLE
Fix broken xrefs in cloud-docs build

### DIFF
--- a/modules/develop/pages/transactions.adoc
+++ b/modules/develop/pages/transactions.adoc
@@ -285,12 +285,14 @@ Tune `transactional_id_expiration_ms` based on your application's transaction pa
 
 Client applications should minimize producer ID churn. Reuse producer instances when possible, instead of creating new ones for each operation. Avoid using random transactional IDs, as some Flink configurations do, because this creates excessive producer ID churn. Instead, use consistent transactional IDs that can be resumed across application restarts.
 
+ifndef::env-cloud[]
 Monitor the following metrics to determine if the limit is being reached:
 
 * xref:reference:internal-metrics-reference.adoc#vectorized_cluster_producer_state_manager_evicted_producers[`vectorized_cluster_producer_state_manager_evicted_producers`]: Number of evicted producers (should be 0 in steady state)
 * xref:reference:internal-metrics-reference.adoc#vectorized_cluster_producer_state_manager_producer_manager_total_active_producers[`vectorized_cluster_producer_state_manager_producer_manager_total_active_producers`]: Current number of active producers per shard
 
 If `vectorized_cluster_producer_state_manager_evicted_producers` > 0, the shard is exceeding the configured limit. For applications with long-running transactions, ensure xref:reference:properties/cluster-properties.adoc#transactional_id_expiration_ms[`transactional_id_expiration_ms`] accommodates your typical transaction lifetime to avoid premature producer ID expiration.
+endif::[]
 
 === Configure transaction timeouts and limits
 

--- a/modules/shared/partials/tristate-behavior-change-25-3.adoc
+++ b/modules/shared/partials/tristate-behavior-change-25-3.adoc
@@ -1,1 +1,5 @@
-Starting in Redpanda v25.3, several topic properties support enhanced tristate behavior. Properties like `retention.ms`, `retention.bytes`, `segment.ms`, and others now distinguish between zero values (immediate eligibility for cleanup/compaction) and negative values (disable the feature entirely). Previously, zero and negative values were treated the same way. For the complete list of affected properties and detailed information, see xref:25.3@get-started:release-notes/redpanda.adoc#behavior-changes[Redpanda v25.3 behavior changes]. Review your topic configurations if you currently use zero values for these properties.
+Starting in Redpanda v25.3, several topic properties support enhanced tristate behavior. Properties like `retention.ms`, `retention.bytes`, `segment.ms`, and others now distinguish between zero values (immediate eligibility for cleanup/compaction) and negative values (disable the feature entirely). Previously, zero and negative values were treated the same way.
+ifndef::env-cloud[]
+For the complete list of affected properties and detailed information, see xref:25.3@get-started:release-notes/redpanda.adoc#behavior-changes[Redpanda v25.3 behavior changes].
+endif::[]
+Review your topic configurations if you currently use zero values for these properties.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Updates from https://github.com/redpanda-data/docs/pull/1527 created bad links in `cloud-docs` repo. This conditionalizes out those specific changes for Cloud.

* [`modules/develop/pages/transactions.adoc`](diffhunk://#diff-8c4cb461a5ff87fa417c8c7872b9f18f05cc44df8fec58791f07d18bee7eddacR288-R295): Added a conditional block so that metric monitoring guidance for producer ID churn is only shown in non-cloud environments, helping users focus on relevant instructions.
* Wrap version-specific xref in ifndef::env-cloud[] in tristate-behavior-change-25-3.adoc (25.3@ prefix causes errors when included in cloud-docs)

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews
[Transactions: Core](https://deploy-preview-1543--redpanda-docs-preview.netlify.app/current/develop/transactions/#tune-producer-id-limits)
[Transactions: Cloud](https://deploy-preview-1543--redpanda-docs-preview.netlify.app/current/develop/transactions/#tune-producer-id-limits)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
