### PR TITLE
DOC-1881: Document normalize toggle in Console Schema Registry

### DIFF
--- a/modules/console/pages/ui/schema-reg.adoc
+++ b/modules/console/pages/ui/schema-reg.adoc
@@ -33,6 +33,8 @@ A schema is registered in the registry with a _subject_, which is a name that is
 
 . Select the serialization format with the schema definition.
 
+. (Optional) Enable **Normalize** to convert the schema to a canonical form before registering it. Normalization prevents duplicate schema versions caused by formatting differences, such as whitespace or field ordering. Normalization is supported for Avro, JSON, and Protobuf formats.
+
 . To build more complex schema definitions, add a reference to other schemas. For example, the two `import` statements are references to the `PhoneNumber` and `Address` schemas:
 +
 [,json]


### PR DESCRIPTION
## Summary
- Add step documenting the optional **Normalize** toggle when registering schemas in Redpanda Console
- Prevents duplicate schema versions caused by formatting differences (whitespace, field ordering)
- Single-sourced to cloud-docs automatically (no cloud-docs PR needed)

Addresses [DOC-1881](https://redpandadata.atlassian.net/browse/DOC-1881) / [ENG-981](https://redpandadata.atlassian.net/browse/ENG-981) (shipped in Console 3.4.0).

## Deploy preview links
- [Use Schema Registry in Redpanda Console](https://deploy-preview-1672--redpanda-docs-preview.netlify.app/current/console/ui/schema-reg/#create-or-edit-a-schema)

## Test plan
- [x] `npm run build` passes with no new errors
- [x] Verified rendered HTML contains normalize content
- [ ] SME review: Verify the toggle label matches the current Console UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-1881]: https://redpandadata.atlassian.net/browse/DOC-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-981]: https://redpandadata.atlassian.net/browse/ENG-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ