### PR TITLE
fix(DOC-2061): clarify schema reference name field per schema type

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -648,7 +648,23 @@ A successful registration returns the schema's `id`:
 
 == Reference a schema
 
-To build more complex schema definitions, you can add a reference to other schemas. The following example registers a Protobuf schema in subject `test-simple` with a message name `Simple`.
+To build more complex schema definitions, you can add a reference to other schemas. A reference identifies another schema using a `name`, `subject`, and `version`. The meaning of `name` depends on the schema type:
+
+[cols="1,2"]
+|===
+| Schema type | Reference name
+
+| Protobuf
+| The import path used in the `.proto` file (for example, `import "simple";` uses name `simple`)
+
+| Avro
+| The fully qualified schema name, combining the namespace and record name (for example, `com.example.Address`)
+
+| JSON Schema
+| A URI used in `$ref` to identify the referenced schema
+|===
+
+The following example registers a Protobuf schema in subject `test-simple` with a message name `Simple`.
 
 [tabs]
 ====

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -655,7 +655,7 @@ To build more complex schema definitions, you can add a reference to other schem
 | Schema type | Reference name
 
 | Protobuf
-| The import path used in the `.proto` file (for example, `import "simple";` uses name `simple`)
+| The import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`)
 
 | Avro
 | The fully qualified schema name, combining the namespace and record name (for example, `com.example.Address`)

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -658,7 +658,7 @@ To build more complex schema definitions, you can add a reference to other schem
 | The import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`)
 
 | Avro
-| The schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not (for example, `com.example.Address` or `Address`)
+| The schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not (for example, `com.example.Address` or `Address`).
 
 | JSON Schema
 | Used to identify the referenced schema in `$ref`. Redpanda's Schema Registry does not yet support external JSON Schema references (where `$ref` points to a schema registered under a different subject). To structure complex JSON schemas, define referenced types within the same schema document using `definitions` / `$defs` or bundled `$id` schemas. See xref:manage:schema-reg/schema-reg-overview.adoc#limitations[JSON Schema limitations].

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -661,7 +661,7 @@ To build more complex schema definitions, you can add a reference to other schem
 | The schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not (for example, `com.example.Address` or `Address`)
 
 | JSON Schema
-| A URI used in `$ref` to identify the referenced schema
+| Used to identify the referenced schema in `$ref`. Redpanda's Schema Registry does not yet support external JSON Schema references (where `$ref` points to a schema registered under a different subject). To structure complex JSON schemas, define referenced types within the same schema document using `definitions` / `$defs` or bundled `$id` schemas. See xref:manage:schema-reg/schema-reg-overview.adoc#limitations[JSON Schema limitations].
 |===
 
 The following example registers a Protobuf schema in subject `test-simple` with a message name `Simple`.

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -655,7 +655,7 @@ To build more complex schema definitions, you can add a reference to other schem
 | Schema type | Reference name
 
 | Protobuf
-| The import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`)
+| The import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`).
 
 | Avro
 | The schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not (for example, `com.example.Address` or `Address`).

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -658,7 +658,7 @@ To build more complex schema definitions, you can add a reference to other schem
 | The import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`)
 
 | Avro
-| The fully qualified schema name, combining the namespace and record name (for example, `com.example.Address`)
+| The schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not (for example, `com.example.Address` or `Address`)
 
 | JSON Schema
 | A URI used in `$ref` to identify the referenced schema

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -146,14 +146,9 @@ All CRUD operations are supported for the JSON Schema (`json-schema`), and Redpa
 
 Schemas are held in subjects. Subjects have a compatibility configuration associated with them, either directly specified by a user, or inherited by the default. See `PUT /config` and `PUT/config/\{subject}` in the link:/api/doc/schema-registry/[Schema Registry API].
 
-If you have inserted a second schema into a subject where the compatibility level is anything but `NONE`, then any JSON Schema containing the following items are rejected:
+JSON Schema supports internal references (`$ref` using JSON Pointer fragments such as `#/definitions/...` or `#/$defs/...`) and bundled schemas (sub-schemas with their own `$id` defined within the same document). These work correctly with all compatibility levels.
 
-* `$ref`
-* `$defs` (`definitions` prior to draft 2019-09)
-* `dependentSchemas` / `dependentRequired` (`dependencies` prior to draft 2019-09)
-* `prefixItems`
-
-Consequently, you cannot https://json-schema.org/understanding-json-schema/structuring[structure a complex schema^] using these features.
+External references, where `$ref` points to a schema registered under a different subject, are not supported. To https://json-schema.org/understanding-json-schema/structuring[structure complex JSON schemas^], define referenced types within the same schema document using `definitions` / `$defs` or bundled `$id` schemas.
 
 ifndef::env-cloud[]
 Additionally, you cannot have xref:manage:schema-reg/schema-id-validation.adoc#about-schema-id-validation[schema ID validation] with JSON schemas if the xref:manage:schema-reg/schema-id-validation.adoc#set-subject-name-strategy-per-topic[subject name strategy] _is not_ `TopicNameStrategy`.


### PR DESCRIPTION
## Summary

Resolves [DOC-2061](https://redpandadata.atlassian.net/browse/DOC-2061).

Adds a reference-name table to the "Reference a schema" section of `schema-reg-api.adoc`, and corrects the JSON Schema Limitations section on `schema-reg-overview.adoc` per `@pgellert`'s review.

This PR was originally opened by `@mfernest`, who is no longer with the team. `@Feediver1` is taking it over to land the remaining work after `@pgellert`'s 2026-04-01 review.

### What changed

- **New reference-name table** under "Reference a schema" in `schema-reg-api.adoc`, explaining what the `name` field means per schema type:
  - **Protobuf** — the import path used in the `.proto` file (for example, `import "simple.proto";` uses name `simple.proto`)
  - **Avro** — the schema name used by Avro resolution: fully qualified (`namespace.name`) when a namespace is defined, or just the record name when it is not
  - **JSON Schema** — used to identify the referenced schema in `$ref`, with a note that Redpanda's Schema Registry does not yet support external references (where `$ref` points to a schema in a different subject), and a link to the limitations
- **JSON Schema Limitations section rewritten** on `schema-reg-overview.adoc`. The previous wording implied any use of `$ref`, `$defs`, `definitions`, `dependentSchemas`, `dependentRequired`, or `prefixItems` was rejected. Per `@pgellert`, that overstates the constraint: internal references via JSON Pointer fragments (`#/definitions/...`, `#/$defs/...`) and bundled schemas with their own `$id` do work; only *external* references (cross-subject) are unsupported.

### Review history

| Reviewer | Status |
|---|---|
| `@kbatuigas` | Approved 2026-03-19 (predates pgellert's review and the JSON Schema correctness fix; re-requesting) |
| CodeRabbit | Avro no-namespace nit — addressed in `bba27a74` |
| `@pgellert` | Three inline comments 2026-04-01 — all three now addressed; re-requesting review |
| `@JakeSCahill` | Originally pinged `@BenPope`, who is no longer at Redpanda; substantive SME is `@pgellert` |

## Preview pages

- [Reference a schema (schema-reg-api)](https://deploy-preview-1613--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-api/#reference-a-schema) — new reference-name table
- [JSON Schema Limitations (schema-reg-overview)](https://deploy-preview-1613--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-overview/#limitations) — rewritten internal-vs-external references

## Test plan

- [ ] Netlify preview builds without errors
- [ ] Reference-name table renders with three rows; JSON Schema row shows the "not yet supported" caveat and the xref resolves to the limitations section
- [ ] Limitations section reads correctly in both cloud and non-cloud builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2061]: https://redpandadata.atlassian.net/browse/DOC-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ