### PR TITLE
Remove token structure examples from Cloud GBAC docs

### DIFF
--- a/modules/manage/partials/gbac-token-claim-extraction.adoc
+++ b/modules/manage/partials/gbac-token-claim-extraction.adoc
@@ -21,6 +21,7 @@ NOTE: When `nested_group_behavior` is set to `suffix`, groups that share a leaf 
 To update these properties, use xref:manage:cluster-maintenance/cluster-property-configuration.adoc[any configuration method] (`rpk cluster config set`, the Admin API, or Redpanda Console). Changes take effect immediately without a restart.
 endif::[]
 
+ifndef::env-cloud[]
 === Token structure examples
 
 The following examples show how Redpanda extracts group principals from different token formats.
@@ -74,3 +75,4 @@ Some identity providers return group claims as a single comma-separated string i
 ----
 
 Redpanda automatically splits comma-separated values and extracts principals `Group:engineering`, `Group:analytics`, and `Group:finance`.
+endif::[]

--- a/modules/manage/partials/gbac-token-claim-extraction.adoc
+++ b/modules/manage/partials/gbac-token-claim-extraction.adoc
@@ -53,8 +53,6 @@ With `nested_group_behavior: "none"` (the default), Redpanda maps the full path 
 {"groups": ["/departments/eng/platform", "/departments/eng/infra"]}
 ----
 
-// Not supported in Cloud
-ifndef::env-cloud[]
 ==== Path-style group names with suffix extraction
 
 When xref:reference:properties/cluster-properties.adoc#nested_group_behavior[`nested_group_behavior`] is set to `suffix`, Redpanda maps the last path segment to principals `Group:platform` and `Group:infra`.
@@ -63,7 +61,6 @@ When xref:reference:properties/cluster-properties.adoc#nested_group_behavior[`ne
 ----
 {"groups": ["/departments/eng/platform", "/departments/eng/infra"]}
 ----
-endif::[]
 
 ==== CSV-formatted group claim
 


### PR DESCRIPTION
## Summary
- Wraps the "Token structure examples" section in `ifndef::env-cloud[]` in the `gbac-token-claim-extraction.adoc` partial
- This removes from Cloud docs: flat group values, nested claim, path-style group names, and CSV-formatted group claim examples
- Cloud users still see the SSO connection configuration instructions for setting up group claim extraction through the Cloud UI

## Why
The token structure examples reference cluster properties (`oidc_group_claim_path`, `nested_group_behavior`) that Cloud users don't configure directly. This content is confusing for Cloud customers, who configure group claim extraction through SSO connection settings in the Cloud UI.

## Preview pages

### Self-managed (unchanged — examples still present)
- [GBAC (self-managed)](https://deploy-preview-1669--redpanda-docs-preview.netlify.app/current/manage/security/authorization/gbac/)

### Cloud (changed — examples removed)
- [GBAC in the Data Plane](https://deploy-preview-553--rp-cloud.netlify.app/redpanda-cloud/security/authorization/gbac/gbac_dp/)
- [GBAC in the Control Plane](https://deploy-preview-553--rp-cloud.netlify.app/redpanda-cloud/security/authorization/gbac/gbac/)

Cloud preview via companion PR: redpanda-data/cloud-docs#553 (⚠️ close after merge)

## Test plan
- [ ] Verify Cloud GBAC data plane page no longer shows "Token structure examples" section
- [ ] Verify Cloud GBAC control plane page no longer shows "Token structure examples" section
- [ ] Verify self-managed GBAC page still shows all token structure examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)