### PR TITLE
chore: Add clean and build:clean scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Redpanda documentation",
   "license": "ISC",
   "scripts": {
+    "clean": "rm -rf docs .cache",
     "build": "antora --to-dir docs --fetch local-antora-playbook.yml",
+    "build:clean": "npm run clean && npm run build",
     "serve": "wds --node-resolve --open / --watch --root-dir docs --port 5002",
     "start": "cross-env-shell LIVERELOAD=true npx gulp",
     "test-quickstart": "cd tests/setup-tests && npx doc-detective --input ../../modules/get-started/pages/quick-start.adoc -l debug",


### PR DESCRIPTION
## Summary

- Add `npm run clean` script to remove `docs/` and `.cache/` directories
- Add `npm run build:clean` script that cleans then builds in one command

This prevents the glob-stream stack overflow error that occurs when the `docs/` directory accumulates too many files from previous builds.

## Usage

When you encounter the stack overflow error during build:

```bash
npm run build:clean
```

Or manually clean first:

```bash
npm run clean
npm run build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)