### PR TITLE
ci: add playbook branch validation check

### DIFF
--- a/.github/workflows/check-playbook.yml
+++ b/.github/workflows/check-playbook.yml
@@ -1,0 +1,49 @@
+---
+name: Check playbook branches
+on:
+  pull_request:
+    paths:
+      - local-antora-playbook.yml
+  push:
+    branches: [main]
+    paths:
+      - local-antora-playbook.yml
+
+jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for non-standard branch references
+        run: |
+          # Allowed branch patterns in local-antora-playbook.yml.
+          # Any value not matching these is likely a PR branch that
+          # must be reverted before merge.
+          ALLOWED='main|HEAD|v/\*|shared|site-search|!v-end-of-life/\*'
+
+          # Extract all branch values from the playbook
+          BRANCHES=$(grep 'branches:' local-antora-playbook.yml \
+            | sed 's/.*branches:\s*//' \
+            | tr -d "[]'" \
+            | tr ',' '\n' \
+            | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+          FAILED=0
+          while IFS= read -r branch; do
+            [ -z "$branch" ] && continue
+            if ! echo "$branch" | grep -qE "^(${ALLOWED})$"; then
+              echo "::error::Non-standard branch reference found: '${branch}'"
+              FAILED=1
+            fi
+          done <<< "$BRANCHES"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "local-antora-playbook.yml contains non-standard branch references."
+            echo "These are used for cross-repo Netlify previews during PR development,"
+            echo "but must be reverted to standard values (e.g., 'main') before merging."
+            exit 1
+          fi
+
+          echo "Playbook OK: all branch references are standard."

--- a/.github/workflows/check-playbook.yml
+++ b/.github/workflows/check-playbook.yml
@@ -24,7 +24,7 @@ jobs:
 
           # Extract all branch values from the playbook
           BRANCHES=$(grep 'branches:' local-antora-playbook.yml \
-            | sed 's/.*branches:\s*//' \
+            | sed 's/.*branches:[[:space:]]*//' \
             | tr -d "[]'" \
             | tr ',' '\n' \
             | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [test, v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, shared, site-search,'!v-end-of-life/*']
+    branches: [test, v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs


### PR DESCRIPTION
## Summary

- Adds a CI workflow that checks `local-antora-playbook.yml` for non-standard branch references
- Fails the check if any `branches:` value doesn't match the allowed set (`main`, `HEAD`, `v/*`, `shared`, `site-search`, `!v-end-of-life/*`)
- Prevents accidentally merging a playbook that still points to a PR branch, which would break the production build

## Context

When single-sourcing pages across repos, we temporarily override playbook branch references to point to PR branches for Netlify previews. This CI check serves as a safety net to ensure those overrides are reverted before merge.

## Test plan

- [ ] Verify the check passes on main (all standard branches)
- [ ] Verify the check would fail if a PR branch name were in the playbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)