### PR TITLE
Update brokers list outputs

### DIFF
--- a/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
+++ b/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
@@ -52,7 +52,8 @@ rpk cluster info
 .Example output
 [%collapsible]
 ====
-```
+[,bash,role="no-wrap"]
+----
 CLUSTER
 =======
 redpanda.560e2403-3fd6-448c-b720-7b456d0aa78c
@@ -67,7 +68,7 @@ ID    HOST                          PORT   RACK
 6     redpanda-4.testcluster.local  32180  C
 8     redpanda-6.testcluster.local  32180  C
 9     redpanda-5.testcluster.local  32180  D
-```
+----
 ====
 
 The output shows four racks (A/B/C/D), so you might want to have at least four brokers to make use of all racks.
@@ -92,7 +93,8 @@ rpk cluster logdirs describe --aggregate-into broker
 .Example output
 [%collapsible]
 ====
-```
+[,bash,role="no-wrap"]
+----
 BROKER  SIZE          ERROR
 0       263882790656
 1       256177979648
@@ -101,7 +103,7 @@ BROKER  SIZE          ERROR
 4       254087316992
 5       258369126144
 6       255227998208
-```
+----
 ====
 
 The example output shows that each broker contains roughly 240GB of data, which  means scaling down to five brokers would require each broker to have at least 337GB to hold current data.
@@ -177,7 +179,8 @@ rpk redpanda admin brokers list
 .Example output
 [%collapsible]
 ====
-```
+[,bash,role="no-wrap"]
+----
 ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
 0     redpanda-0.testcluster.local  32180  A     8      active      true      25.2.13  24c08934-94f6-478c-b57d-45239f452488
 1     redpanda-1.testcluster.local  32180  B     8      active      true      25.2.13  7f3c1c6e-2f4d-4c8a-9c6e-0a8a6d8b2b61
@@ -186,7 +189,7 @@ ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VE
 4     redpanda-4.testcluster.local  32180  B     8      active      true      25.2.13  4e8b1c3a-9d7f-4a6e-b2c5-8f6d1a3e9b74
 5     redpanda-5.testcluster.local  32180  C     8      active      true      25.2.13  a1f9c6b4-3d2e-4a8f-9e5b-7c6d8a1b2f93
 6     redpanda-6.testcluster.local  32180  A     8      active      true      25.2.13  e6b4d2a8-5f1c-4e9b-8a3d-9c7f1b6a5e42
-```
+----
 ====
 
 In this example each broker has 8 cores available. If you plan to scale down to five brokers, then you would have 40 cores available, which means that your cluster is limited by core count to 40K partitions (well above the current 3018 partitions).

--- a/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
+++ b/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
@@ -178,14 +178,14 @@ rpk redpanda admin brokers list
 [%collapsible]
 ====
 ```
-NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
-0        8          active             true      v23.1.8
-1        8          active             true      v23.1.8
-2        8          active             true      v23.1.8
-3        8          active             true      v23.1.8
-4        8          active             true      v23.1.8
-5        8          active             true      v23.1.8
-6        8          active             true      v23.1.8
+ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
+0     redpanda-0.testcluster.local  32180  A     8      active      true      25.2.13  24c08934-94f6-478c-b57d-45239f452488
+1     redpanda-1.testcluster.local  32180  B     8      active      true      25.2.13  7f3c1c6e-2f4d-4c8a-9c6e-0a8a6d8b2b61
+2     redpanda-2.testcluster.local  32180  C     8      active      true      25.2.13  b2e8d4a9-91c1-4b55-9f6a-3f7a2d3c5e44
+3     redpanda-3.testcluster.local  32180  A     8      active      true      25.2.13  c9a6f7d2-5e3b-4f8c-8d1a-6e2b4a9f7c31
+4     redpanda-4.testcluster.local  32180  B     8      active      true      25.2.13  4e8b1c3a-9d7f-4a6e-b2c5-8f6d1a3e9b74
+5     redpanda-5.testcluster.local  32180  C     8      active      true      25.2.13  a1f9c6b4-3d2e-4a8f-9e5b-7c6d8a1b2f93
+6     redpanda-6.testcluster.local  32180  A     8      active      true      25.2.13  e6b4d2a8-5f1c-4e9b-8a3d-9c7f1b6a5e42
 ```
 ====
 

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -192,14 +192,14 @@ rpk redpanda admin brokers list
 [%collapsible]
 ====
 ```
-NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
-0        8          active             true      v23.1.8
-1        8          active             true      v23.1.8
-2        8          active             true      v23.1.8
-3        8          active             true      v23.1.8
-4        8          active             true      v23.1.8
-5        8          active             true      v23.1.8
-6        8          active             true      v23.1.8
+ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
+0     redpanda-0.testcluster.local  32180  A     8      active      true      25.2.13  24c08934-94f6-478c-b57d-45239f452488
+1     redpanda-1.testcluster.local  32180  B     8      active      true      25.2.13  7f3c1c6e-2f4d-4c8a-9c6e-0a8a6d8b2b61
+2     redpanda-2.testcluster.local  32180  C     8      active      true      25.2.13  b2e8d4a9-91c1-4b55-9f6a-3f7a2d3c5e44
+3     redpanda-3.testcluster.local  32180  A     8      active      true      25.2.13  c9a6f7d2-5e3b-4f8c-8d1a-6e2b4a9f7c31
+4     redpanda-4.testcluster.local  32180  B     8      active      true      25.2.13  4e8b1c3a-9d7f-4a6e-b2c5-8f6d1a3e9b74
+5     redpanda-5.testcluster.local  32180  C     8      active      true      25.2.13  a1f9c6b4-3d2e-4a8f-9e5b-7c6d8a1b2f93
+6     redpanda-6.testcluster.local  32180  A     8      active      true      25.2.13  e6b4d2a8-5f1c-4e9b-8a3d-9c7f1b6a5e42
 ```
 ====
 

--- a/modules/upgrade/pages/k-rolling-upgrade.adoc
+++ b/modules/upgrade/pages/k-rolling-upgrade.adoc
@@ -35,13 +35,13 @@ kubectl exec <pod-name> --namespace <namespace> -c redpanda -- \
 .Expected output:
 [%collapsible]
 ====
-The Redpanda version for each broker is listed under `BROKER-VERSION`.
+The Redpanda version for each broker is listed under `VERSION`.
 [role="no-copy",subs="attributes+"]
 ```
-NODE-ID  BROKER-VERSION
-0        {latest-redpanda-tag}
-1        {latest-redpanda-tag}
-2        {latest-redpanda-tag}
+ID  VERSION
+0   {latest-redpanda-tag}
+1   {latest-redpanda-tag}
+2   {latest-redpanda-tag}
 ```
 ====
 - xref:upgrade:k-compatibility.adoc[Review the Kubernetes compatibility matrix] to find out if you need to upgrade the Helm chart or the Redpanda Operator to use your chosen version of Redpanda.

--- a/modules/upgrade/partials/rolling-upgrades/rolling-restart-intro.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/rolling-restart-intro.adoc
@@ -14,17 +14,17 @@ If you have topics with `replication.factor=1`, and if you have sufficient disk 
 rpk redpanda admin brokers list
 ----
 +
-All brokers should show `active` for `MEMBERSHIP-STATUS` and `true` for `IS-ALIVE`:
+All brokers should show `active` for `MEMBERSHIP` and `true` for `IS-ALIVE`:
 +
 .Example output
 [%collapsible]
 ====
 [.no-copy]
 ```
-NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
-0        1          active             true      v22.3.11
-1        1          active             true      v22.3.11
-2        1          active             true      v22.3.11
+ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
+0     redpanda-0.testcluster.local  32180  A     8      active      true      25.2.13  24c08934-94f6-478c-b57d-45239f452488
+1     redpanda-1.testcluster.local  32180  B     8      active      true      25.2.13  7f3c1c6e-2f4d-4c8a-9c6e-0a8a6d8b2b61
+2     redpanda-2.testcluster.local  32180  C     8      active      true      25.2.13  b2e8d4a9-91c1-4b55-9f6a-3f7a2d3c5e44
 ```
 ====
 
@@ -48,17 +48,17 @@ If you have topics with `replication.factor=1`, and if you have sufficient disk 
 rpk redpanda admin brokers list
 ----
 +
-All brokers should show `active` for `MEMBERSHIP-STATUS` and `true` for `IS-ALIVE`:
+All brokers should show `active` for `MEMBERSHIP` and `true` for `IS-ALIVE`:
 +
 .Example output
 [%collapsible]
 ====
 [.no-copy]
 ```
-NODE-ID  NUM-CORES  MEMBERSHIP-STATUS  IS-ALIVE  BROKER-VERSION
-0        1          active             true      v22.3.11
-1        1          active             true      v22.3.11
-2        1          active             true      v22.3.11
+ID    HOST                          PORT   RACK  CORES  MEMBERSHIP  IS-ALIVE  VERSION  UUID
+0     redpanda-0.testcluster.local  32180  A     8      active      true      25.2.13  24c08934-94f6-478c-b57d-45239f452488
+1     redpanda-1.testcluster.local  32180  B     8      active      true      25.2.13  7f3c1c6e-2f4d-4c8a-9c6e-0a8a6d8b2b61
+2     redpanda-2.testcluster.local  32180  C     8      active      true      25.2.13  b2e8d4a9-91c1-4b55-9f6a-3f7a2d3c5e44
 ```
 ====
 endif::[]


### PR DESCRIPTION
## Description

This PR updates the output of the `rpk redpanda admin brokers list` command in all pages that exists because they are still old. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
