### PR TITLE
DOC-1907: Add Paginate Messages page

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -18,7 +18,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'main'
+    branches: 'DOC-1907-paginate-messages-events'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -18,7 +18,7 @@ content:
   - url: https://github.com/redpanda-data/docs
     branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
-    branches: 'DOC-1907-paginate-messages-events'
+    branches: 'main'
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -49,7 +49,7 @@
 *** xref:develop:consume-data/follower-fetching.adoc[Follower Fetching]
 *** xref:console:ui/programmable-push-filters.adoc[Filter Messages]
 *** xref:console:ui/record-deserialization.adoc[Deserialize Messages]
-*** xref:console:ui/paginate-messages-events.adoc[Paginate Messages and Events]
+*** xref:console:ui/paginate-messages-events.adoc[]
 ** xref:develop:data-transforms/index.adoc[]
 *** xref:develop:data-transforms/how-transforms-work.adoc[Overview]
 *** xref:develop:data-transforms/run-transforms-index.adoc[Get Started]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -49,6 +49,7 @@
 *** xref:develop:consume-data/follower-fetching.adoc[Follower Fetching]
 *** xref:console:ui/programmable-push-filters.adoc[Filter Messages]
 *** xref:console:ui/record-deserialization.adoc[Deserialize Messages]
+*** xref:console:ui/paginate-messages-events.adoc[Paginate Messages and Events]
 ** xref:develop:data-transforms/index.adoc[]
 *** xref:develop:data-transforms/how-transforms-work.adoc[Overview]
 *** xref:develop:data-transforms/run-transforms-index.adoc[Get Started]

--- a/modules/console/pages/index.adoc
+++ b/modules/console/pages/index.adoc
@@ -24,7 +24,7 @@ image::broker-overview.png[]
 
 Observe and debug your streaming data:
 
-* *Message inspection*: Browse and filter messages within your topics, with options to search by key, timestamp, or custom filters.
+* *Message inspection*: Browse and filter messages within your topics, with options to search by key, timestamp, or custom filters. See xref:console:ui/paginate-messages-events.adoc[] to inspect large result sets.
 * xref:console:ui/programmable-push-filters.adoc[*Programmable push filters*]: Write custom JavaScript filters to isolate specific messages, enabling deep inspection and debugging.
 * *Rewind and Replay*: Roll back consumer offsets to reprocess messages, allowing you to correct issues or replay data as needed.
 

--- a/modules/console/pages/ui/paginate-messages-events.adoc
+++ b/modules/console/pages/ui/paginate-messages-events.adoc
@@ -1,19 +1,17 @@
 = Paginate Messages in {ui}
-:description: Retrieve more than the default batch of messages in {ui} by paging through larger result sets.
+:description: Enable Continuous Pagination on a topic's Messages tab to scroll through all records instead of being capped by Max results.
 :page-topic-type: how-to
 
 
 // tag::single-source[]
 
-{description} Use pagination when you need to inspect large topics without being limited to the initial result set.
+By default, the *Messages* tab on a topic returns up to the number of records set in *Max results*. Enable *Continuous Pagination* when you need to inspect a topic beyond that cap.
 
-== Paginate topic messages
-
-When you browse a topic in {ui}, the *Messages* tab returns an initial batch of records. To retrieve additional records beyond this batch:
+== Browse all messages in a topic
 
 . In the menu, go to *Topics* and select a topic.
 . Open the *Messages* tab.
-. Apply any filters or a starting offset to narrow the records you want to inspect.
+. (Optional) Set *Start offset* and *Max results*, or apply filters, to narrow the records you want to inspect.
 +
 ifdef::env-cloud[]
 See xref:manage:schema-reg/programmable-push-filters.adoc[] and xref:manage:schema-reg/record-deserialization.adoc[].
@@ -21,20 +19,22 @@ endif::[]
 ifndef::env-cloud[]
 See xref:console:ui/programmable-push-filters.adoc[] and xref:console:ui/record-deserialization.adoc[].
 endif::[]
-. After the initial results load, load the next batch to continue through the topic.
+. Enable the *Continuous Pagination* toggle.
+. Scroll the message list. {ui} keeps loading records until you reach the end of the topic.
 
-You can continue paginating until you reach the end of the topic or the end of the offset range you specified.
+When continuous pagination is on, the max results cap no longer limits the browsing session.
 
 == Performance considerations
 
 Retrieving large result sets increases load on the {ui} backend and the cluster. To keep responses fast:
 
-* Narrow the result set with filters or a bounded offset range before paginating.
+* Narrow the result set with filters or a bounded offset range before enabling continuous pagination*.
 ifdef::env-cloud[]
 * Use xref:manage:schema-reg/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
 endif::[]
 ifndef::env-cloud[]
 * Use xref:console:ui/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
 endif::[]
+* Leave continuous pagination off and rely on max results when you only need a sample.
 
 // end::single-source[]

--- a/modules/console/pages/ui/paginate-messages-events.adoc
+++ b/modules/console/pages/ui/paginate-messages-events.adoc
@@ -1,0 +1,65 @@
+= Paginate Messages and Pipeline Events in {ui}
+:description: Retrieve more than 500 messages or pipeline events in {ui} by paging through larger result sets.
+:page-topic-type: how-to
+
+
+// tag::single-source[]
+
+{description} Use pagination when you need to inspect large topics or debug
+ifdef::env-cloud[]
+xref:develop:connect/about.adoc[Redpanda Connect]
+endif::[]
+ifndef::env-cloud[]
+xref:redpanda-connect:home:index.adoc[Redpanda Connect]
+endif::[]
+pipelines that emit more events than the initial result set includes.
+
+== Paginate topic messages
+
+When you browse a topic in {ui}, the *Messages* tab returns an initial batch of records. To retrieve additional records beyond this batch:
+
+. In the menu, go to *Topics* and select a topic.
+. Open the *Messages* tab.
+. Apply any filters or a starting offset to narrow the records you want to inspect.
++
+ifdef::env-cloud[]
+See xref:manage:schema-reg/programmable-push-filters.adoc[] and xref:manage:schema-reg/record-deserialization.adoc[].
+endif::[]
+ifndef::env-cloud[]
+See xref:console:ui/programmable-push-filters.adoc[] and xref:console:ui/record-deserialization.adoc[].
+endif::[]
+. After the initial results load, load the next batch to continue through the topic.
+
+You can continue paginating until you reach the end of the topic or the end of the offset range you specified.
+
+== Paginate Redpanda Connect pipeline events
+
+When you debug a Redpanda Connect pipeline, {ui} shows the events the pipeline emits, including logs at the configured log level. Pipelines that run with debug-level logging often produce more events than fit in a single result set.
+
+To retrieve additional pipeline events:
+
+. In the menu, go to *Connect* and select the pipeline you want to debug.
+. Open the pipeline's events view.
+. After the initial events load, load the next batch to continue inspecting events.
+
+ifdef::env-cloud[]
+For guidance on configuring log levels and monitoring pipelines, see xref:develop:connect/configuration/monitor-connect.adoc[].
+endif::[]
+ifndef::env-cloud[]
+For guidance on configuring log levels and monitoring pipelines, see xref:redpanda-connect:guides:monitoring.adoc[].
+endif::[]
+
+== Performance considerations
+
+Retrieving large result sets increases load on the {ui} backend and the cluster. To keep responses fast:
+
+* Narrow the result set with filters or a bounded offset range before paginating.
+ifdef::env-cloud[]
+* Use xref:manage:schema-reg/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
+endif::[]
+ifndef::env-cloud[]
+* Use xref:console:ui/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
+endif::[]
+* For pipeline debugging, raise the log level only as long as you need it.
+
+// end::single-source[]

--- a/modules/console/pages/ui/paginate-messages-events.adoc
+++ b/modules/console/pages/ui/paginate-messages-events.adoc
@@ -5,11 +5,11 @@
 
 // tag::single-source[]
 
-By default, the *Messages* tab on a topic returns up to the number of records set in *Max results*. Enable *Continuous Pagination* when you need to inspect a topic beyond that cap.
+By default, the *Messages* tab on a topic returns the number of records set in *Max results*. Enable *Continuous Pagination* when you need to inspect a topic beyond that cap.
 
 == Browse all messages in a topic
 
-. In the menu, go to *Topics* and select a topic.
+. Go to *Topics* and select a topic.
 . Open the *Messages* tab.
 . (Optional) Set *Start offset* and *Max results*, or apply filters, to narrow the records you want to inspect.
 +

--- a/modules/console/pages/ui/paginate-messages-events.adoc
+++ b/modules/console/pages/ui/paginate-messages-events.adoc
@@ -1,18 +1,11 @@
-= Paginate Messages and Pipeline Events in {ui}
-:description: Retrieve more than 500 messages or pipeline events in {ui} by paging through larger result sets.
+= Paginate Messages in {ui}
+:description: Retrieve more than the default batch of messages in {ui} by paging through larger result sets.
 :page-topic-type: how-to
 
 
 // tag::single-source[]
 
-{description} Use pagination when you need to inspect large topics or debug
-ifdef::env-cloud[]
-xref:develop:connect/about.adoc[Redpanda Connect]
-endif::[]
-ifndef::env-cloud[]
-xref:redpanda-connect:home:index.adoc[Redpanda Connect]
-endif::[]
-pipelines that emit more events than the initial result set includes.
+{description} Use pagination when you need to inspect large topics without being limited to the initial result set.
 
 == Paginate topic messages
 
@@ -32,23 +25,6 @@ endif::[]
 
 You can continue paginating until you reach the end of the topic or the end of the offset range you specified.
 
-== Paginate Redpanda Connect pipeline events
-
-When you debug a Redpanda Connect pipeline, {ui} shows the events the pipeline emits, including logs at the configured log level. Pipelines that run with debug-level logging often produce more events than fit in a single result set.
-
-To retrieve additional pipeline events:
-
-. In the menu, go to *Connect* and select the pipeline you want to debug.
-. Open the pipeline's events view.
-. After the initial events load, load the next batch to continue inspecting events.
-
-ifdef::env-cloud[]
-For guidance on configuring log levels and monitoring pipelines, see xref:develop:connect/configuration/monitor-connect.adoc[].
-endif::[]
-ifndef::env-cloud[]
-For guidance on configuring log levels and monitoring pipelines, see xref:redpanda-connect:guides:monitoring.adoc[].
-endif::[]
-
 == Performance considerations
 
 Retrieving large result sets increases load on the {ui} backend and the cluster. To keep responses fast:
@@ -60,6 +36,5 @@ endif::[]
 ifndef::env-cloud[]
 * Use xref:console:ui/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
 endif::[]
-* For pipeline debugging, raise the log level only as long as you need it.
 
 // end::single-source[]

--- a/modules/console/pages/ui/paginate-messages-events.adoc
+++ b/modules/console/pages/ui/paginate-messages-events.adoc
@@ -28,7 +28,7 @@ When continuous pagination is on, the max results cap no longer limits the brows
 
 Retrieving large result sets increases load on the {ui} backend and the cluster. To keep responses fast:
 
-* Narrow the result set with filters or a bounded offset range before enabling continuous pagination*.
+* Narrow the result set with filters or a bounded offset range before enabling continuous pagination.
 ifdef::env-cloud[]
 * Use xref:manage:schema-reg/programmable-push-filters.adoc[JavaScript push filters] to match only the records you need.
 endif::[]


### PR DESCRIPTION
Resolves https://redpandadata.atlassian.net/browse/DOC-1907

## Description

Documents Redpanda Console's unlimited pagination feature (ENG-971), which lets users retrieve more than 500 messages when browsing topic messages.

- Adds `modules/console/pages/ui/paginate-messages-events.adoc` as the single-source page (wrapped in `// tag::single-source[]` tags so cloud-docs can include it)
- Adds nav entry under Develop > Consume Data
- Updates the Console overview "Message inspection" bullet to xref the new page

## Preview pages

- [Paginate Messages in Redpanda Console](https://deploy-preview-1673--redpanda-docs-preview.netlify.app/current/console/ui/paginate-messages-events/) (new)
- [Introduction to Redpanda Console](https://deploy-preview-1673--redpanda-docs-preview.netlify.app/current/console/) (updated)

## Dependencies

- Companion cloud-docs PR: redpanda-data/cloud-docs#556

## Before merge

- [ ] **Revert docs playbook**: Revert `local-antora-playbook.yml` so the `cloud-docs` source points back to `'main'` instead of `'DOC-1907-paginate-messages-events'`
- [ ] Ensure companion cloud-docs PR merges after this one

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)