### PR TITLE
Add gloss term for log

### DIFF
--- a/modules/terms/partials/log.adoc
+++ b/modules/terms/partials/log.adoc
@@ -3,6 +3,6 @@
 :hover-text: An ordered, append-only, immutable sequence of records.
 :category: Redpanda core
 
-The log is Redpanda's core storage abstraction. Topics and partitions are implemented as logs. Logs are replicated across brokers within a Redpanda cluster for fault tolerance.
+The log is Redpanda's core storage abstraction for event streams. At the conceptual level, topics represent replayable logs. Physically, each partition is implemented as a log file on disk, divided into segments. Redpanda uses the Raft consensus algorithm to coordinate writing data to log files and replicate them across brokers for fault tolerance.
 
-See also: topic, partition
+See also: topic, partition, segment

--- a/modules/terms/partials/log.adoc
+++ b/modules/terms/partials/log.adoc
@@ -1,0 +1,8 @@
+=== log
+:term-name: log
+:hover-text: An ordered, append-only, immutable sequence of records.
+:category: Redpanda core
+
+The log is Redpanda's core storage abstraction. Topics and partitions are implemented as logs. Logs are replicated across brokers within a Redpanda cluster for fault tolerance.
+
+See also: topic, partition


### PR DESCRIPTION
## Description

This pull request adds documentation for the term "log" in the Redpanda core module. The new partial provides a concise definition and context for how logs are used within Redpanda.

Documentation update:

* Added a new partial `log.adoc` defining "log" as an ordered, append-only, immutable sequence of records, and explaining its role in Redpanda's storage and replication.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
