### PR TITLE
Iceberg: Manage access for end users/clients

### DIFF
--- a/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-aws-glue.adoc
@@ -333,6 +333,10 @@ Your query results should look like the following:
 +-----------------------------------------------------+----------------+
 ----
 
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and the AWS Glue Data Catalog. To grant your end users and query engines (such as Amazon Athena or Apache Spark) read access to the Iceberg tables, use https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html[AWS Lake Formation^] to assign table-level and column-level permissions.
+
 include::shared:partial$suggested-reading.adoc[]
 
 - xref:manage:iceberg/query-iceberg-topics.adoc[]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -240,10 +240,6 @@ You should see the topic as a table with data in Unity Catalog. The data may tak
 
 You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table.
 
-=== Manage access for query engine users
-
-Redpanda manages the permissions between Redpanda and Unity Catalog. To grant your end users or query engines read access to the Iceberg tables, use Unity Catalog to assign the appropriate privileges. Review the Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
-
 The following example shows how to query the Iceberg table using SQL in Databricks SQL.
 
 . In the Databricks console, open *SQL Editor*.
@@ -271,6 +267,10 @@ Your query results should look like the following:
 | "headers":null,"key":"68656c6c6f"}                                   |            |
 +----------------------------------------------------------------------+------------+
 ----
+
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and Unity Catalog. To grant your end users or query engines read access to the Iceberg tables, use Unity Catalog to assign the appropriate privileges. Review the Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -238,7 +238,11 @@ You should see the topic as a table with data in Unity Catalog. The data may tak
 
 == Query Iceberg table using Databricks SQL
 
-You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table. Review the Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
+You can query the Iceberg table using different engines, such as Databricks SQL, PyIceberg, or Apache Spark. To query the table or view the table data in Catalog Explorer, ensure that your account has the necessary permissions to read the table.
+
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and Unity Catalog. To grant your end users or query engines read access to the Iceberg tables, use Unity Catalog to assign the appropriate privileges. Review the Databricks documentation on https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/?language=SQL#grant-permissions-on-objects-in-a-unity-catalog-metastore[granting permissions to objects^] and https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/privileges[Unity Catalog privileges^] for details.
 
 The following example shows how to query the Iceberg table using SQL in Databricks SQL.
 

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -430,6 +430,10 @@ gcloud iam service-accounts delete <service-account-name>@$(gcloud config get-va
 NOTE: Manually delete the Lakehouse catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API^].
 endif::[]
 
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and the BigLake catalog. To grant your end users and query engines read access to the Iceberg tables in BigQuery, see https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[Grant permissions for BigLake tables^] in the Google Cloud documentation.
+
 include::shared:partial$suggested-reading.adoc[]
 
 - xref:manage:iceberg/use-iceberg-catalogs.adoc[]

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -410,6 +410,10 @@ Replace `<bucket-name>` with your bucket name.
 
 Your Redpanda topic is now available as Iceberg tables in Lakehouse, allowing you to run analytics queries directly on your streaming data.
 
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and the BigLake catalog. To grant your end users and query engines read access to the Iceberg tables in BigQuery, see https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[Grant permissions for BigLake tables^] in the Google Cloud documentation.
+
 ifndef::env-cloud[]
 == Optional: Clean up resources
 
@@ -429,10 +433,6 @@ gcloud iam service-accounts delete <service-account-name>@$(gcloud config get-va
 
 NOTE: Manually delete the Lakehouse catalog using the https://docs.cloud.google.com/bigquery/docs/reference/biglake/rest/v1/projects.locations.catalogs/delete[REST API^].
 endif::[]
-
-=== Manage access for query engine users
-
-Redpanda manages the permissions between Redpanda and the BigLake catalog. To grant your end users and query engines read access to the Iceberg tables in BigQuery, see https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[Grant permissions for BigLake tables^] in the Google Cloud documentation.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -53,6 +53,31 @@ EOF
 
 endif::[]
 
+=== Grant access to query engine users
+
+Redpanda manages the service-to-service permissions between Redpanda and the catalog (documented in each catalog integration guide). However, you are responsible for granting your end users and query engines (such as Amazon Athena, Apache Spark, Trino, or Snowflake) read access to the Iceberg data.
+
+There are two approaches to controlling access, and you can use them together:
+
+==== Cloud storage prefix-level access
+
+Grant query engine roles or users read access to the Iceberg data prefix in the cluster's storage bucket. This controls who can read the underlying data and metadata files. Scope permissions to specific prefixes to restrict access to individual tables.
+
+* AWS (S3): Use IAM policies to grant `s3:GetObject` and `s3:ListBucket` on the Iceberg prefix (for example, `<cluster-storage-bucket-name>/redpanda-iceberg-catalog/*`). See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-iam-policies.html[Using IAM policies with Amazon S3^].
+* GCP (GCS): Use IAM conditions or bucket-level policies to grant `storage.objects.get` and `storage.objects.list` on the Iceberg prefix. See https://cloud.google.com/storage/docs/access-control/iam[GCS IAM permissions^].
+* Azure (Blob Storage): Use Azure RBAC roles such as Storage Blob Data Reader scoped to the container or prefix. See https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory[Authorize access to blob data^].
+
+==== Catalog-level table access
+
+If you use a REST catalog, you can control access at the table level through the catalog's own access control layer. This is useful when query engines access tables through the catalog rather than reading files directly.
+
+* AWS Glue: Use https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html[AWS Lake Formation^] to grant table-level and column-level permissions.
+* Databricks Unity Catalog: See the https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/index.html[Unity Catalog privileges documentation^].
+* Snowflake Open Catalog: See https://other-docs.snowflake.com/en/opencatalog/access-control[Open Catalog access control^].
+* GCP BigLake: See https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[BigLake table permissions^].
+
+=== Refresh table data
+
 Some query engines may require you to manually refresh the Iceberg table snapshot (for example, by running a command like `ALTER TABLE <table-name> REFRESH;`) to see the latest data.
 
 If your engine needs the full JSON metadata path, use the following:

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -70,6 +70,31 @@ EOF
 
 endif::[]
 
+=== Grant access to query engine users
+
+Redpanda manages the service-to-service permissions between Redpanda and the catalog (documented in each catalog integration guide). However, you are responsible for granting your end users and query engines (such as Amazon Athena, Apache Spark, Trino, or Snowflake) read access to the Iceberg data.
+
+There are two approaches to controlling access, and you can use them together:
+
+==== Cloud storage prefix-level access
+
+Grant query engine roles or users read access to the Iceberg data prefix in the cluster's storage bucket. This controls who can read the underlying data and metadata files. Scope permissions to specific prefixes to restrict access to individual tables.
+
+* AWS (S3): Use IAM policies to grant `s3:GetObject` and `s3:ListBucket` on the Iceberg prefix (for example, `<cluster-storage-bucket-name>/redpanda-iceberg-catalog/*`). See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-iam-policies.html[Using IAM policies with Amazon S3^].
+* GCP (GCS): Use IAM conditions or bucket-level policies to grant `storage.objects.get` and `storage.objects.list` on the Iceberg prefix. See https://cloud.google.com/storage/docs/access-control/iam[GCS IAM permissions^].
+* Azure (Blob Storage): Use Azure RBAC roles such as Storage Blob Data Reader scoped to the container or prefix. See https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory[Authorize access to blob data^].
+
+==== Catalog-level table access
+
+If you use a REST catalog, you can control access at the table level through the catalog's own access control layer. This is useful when query engines access tables through the catalog rather than reading files directly.
+
+* AWS Glue: Use https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html[AWS Lake Formation^] to grant table-level and column-level permissions.
+* Databricks Unity Catalog: See the https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/index.html[Unity Catalog privileges documentation^].
+* Snowflake Open Catalog: See https://other-docs.snowflake.com/en/opencatalog/access-control[Open Catalog access control^].
+* GCP BigLake: See https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[BigLake table permissions^].
+
+=== Refresh table data
+
 Some query engines may require you to manually refresh the Iceberg table snapshot (for example, by running a command like `ALTER TABLE <table-name> REFRESH;`) to see the latest data.
 
 If your engine needs the full JSON metadata path, use the following:

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -82,7 +82,7 @@ If you use a REST catalog, you can control access at the table level through the
 
 * AWS Glue: Use https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html[AWS Lake Formation^] to grant table-level and column-level permissions.
 * Databricks Unity Catalog: See the https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/index.html[Unity Catalog privileges documentation^].
-* Snowflake Open Catalog: See https://other-docs.snowflake.com/en/opencatalog/access-control[Open Catalog access control^].
+* Snowflake Open Catalog: See https://docs.snowflake.com/en/user-guide/opencatalog/access-control[Open Catalog access control^].
 * GCP BigLake: See https://cloud.google.com/bigquery/docs/manage-open-source-metadata#grant_permissions[BigLake table permissions^].
 
 === Refresh table data

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -3,6 +3,10 @@
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
 
 // tag::single-source[]
+:page-topic-type: how-to
+:personas: data_engineer
+:learning-objective-1: Query Redpanda topic data from an Iceberg-compatible engine
+:learning-objective-2: Grant end-user and query engine access to Iceberg data
 
 ifndef::env-cloud[]
 [NOTE]
@@ -12,6 +16,11 @@ include::shared:partial$enterprise-license.adoc[]
 endif::[]
 
 When you access Iceberg topics from a data lakehouse or other Iceberg-compatible tools, how you consume the data depends on the topic xref:manage:iceberg/choose-iceberg-mode.adoc[Iceberg mode] and whether you've registered a schema for the topic in the xref:manage:schema-reg/schema-reg-overview.adoc[Redpanda Schema Registry]. You do not need to rely on complex ETL jobs or pipelines to access real-time data from Redpanda.
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
 
 == Access Iceberg tables
 
@@ -55,9 +64,9 @@ endif::[]
 
 === Grant access to query engine users
 
-Redpanda manages the service-to-service permissions between Redpanda and the catalog (documented in each catalog integration guide). However, you are responsible for granting your end users and query engines (such as Amazon Athena, Apache Spark, Trino, or Snowflake) read access to the Iceberg data.
+Redpanda manages the service-to-service permissions between Redpanda and the catalog (see xref:manage:iceberg/use-iceberg-catalogs.adoc[]). However, you are responsible for granting your end users and query engines (such as Amazon Athena, Apache Spark, Trino, or Snowflake) read access to the Iceberg data.
 
-There are two approaches to controlling access, and you can use them together:
+Use either or both of the following approaches to control access:
 
 ==== Cloud storage prefix-level access
 
@@ -69,7 +78,7 @@ Grant query engine roles or users read access to the Iceberg data prefix in the 
 
 ==== Catalog-level table access
 
-If you use a REST catalog, you can control access at the table level through the catalog's own access control layer. This is useful when query engines access tables through the catalog rather than reading files directly.
+If you use a REST catalog, you can control access at the table level through the catalog's own access control layer. Use this approach when query engines access tables through the catalog rather than reading files directly.
 
 * AWS Glue: Use https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html[AWS Lake Formation^] to grant table-level and column-level permissions.
 * Databricks Unity Catalog: See the https://docs.databricks.com/en/data-governance/unity-catalog/manage-privileges/index.html[Unity Catalog privileges documentation^].

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -56,7 +56,7 @@ Create an IAM policy with the following S3 permissions, scoped to your cluster's
         "s3:DeleteObject",
         "s3:DeleteObjectVersion"
       ],
-      "Resource": "arn:aws:s3:::<bucket-name>/redpanda-iceberg-catalog/*"
+      "Resource": "arn:aws:s3:::<bucket-name>/*"
     },
     {
       "Effect": "Allow",

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -13,7 +13,12 @@ include::shared:partial$enterprise-license.adoc[]
 :learning-objective-1: Configure AWS IAM credentials granting Open Catalog access to your S3 bucket
 :learning-objective-2: Integrate Redpanda Iceberg topics with Snowflake using Open Catalog
 
-This guide walks you through querying Redpanda topics as Iceberg tables in https://docs.snowflake.com/en/user-guide/tables-iceberg[Snowflake^], with Amazon S3 as object storage and a catalog integration using https://other-docs.snowflake.com/en/opencatalog/overview[Open Catalog^].
+This guide walks you through querying Redpanda topics as Iceberg tables in https://docs.snowflake.com/en/user-guide/tables-iceberg[Snowflake^], with Amazon S3 as object storage and a catalog integration using https://docs.snowflake.com/en/user-guide/opencatalog/overview[Open Catalog^].
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
 
 == Prerequisites
 
@@ -27,20 +32,11 @@ You need the S3 bucket URI to configure it as external storage for Open Catalog.
 endif::[]
 * A Snowflake account.
 * An Open Catalog account. To https://other-docs.snowflake.com/en/opencatalog/create-open-catalog-account[create an Open Catalog account^], you require ORGADMIN access in Snowflake.
-* An internal catalog created in Open Catalog with your Tiered Storage AWS S3 bucket configured as external storage.
-+
-Follow the https://other-docs.snowflake.com/en/opencatalog/create-catalog#create-a-catalog-using-amazon-simple-storage-service-amazon-s3[Open Catalog documentation^] to create a catalog with the S3 bucket configured as external storage. For the required IAM permissions, see <<authorize-access-to-open-catalog>>.
-+
-NOTE: Your Open Catalog account must be in the same AWS region as your S3 bucket.
-+
-* A Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume[external volume^] set up using the Tiered Storage bucket.
-+
-Follow the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[Snowflake documentation^] to configure the external volume with S3. You can use the same IAM policy and role as the catalog.
 
 [[authorize-access-to-open-catalog]]
 == Authorize access to Open Catalog
 
-You must create an AWS IAM policy and role that grants Open Catalog read and write access to the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so Redpanda does not need additional IAM configuration for its own S3 access.
+You must create an AWS IAM policy and role that Open Catalog and Snowflake use to access the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so Redpanda does not need additional IAM configuration for its own S3 access. You finish configuring this role's trust policy when you create the catalog and the external volume, using values that Open Catalog and Snowflake generate for you.
 
 === Create an IAM policy
 
@@ -60,7 +56,7 @@ Create an IAM policy with the following S3 permissions, scoped to your cluster's
         "s3:DeleteObject",
         "s3:DeleteObjectVersion"
       ],
-      "Resource": "arn:aws:s3:::<bucket-name>/*"
+      "Resource": "arn:aws:s3:::<bucket-name>/redpanda-iceberg-catalog/*"
     },
     {
       "Effect": "Allow",
@@ -74,16 +70,34 @@ Create an IAM policy with the following S3 permissions, scoped to your cluster's
 }
 ----
 
-Replace `<bucket-name>` with the name of your cluster's object storage bucket. You can use the same IAM policy for both the catalog and the Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[external volume^].
+Replace `<bucket-name>` with the name of your cluster's object storage bucket. You use this same IAM policy for both the Open Catalog role and the Snowflake external volume.
 
-=== Create an IAM role and configure the trust policy
+=== Create an IAM role
 
-Create an IAM role and attach the IAM policy you created. To configure the trust relationship, you need the IAM user ARN and external ID provided by Open Catalog:
+Create an IAM role and attach the IAM policy you created. Open Catalog and Snowflake each need this role's ARN before they can generate the IAM user and external ID values you use to finish configuring the trust policy, so create the role with a temporary trust relationship for now:
 
-. In Open Catalog, navigate to your catalog.
-. Under *Configuration*, find the *IAM user ARN* and *External ID*.
+. In the AWS IAM console, create a new role.
+. For the trusted entity type, select *AWS account*. Under *An AWS account*, select *This account*.
+. Attach the IAM policy you created.
+. Note the role's ARN (`<iam-role-arn>`). You update this role's trust policy after Open Catalog and Snowflake generate the values you need, when you create the catalog and the external volume.
 
-Use these values in the trust policy for the IAM role:
+== Create a catalog in Open Catalog
+
+Create the catalog that Redpanda's Iceberg data and metadata are registered to, with your Tiered Storage S3 bucket configured as external storage:
+
+. In Open Catalog, create a new catalog.
+. For *S3 role ARN*, enter `<iam-role-arn>`, the ARN of the IAM role you created.
+. Configure the catalog's external storage location to point to your Tiered Storage S3 bucket.
++
+NOTE: Your Open Catalog account must be in the same AWS region as your S3 bucket.
+. On the Open Catalog home page, in the *Catalogs* pane, select the catalog you created. Under *Storage Details*, copy the *IAM user arn* (`<open-catalog-iam-user-arn>`).
+. If you didn't specify an external ID when you created the IAM role, Open Catalog generates one for you (`<open-catalog-external-id>`). Record this value.
+
+For complete steps, see the https://docs.snowflake.com/en/user-guide/opencatalog/create-catalog[Open Catalog documentation^].
+
+=== Update the IAM role trust policy for Open Catalog
+
+Update the trust policy for the IAM role you created, using the IAM user ARN and external ID that Open Catalog generated when you created the catalog:
 
 [,json]
 ----
@@ -106,7 +120,86 @@ Use these values in the trust policy for the IAM role:
 }
 ----
 
-After creating the IAM role, provide the role ARN to Open Catalog to complete the catalog configuration.
+After you update the trust policy, Open Catalog can assume the role to read and write Iceberg data and metadata in your S3 bucket.
+
+== Create a Snowflake external volume
+
+Create a Snowflake external volume using the same IAM role you created for Open Catalog. Snowflake provisions its own IAM user to assume the role, so you add a second statement to the role's trust policy rather than replacing the statement that trusts Open Catalog:
+
+. In Snowflake, run `CREATE EXTERNAL VOLUME`, pointing `STORAGE_AWS_ROLE_ARN` to the IAM role you created:
++
+[,sql]
+----
+CREATE OR REPLACE EXTERNAL VOLUME <iceberg-external-volume-name>
+  STORAGE_LOCATIONS = (
+    (
+      NAME = '<storage-location-name>'
+      STORAGE_PROVIDER = 'S3'
+      STORAGE_BASE_URL = 's3://<bucket-name>/'
+      STORAGE_AWS_ROLE_ARN = '<iam-role-arn>'
+      STORAGE_AWS_EXTERNAL_ID = '<external-volume-external-id>'
+    )
+  )
+  ALLOW_WRITES = TRUE;
+----
++
+Use your own values for the following placeholders:
++
+- `<iceberg-external-volume-name>`: Provide a name for your external volume in Snowflake.
+- `<storage-location-name>`: Provide a name for the storage location.
+- `<external-volume-external-id>`: Choose an external ID for the volume's trust relationship, distinct from the external ID Open Catalog uses. If you don't set `STORAGE_AWS_EXTERNAL_ID`, Snowflake generates one for you.
+. Run `DESC EXTERNAL VOLUME` to retrieve the IAM user ARN that Snowflake generated for the volume:
++
+[,sql]
+----
+DESC EXTERNAL VOLUME <iceberg-external-volume-name>;
+----
++
+Record the `STORAGE_AWS_IAM_USER_ARN` value from the output (`<external-volume-iam-user-arn>`).
+. Add a new statement to the IAM role's trust policy for the volume's IAM user ARN and external ID, alongside the existing statement that trusts Open Catalog:
++
+IMPORTANT: Add this as a new statement in the trust policy's `Statement` array. If you replace the existing trust policy instead, Open Catalog loses access to the bucket.
++
+[,json,lines=16-27]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<open-catalog-iam-user-arn>"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<open-catalog-external-id>"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<external-volume-iam-user-arn>"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<external-volume-external-id>"
+        }
+      }
+    }
+  ]
+}
+----
+. Run `SYSTEM$VERIFY_EXTERNAL_VOLUME` to confirm Snowflake can access the bucket:
++
+[,sql]
+----
+SELECT SYSTEM$VERIFY_EXTERNAL_VOLUME('<iceberg-external-volume-name>');
+----
+
+For complete steps, see the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[Snowflake documentation^].
 
 == Set up catalog integration using Open Catalog
 
@@ -130,7 +223,7 @@ Grant privileges to the principal created in the previous step:
 . In Open Catalog, select *Catalogs*, and select your catalog.
 . On the *Roles* tab of your catalog, click *+ Catalog Role*.
 . Give the catalog role a name. 
-. Under *Privileges*, select `CATALOG_MANAGE_CONTENT`. This provides full management https://other-docs.snowflake.com/en/opencatalog/access-control#catalog-privileges[privileges^] for the catalog. Then, click *Create*. 
+. Under *Privileges*, select `CATALOG_MANAGE_CONTENT`. This provides full management https://docs.snowflake.com/en/user-guide/opencatalog/access-control#catalog-privileges[privileges^] for the catalog. Then, click *Create*.
 . On the *Roles* tab of the catalog, click *Grant to Principal Role*. 
 . Select the catalog role you just created.
 . Select the principal role you created earlier. Click *Grant*.
@@ -348,7 +441,7 @@ Your query results should look like the following:
 
 === Manage access for query engine users
 
-Redpanda manages the permissions between Redpanda and Open Catalog. To grant your Snowflake users or other query engines read access to the Iceberg tables, use https://other-docs.snowflake.com/en/opencatalog/access-control[Open Catalog access control^] to assign catalog privileges. For example, you can grant `TABLE_READ_DATA` to a read-only role rather than the `CATALOG_MANAGE_CONTENT` privilege used by the Redpanda service principal.
+Redpanda manages the permissions between Redpanda and Open Catalog. To grant your Snowflake users or other query engines read access to the Iceberg tables, use https://docs.snowflake.com/en/user-guide/opencatalog/access-control[Open Catalog access control^] to assign catalog privileges. For example, you can grant `TABLE_READ_DATA` to a read-only role rather than the `CATALOG_MANAGE_CONTENT` privilege used by the Redpanda service principal.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -25,15 +25,84 @@ endif::[]
 * An Open Catalog account. To https://other-docs.snowflake.com/en/opencatalog/create-open-catalog-account[create an Open Catalog account^], you require ORGADMIN access in Snowflake.
 * An internal catalog created in Open Catalog with your Tiered Storage AWS S3 bucket configured as external storage.
 +
-Follow this guide to https://other-docs.snowflake.com/en/opencatalog/create-catalog#create-a-catalog-using-amazon-simple-storage-service-amazon-s3[create a catalog^] with the S3 bucket configured as external storage. You require admin permissions to carry out these steps in AWS:
+Follow the https://other-docs.snowflake.com/en/opencatalog/create-catalog#create-a-catalog-using-amazon-simple-storage-service-amazon-s3[Open Catalog documentation^] to create a catalog with the S3 bucket configured as external storage. For the required IAM permissions, see <<authorize-access-to-open-catalog>>.
 +
-. If you don't already have one, create an IAM policy that gives Open Catalog read and write access to your S3 bucket.
-. Create an IAM role and attach the IAM policy to the role.
-. After creating a new catalog in Open Catalog, grant the catalog's AWS IAM user access to the S3 bucket.
+* A Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume[external volume^] set up using the Tiered Storage bucket.
 +
-* A Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume[external volume^] set up using the Tiered Storage bucket. 
-+
-Follow this guide to https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[configure the external volume with S3^]. You can use the same IAM policy as the catalog for the external volume's IAM role and user. 
+Follow the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[Snowflake documentation^] to configure the external volume with S3. You can use the same IAM policy and role as the catalog.
+
+[[authorize-access-to-open-catalog]]
+== Authorize access to Open Catalog
+
+You must create an AWS IAM policy and role that grants Open Catalog read and write access to the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so no additional IAM configuration is needed for Redpanda's own S3 access.
+
+NOTE: Unlike the AWS Glue catalog integration, this IAM setup is not automatically provisioned for BYOC clusters. Both Cloud (BYOC) and self-managed users must create these resources manually.
+
+=== Create an IAM policy
+
+Create an IAM policy with the following S3 permissions, scoped to your cluster's storage bucket:
+
+[,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion"
+      ],
+      "Resource": "arn:aws:s3:::<bucket-name>/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::<bucket-name>"
+    }
+  ]
+}
+----
+
+Replace `<bucket-name>` with the name of your cluster's object storage bucket. You can use the same IAM policy for both the catalog and the Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[external volume^].
+
+=== Create an IAM role and configure the trust policy
+
+Create an IAM role and attach the IAM policy you created. To configure the trust relationship, you need the IAM user ARN and external ID provided by Open Catalog:
+
+. In Open Catalog, navigate to your catalog.
+. Under *Configuration*, find the *IAM user ARN* and *External ID*.
+
+Use these values in the trust policy for the IAM role:
+
+[,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<open-catalog-iam-user-arn>"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<open-catalog-external-id>"
+        }
+      }
+    }
+  ]
+}
+----
+
+After creating the IAM role, provide the role ARN to Open Catalog to complete the catalog configuration.
 
 == Set up catalog integration using Open Catalog
 
@@ -270,5 +339,13 @@ Your query results should look like the following:
 +--------------------------------------------------------------------------------------------------------------+------------+
 
 ----
+
+=== Manage access for query engine users
+
+Redpanda manages the permissions between Redpanda and Open Catalog. To grant your Snowflake users or other query engines read access to the Iceberg tables, use https://other-docs.snowflake.com/en/opencatalog/access-control[Open Catalog access control^] to assign catalog privileges. For example, you can grant `TABLE_READ_DATA` to a read-only role rather than the `CATALOG_MANAGE_CONTENT` privilege used by the Redpanda service principal.
+
+include::shared:partial$suggested-reading.adoc[]
+
+- xref:manage:iceberg/query-iceberg-topics.adoc[]
 
 // end::single-source[]

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -8,8 +8,12 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 
 // tag::single-source[]
+:page-topic-type: how-to
+:personas: platform_admin, data_engineer
+:learning-objective-1: Configure AWS IAM credentials granting Open Catalog access to your S3 bucket
+:learning-objective-2: Integrate Redpanda Iceberg topics with Snowflake using Open Catalog
 
-This guide walks you through querying Redpanda topics as Iceberg tables in https://docs.snowflake.com/en/user-guide/tables-iceberg[Snowflake^], with AWS S3 as object storage and a catalog integration using https://other-docs.snowflake.com/en/opencatalog/overview[Open Catalog^].
+This guide walks you through querying Redpanda topics as Iceberg tables in https://docs.snowflake.com/en/user-guide/tables-iceberg[Snowflake^], with Amazon S3 as object storage and a catalog integration using https://other-docs.snowflake.com/en/opencatalog/overview[Open Catalog^].
 
 == Prerequisites
 
@@ -36,7 +40,7 @@ Follow the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-ext
 [[authorize-access-to-open-catalog]]
 == Authorize access to Open Catalog
 
-You must create an AWS IAM policy and role that grants Open Catalog read and write access to the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so no additional IAM configuration is needed for Redpanda's own S3 access.
+You must create an AWS IAM policy and role that grants Open Catalog read and write access to the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so Redpanda does not need additional IAM configuration for its own S3 access.
 
 === Create an IAM policy
 
@@ -105,6 +109,8 @@ Use these values in the trust policy for the IAM role:
 After creating the IAM role, provide the role ARN to Open Catalog to complete the catalog configuration.
 
 == Set up catalog integration using Open Catalog
+
+To integrate Iceberg-enabled topics with Open Catalog, create a service connection and configure catalog roles.
 
 === Create a new Open Catalog service connection for Redpanda
 
@@ -235,10 +241,10 @@ rpk topic alter-config <topic-name> --set redpanda.iceberg.mode=key_value
 echo "hello world\nfoo bar\nbaz qux" | rpk topic produce <topic-name> --format='%k %v\n'
 ----
 
-You should see the topic as a table in Open Catalog.
+The topic appears as a table in Open Catalog.
 
-. In Open Catalog, select *Catalogs*, then open your catalog. 
-. Under your catalog, you should see the `redpanda` namespace (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), and a table with the name of your topic. The namespace and the table are automatically added for you.
+. In Open Catalog, select *Catalogs*, then open your catalog.
+. Under your catalog, you will see the `redpanda` namespace (or the namespace you configured with config_ref:iceberg_default_catalog_namespace,true,properties/cluster-properties[`iceberg_default_catalog_namespace`]), and a table with the name of your topic. The namespace and the table are automatically added for you.
 
 == Query Iceberg table in Snowflake
 
@@ -315,7 +321,7 @@ Use your own values for the following placeholders:
 - `<iceberg-external-volume-name>`: The name of the external volume you configured using the Tiered Storage bucket.
 - `<topic-name>`: The name of the table in your catalog, which is the same as your Redpanda topic name.
 
-=== Query table
+=== Query the Iceberg table
 
 To verify that Snowflake has successfully created the table containing the topic data, run the following:
 

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -27,6 +27,8 @@ endif::[]
 +
 Follow the https://other-docs.snowflake.com/en/opencatalog/create-catalog#create-a-catalog-using-amazon-simple-storage-service-amazon-s3[Open Catalog documentation^] to create a catalog with the S3 bucket configured as external storage. For the required IAM permissions, see <<authorize-access-to-open-catalog>>.
 +
+NOTE: Your Open Catalog account must be in the same AWS region as your S3 bucket.
++
 * A Snowflake https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume[external volume^] set up using the Tiered Storage bucket.
 +
 Follow the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume-s3[Snowflake documentation^] to configure the external volume with S3. You can use the same IAM policy and role as the catalog.
@@ -35,8 +37,6 @@ Follow the https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-ext
 == Authorize access to Open Catalog
 
 You must create an AWS IAM policy and role that grants Open Catalog read and write access to the S3 bucket where your Iceberg data is stored. Redpanda writes Iceberg data and metadata files to the bucket using your cluster's existing object storage credentials, so no additional IAM configuration is needed for Redpanda's own S3 access.
-
-NOTE: Unlike the AWS Glue catalog integration, this IAM setup is not automatically provisioned for BYOC clusters. Both Cloud (BYOC) and self-managed users must create these resources manually.
 
 === Create an IAM policy
 


### PR DESCRIPTION
## Description

This pull request adds a new section to the Iceberg documentation, clarifying how to grant query engine users access to Iceberg data. The update explains both cloud storage-level and catalog-level access control, providing practical guidance and links for AWS, GCP, Azure, and popular catalogs.

Access control documentation improvements:

* Added a detailed explanation of how to grant query engine users (such as Athena, Spark, Trino, or Snowflake) read access to Iceberg data, including both cloud storage prefix-level access and catalog-level table access.
* Provided specific instructions and documentation links for configuring permissions on AWS S3, GCP GCS, and Azure Blob Storage for prefix-level access.
* Included guidance and links for catalog-level access control using AWS Lake Formation, Databricks Unity Catalog, Snowflake Open Catalog, and GCP BigLake.

Resolves https://redpandadata.atlassian.net/browse/DOC-1883, https://redpandadata.atlassian.net/browse/DOC-1086 ,https://redpandadata.atlassian.net/browse/DOC-1692
Review deadline: 13 Jul

## Page previews

https://deploy-preview-1648--redpanda-docs-preview.netlify.app/streaming/current/manage/iceberg/query-iceberg-topics/#grant-access-to-query-engine-users
https://deploy-preview-1648--redpanda-docs-preview.netlify.app/streaming/current/manage/iceberg/redpanda-topics-iceberg-snowflake-catalog/#authorize-access-to-open-catalog

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
