### PR TITLE
DOC-1927 Document configuration param maximumSessionAge in console

### DIFF
--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -497,6 +497,98 @@ Most Kafka client libraries support SASL/SCRAM out of the box. You must configur
 - `sasl.username`: The Redpanda username
 - `sasl.password`: The corresponding password
 
+== Configure session duration
+
+[NOTE]
+====
+include::shared:partial$enterprise-and-console.adoc[]
+====
+
+By default, Redpanda Console sessions remain valid for one year. For enterprise deployments, you can limit the maximum session duration using the `maximumSessionAge` configuration parameter.
+
+When a session exceeds the configured maximum age, users must re-authenticate to continue using Redpanda Console.
+
+[tabs]
+======
+Standalone::
++
+--
+[,yaml]
+----
+authentication:
+  jwtSigningKey: "<secret-key>"
+  useSecureCookies: true
+  maximumSessionAge: "90d" # <1>
+  basic:
+    enabled: true
+----
+--
+
+Kubernetes embedded::
++
+--
+When using the Redpanda Operator or the Redpanda Helm chart:
+
+[tabs]
+====
+Operator::
++
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  clusterSpec:
+    console:
+      enabled: true
+      console:
+        config:
+          authentication:
+            jwtSigningKey: "<secret-key>"
+            useSecureCookies: true
+            maximumSessionAge: "90d" # <1>
+            basic:
+              enabled: true
+----
+
+Helm::
++
+[,yaml]
+----
+console:
+  enabled: true
+  console:
+    config:
+      authentication:
+        jwtSigningKey: "<secret-key>"
+        useSecureCookies: true
+        maximumSessionAge: "90d" # <1>
+        basic:
+          enabled: true
+----
+====
+--
+
+Kubernetes standalone::
++
+--
+[,yaml]
+----
+config:
+  authentication:
+    jwtSigningKey: "<secret-key>"
+    useSecureCookies: true
+    maximumSessionAge: "90d" # <1>
+    basic:
+      enabled: true
+----
+--
+======
+
+<1> Maximum duration for browser sessions. Accepts duration strings such as `90d` (90 days), `24h` (24 hours), or `30m` (30 minutes). If not specified, sessions remain valid for one year.
+
 == Configure API authentication
 
 After enabling authentication, you must configure how Redpanda Console authenticates to each Redpanda API: Kafka, Admin, and Schema Registry.

--- a/modules/console/pages/config/security/authentication.adoc
+++ b/modules/console/pages/config/security/authentication.adoc
@@ -499,11 +499,6 @@ Most Kafka client libraries support SASL/SCRAM out of the box. You must configur
 
 == Configure session duration
 
-[NOTE]
-====
-include::shared:partial$enterprise-and-console.adoc[]
-====
-
 By default, Redpanda Console sessions remain valid for one year. For enterprise deployments, you can limit the maximum session duration using the `maximumSessionAge` configuration parameter.
 
 When a session exceeds the configured maximum age, users must re-authenticate to continue using Redpanda Console.

--- a/modules/shared/attachments/redpanda-console-config.yaml
+++ b/modules/shared/attachments/redpanda-console-config.yaml
@@ -85,6 +85,8 @@ schemaRegistry:
 authentication:
   jwtSigningKey: "secret-value"
   useSecureCookies: true
+  # Maximum browser session age (Enterprise). Accepts duration strings (for example, "90d", "24h", "30m"). Default: 1 year.
+  # maximumSessionAge: "90d"
   # Optionally enable cookie chunking if cookie size is an issue.
   # useCookieChunking: false
   # OIDC configuration (if using OIDC):


### PR DESCRIPTION
## Description
This pull request adds documentation and configuration support for limiting Redpanda Console session duration using the new `maximumSessionAge` parameter. This allows enterprise users to control how long browser sessions remain valid before requiring users to re-authenticate.

* Added a new section to the authentication documentation explaining how to set the `maximumSessionAge` parameter to limit session duration for Redpanda Console, including examples for standalone, Kubernetes Operator, Helm, and Kubernetes standalone deployments.
* Updated the sample configuration file (`redpanda-console-config.yaml`) to document the new `maximumSessionAge` option, including usage notes and example values.

Resolves https://redpandadata.atlassian.net/browse/DOC-1927
Review deadline:

## Page previews
[Configure session duration](https://deploy-preview-1561--redpanda-docs-preview.netlify.app/current/console/config/security/authentication/#configure-session-duration)
[config.yaml example](https://deploy-preview-1561--redpanda-docs-preview.netlify.app/current/console/config/configure-console/#config-yaml)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
