### PR TITLE
DOC-1943 single source schema id validation

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -10,9 +10,7 @@ urls:
   latest_version_segment: 'current'
 output:
   clean: true
-runtime:
-  log:
-    failure_level: error
+
 content:
   sources:
   - url: .

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1939-Add-Schema-Validation-topic-in-general-and-cluster-property-enable_schema_id_validation-to-cloud-docs'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1939-Add-Schema-Validation-topic-in-general-and-cluster-property-enable_schema_id_validation-to-cloud-docs'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -87,8 +87,8 @@ When <<enable-schema-id-validation,schema ID validation is enabled>>, Redpanda u
 
 To customize the subject name strategy per topic, set the following client topic properties:
 
-* Set xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
-* Set xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
+* Set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]]ifdef::env-cloud[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]]ifdef::env-cloud[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
+* Set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]]ifdef::env-cloud[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]]ifdef::env-cloud[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
 
 [NOTE]
 ====
@@ -97,17 +97,17 @@ The `redpanda.` properties have corresponding `confluent.` properties.
 |===
 | Redpanda property | Confluent property
 
-| xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]
-| xref:reference:properties/topic-properties.adoc#confluentkeyschemavalidation[`confluent.key.schema.validation`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]]ifdef::env-cloud[`redpanda.key.schema.id.validation`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentkeyschemavalidation[`confluent.key.schema.validation`]]ifdef::env-cloud[`confluent.key.schema.validation`]
 
-| xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]
-| xref:reference:properties/topic-properties.adoc#confluentkeysubjectnamestrategy[`confluent.key.subject.name.strategy`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]]ifdef::env-cloud[`redpanda.key.subject.name.strategy`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentkeysubjectnamestrategy[`confluent.key.subject.name.strategy`]]ifdef::env-cloud[`confluent.key.subject.name.strategy`]
 
-| xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]
-| xref:reference:properties/topic-properties.adoc#confluentvalueschemavalidation[`confluent.value.schema.validation`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]]ifdef::env-cloud[`redpanda.value.schema.id.validation`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentvalueschemavalidation[`confluent.value.schema.validation`]]ifdef::env-cloud[`confluent.value.schema.validation`]
 
-| xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]
-| xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]]ifdef::env-cloud[`redpanda.value.subject.name.strategy`]
+| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]]ifdef::env-cloud[`confluent.value.subject.name.strategy`]
 |===
 
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -35,13 +35,13 @@ To use schema ID validation:
 
 === Enable schema ID validation
 
-ifndef::env-cloud[]
 By default, server-side schema ID validation is disabled in Redpanda. To enable schema ID validation, change the xref:reference:cluster-properties.adoc#enable_schema_id_validation[`enable_schema_id_validation`] cluster property from its default value of `none` to either `redpanda` or `compat`:
 
 * `none`: Schema validation is disabled (no schema ID checks are done). Associated topic properties cannot be modified.
 * `redpanda`: Schema validation is enabled. Only Redpanda topic properties are accepted.
 * `compat`: Schema validation is enabled. Both Redpanda and compatible topic properties are accepted.
 
+ifndef::env-cloud[]
 For example, use `rpk` to set the value of `enable_schema_id_validation` to `redpanda` through the Admin API:
 
 [,bash]
@@ -51,12 +51,6 @@ rpk cluster config set enable_schema_id_validation redpanda -X admin.hosts=<admi
 endif::[]
 
 ifdef::env-cloud[]
-To enable schema ID validation, set the `enable_schema_id_validation` cluster property to either `redpanda` or `compat`:
-
-* `none`: Schema validation is disabled (no schema ID checks are done). Associated topic properties cannot be modified.
-* `redpanda`: Schema validation is enabled. Only Redpanda topic properties are accepted.
-* `compat`: Schema validation is enabled. Both Redpanda and compatible topic properties are accepted.
-
 See xref:manage:cluster-maintenance/config-cluster.adoc[]
 endif::[]
 
@@ -85,35 +79,16 @@ The subject name strategies supported by Redpanda:
 
 When <<enable-schema-id-validation,schema ID validation is enabled>>, Redpanda uses `TopicNameStrategy` by default.
 
+ifndef::env-cloud[]
 To customize the subject name strategy per topic, set the following client topic properties:
 
 * Set xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
 * Set xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
 
-
 [NOTE]
 ====
 The `redpanda.` properties have corresponding `confluent.` properties.
 
-ifdef::env-cloud[]
-|===
-| Redpanda property | Confluent property
-
-| `redpanda.key.schema.id.validation`
-| `confluent.key.schema.validation`
-
-| `redpanda.key.subject.name.strategy`
-| `confluent.key.subject.name.strategy`
-
-| `redpanda.value.schema.id.validation`
-| `confluent.value.schema.validation`
-
-| `redpanda.value.subject.name.strategy`
-| `confluent.value.subject.name.strategy`
-|===
-endif::[]
-
-ifndef::env-cloud[]
 |===
 | Redpanda property | Confluent property
 
@@ -134,7 +109,6 @@ endif::[]
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.
 
 If `subject.name.strategy` is prefixed with `confluent.`, the available subject name strategies must be prefixed with `io.confluent.kafka.serializers.subject.`. For example, `io.confluent.kafka.serializers.subject.TopicNameStrategy`.
-====
 
 
 NOTE: To support schema ID validation for compressed topics, a Redpanda broker decompresses each batch written to it so it can access the schema ID.

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -35,7 +35,13 @@ To use schema ID validation:
 
 === Enable schema ID validation
 
+ifndef::env-cloud[]
 By default, server-side schema ID validation is disabled in Redpanda. To enable schema ID validation, change the xref:reference:cluster-properties.adoc#enable_schema_id_validation[`enable_schema_id_validation`] cluster property from its default value of `none` to either `redpanda` or `compat`:
+endif::[]
+
+ifdef::env-cloud[]
+By default, server-side schema ID validation is disabled in Redpanda. To enable schema ID validation, change the xref:reference:properties/cluster-properties.adoc#enable_schema_id_validation[`enable_schema_id_validation`] cluster property from its default value of `none` to either `redpanda` or `compat`:
+endif::[]
 
 * `none`: Schema validation is disabled (no schema ID checks are done). Associated topic properties cannot be modified.
 * `redpanda`: Schema validation is enabled. Only Redpanda topic properties are accepted.

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -90,11 +90,30 @@ To customize the subject name strategy per topic, set the following client topic
 * Set xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
 * Set xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
 
-ifndef::env-cloud[]
+
 [NOTE]
 ====
 The `redpanda.` properties have corresponding `confluent.` properties.
 
+ifdef::env-cloud[]
+|===
+| Redpanda property | Confluent property
+
+| `redpanda.key.schema.id.validation`
+| `confluent.key.schema.validation`
+
+| `redpanda.key.subject.name.strategy`
+| `confluent.key.subject.name.strategy`
+
+| `redpanda.value.schema.id.validation`
+| `confluent.value.schema.validation`
+
+| `redpanda.value.subject.name.strategy`
+| `confluent.value.subject.name.strategy`
+|===
+endif::[]
+
+ifndef::env-cloud[]
 |===
 | Redpanda property | Confluent property
 
@@ -110,12 +129,13 @@ The `redpanda.` properties have corresponding `confluent.` properties.
 | xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]
 | xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]
 |===
+endif::[]
 
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.
 
 If `subject.name.strategy` is prefixed with `confluent.`, the available subject name strategies must be prefixed with `io.confluent.kafka.serializers.subject.`. For example, `io.confluent.kafka.serializers.subject.TopicNameStrategy`.
 ====
-endif::[]
+
 
 NOTE: To support schema ID validation for compressed topics, a Redpanda broker decompresses each batch written to it so it can access the schema ID.
 

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -85,9 +85,9 @@ The subject name strategies supported by Redpanda:
 
 When <<enable-schema-id-validation,schema ID validation is enabled>>, Redpanda uses `TopicNameStrategy` by default.
 
-ifndef::env-cloud[]
 To customize the subject name strategy per topic, set the following client topic properties:
 
+ifndef::env-cloud[]
 * Set xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
 * Set xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
 
@@ -111,12 +111,37 @@ The `redpanda.` properties have corresponding `confluent.` properties.
 | xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]
 |===
 ====
+endif::[]
+
+ifdef::env-cloud[]
+* Set `redpanda.key.schema.id.validation` to `true` to enable key schema ID validation for the topic, and set `redpanda.key.subject.name.strategy` to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
+* Set `redpanda.value.schema.id.validation` to `true` to enable value schema ID validation for the topic, and set `redpanda.value.subject.name.strategy` to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
+
+[NOTE]
+====
+The `redpanda.` properties have corresponding `confluent.` properties.
+
+|===
+| Redpanda property | Confluent property
+
+| `redpanda.key.schema.id.validation`
+| `confluent.key.schema.validation`
+
+| `redpanda.key.subject.name.strategy`
+| `confluent.key.subject.name.strategy`
+
+| `redpanda.value.schema.id.validation`
+| `confluent.value.schema.validation`
+
+| `redpanda.value.subject.name.strategy`
+| `confluent.value.subject.name.strategy`
+|===
+====
+endif::[]
 
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.
 
 If `subject.name.strategy` is prefixed with `confluent.`, the available subject name strategies must be prefixed with `io.confluent.kafka.serializers.subject.`. For example, `io.confluent.kafka.serializers.subject.TopicNameStrategy`.
-
-endif::[]
 
 NOTE: To support schema ID validation for compressed topics, a Redpanda broker decompresses each batch written to it so it can access the schema ID.
 

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -87,9 +87,10 @@ When <<enable-schema-id-validation,schema ID validation is enabled>>, Redpanda u
 
 To customize the subject name strategy per topic, set the following client topic properties:
 
-* Set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]]ifdef::env-cloud[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]]ifdef::env-cloud[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
-* Set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]]ifdef::env-cloud[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]]ifdef::env-cloud[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
+* Set xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`] to `true` to enable key schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`] to the desired subject name strategy for keys of the topic (default: `TopicNameStrategy`).
+* Set xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`] to `true` to enable value schema ID validation for the topic, and set xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`] to the desired subject name strategy for values of the topic (default: `TopicNameStrategy`).
 
+ifndef::env-cloud[]
 [NOTE]
 ====
 The `redpanda.` properties have corresponding `confluent.` properties.
@@ -97,23 +98,24 @@ The `redpanda.` properties have corresponding `confluent.` properties.
 |===
 | Redpanda property | Confluent property
 
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]]ifdef::env-cloud[`redpanda.key.schema.id.validation`]
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentkeyschemavalidation[`confluent.key.schema.validation`]]ifdef::env-cloud[`confluent.key.schema.validation`]
+| xref:reference:properties/topic-properties.adoc#redpandakeyschemavalidation[`redpanda.key.schema.id.validation`]
+| xref:reference:properties/topic-properties.adoc#confluentkeyschemavalidation[`confluent.key.schema.validation`]
 
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]]ifdef::env-cloud[`redpanda.key.subject.name.strategy`]
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentkeysubjectnamestrategy[`confluent.key.subject.name.strategy`]]ifdef::env-cloud[`confluent.key.subject.name.strategy`]
+| xref:reference:properties/topic-properties.adoc#redpandakeysubjectnamestrategy[`redpanda.key.subject.name.strategy`]
+| xref:reference:properties/topic-properties.adoc#confluentkeysubjectnamestrategy[`confluent.key.subject.name.strategy`]
 
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]]ifdef::env-cloud[`redpanda.value.schema.id.validation`]
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentvalueschemavalidation[`confluent.value.schema.validation`]]ifdef::env-cloud[`confluent.value.schema.validation`]
+| xref:reference:properties/topic-properties.adoc#redpandavalueschemavalidation[`redpanda.value.schema.id.validation`]
+| xref:reference:properties/topic-properties.adoc#confluentvalueschemavalidation[`confluent.value.schema.validation`]
 
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]]ifdef::env-cloud[`redpanda.value.subject.name.strategy`]
-| ifndef::env-cloud[xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]]ifdef::env-cloud[`confluent.value.subject.name.strategy`]
+| xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]
+| xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]
 |===
 
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.
 
 If `subject.name.strategy` is prefixed with `confluent.`, the available subject name strategies must be prefixed with `io.confluent.kafka.serializers.subject.`. For example, `io.confluent.kafka.serializers.subject.TopicNameStrategy`.
 ====
+endif::[]
 
 NOTE: To support schema ID validation for compressed topics, a Redpanda broker decompresses each batch written to it so it can access the schema ID.
 

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -142,4 +142,4 @@ rpk topic alter-config topic_foo \
   -X brokers=<broker-addr>:9092
 ----
 
-// end::single-source[]
+// end::single-source[] 

--- a/modules/manage/pages/schema-reg/schema-id-validation.adoc
+++ b/modules/manage/pages/schema-reg/schema-id-validation.adoc
@@ -51,7 +51,7 @@ rpk cluster config set enable_schema_id_validation redpanda -X admin.hosts=<admi
 endif::[]
 
 ifdef::env-cloud[]
-See xref:manage:cluster-maintenance/config-cluster.adoc[]
+See xref:manage:cluster-maintenance/config-cluster.adoc[].
 endif::[]
 
 === Set subject name strategy per topic
@@ -104,12 +104,13 @@ The `redpanda.` properties have corresponding `confluent.` properties.
 | xref:reference:properties/topic-properties.adoc#redpandavaluesubjectnamestrategy[`redpanda.value.subject.name.strategy`]
 | xref:reference:properties/topic-properties.adoc#confluentvaluesubjectnamestrategy[`confluent.value.subject.name.strategy`]
 |===
-endif::[]
+====
 
 The `redpanda.*` and `confluent.*` properties are compatible. Either or both can be set simultaneously.
 
 If `subject.name.strategy` is prefixed with `confluent.`, the available subject name strategies must be prefixed with `io.confluent.kafka.serializers.subject.`. For example, `io.confluent.kafka.serializers.subject.TopicNameStrategy`.
 
+endif::[]
 
 NOTE: To support schema ID validation for compressed topics, a Redpanda broker decompresses each batch written to it so it can access the schema ID.
 

--- a/modules/reference/pages/glossary.adoc
+++ b/modules/reference/pages/glossary.adoc
@@ -2,6 +2,7 @@
 
 Terms are organized into the following categories:
 
+- <<Redpanda Agentic Data Plane>>
 - <<Redpanda Cloud>>
 - <<Redpanda core>>
 - <<Redpanda features>>

--- a/modules/reference/pages/glossary.adoc
+++ b/modules/reference/pages/glossary.adoc
@@ -2,7 +2,7 @@
 
 Terms are organized into the following categories:
 
-- <<Redpanda Agentic Data Plane>>
+- <<Agentic Data Plane>>
 - <<Redpanda Cloud>>
 - <<Redpanda core>>
 - <<Redpanda features>>

--- a/modules/reference/partials/properties/cluster-properties.adoc
+++ b/modules/reference/partials/properties/cluster-properties.adoc
@@ -5011,9 +5011,12 @@ endif::[]
 |===
 
 
+// tag::redpanda-cloud[]
 === enable_schema_id_validation
 
 Controls whether Redpanda validates schema IDs in records and which topic properties are enforced.
+
+CAUTION: This property could cause decompression across topics and increase CPU load.
 
 Values:
 
@@ -5070,6 +5073,7 @@ endif::[]
 
 |===
 
+// end::redpanda-cloud[]
 
 // tag::redpanda-cloud[]
 === enable_shadow_linking

--- a/modules/reference/partials/properties/cluster-properties.adoc
+++ b/modules/reference/partials/properties/cluster-properties.adoc
@@ -5016,7 +5016,7 @@ endif::[]
 
 Controls whether Redpanda validates schema IDs in records and which topic properties are enforced.
 
-CAUTION: This property could cause decompression across topics and increase CPU load.
+NOTE: Enabling this property will trigger decompression of message batches for topics on which validation is configured, which may lead to a modest increase in CPU load. Redpanda recommends monitoring CPU utilization after topics are configured.
 
 Values:
 


### PR DESCRIPTION
## Description
NOTE: Single sourcing for this in `cloud-docs` in https://github.com/redpanda-data/cloud-docs/pull/495

This pull request updates doc for schema ID validation to support both cloud and SM environments. 

* Added start and end tags (`// tag::redpanda-cloud[]` and `// end::redpanda-cloud[]`) around the cloud-specific documentation for the `enable_schema_id_validation` property in `cluster-properties.adoc`. [[1]](diffhunk://#diff-1f601bd5bc3e3f82790c225c9662d9d4c4b7a597b7ed3d7d580535a904035c9eR5014-R5020) [[2]](diffhunk://#diff-1f601bd5bc3e3f82790c225c9662d9d4c4b7a597b7ed3d7d580535a904035c9eR5076)
* Added a caution note to the `enable_schema_id_validation` property documentation, warning that enabling this property may cause decompression across topics and increase CPU load.
* * Updated references to `redpanda.*` and `confluent.*` topic properties in `schema-id-validation.adoc` to use conditional AsciiDoc macros (`ifndef::env-cloud[]` and `ifdef::env-cloud[]`), ensuring correct property linking for cloud and non-cloud environments. [[1]](diffhunk://#diff-d556eaf847c04654b681c11bee991df97ce245f7581672f0afc867854de47e13L90-R91) [[2]](diffhunk://#diff-d556eaf847c04654b681c11bee991df97ce245f7581672f0afc867854de47e13L100-R110)

Resolves https://redpandadata.atlassian.net/browse/DOC-1943
Review deadline:

## Page previews
[What's New in Redpanda Cloud](https://deploy-preview-1565--redpanda-docs-preview.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[Schema ID Validation](https://deploy-preview-1565--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/schema-reg/schema-id-validation/) (in Cloud)
[enable_schema_id_validation](https://deploy-preview-1565--redpanda-docs-preview.netlify.app/redpanda-cloud/reference/properties/cluster-properties/#enable_schema_id_validation) (in Cloud)
[enable_schema_id_validation](https://deploy-preview-1565--redpanda-docs-preview.netlify.app/current/reference/properties/cluster-properties/#enable_schema_id_validation) (in SM)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
