### PR TITLE
fix: clarify reclaim condition on redpanda_memory_allocated_memory

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -889,7 +889,7 @@ endif::[]
 
 === redpanda_memory_allocated_memory
 
-Total memory allocated (in bytes) per CPU shard. This includes all memory currently held by Redpanda on that shard, including memory in the batch cache that has been allocated but could be reclaimed.
+Total memory allocated (in bytes) per CPU shard. This includes all memory currently held by Redpanda on that shard, including memory in the batch cache that has been allocated but could be reclaimed if needed.
 
 *Type*: gauge
 


### PR DESCRIPTION
## Summary

- Adds "if needed" to the `redpanda_memory_allocated_memory` description so the batch cache reclaim phrasing is technically accurate.
- Follow-up to #1656 addressing a post-merge review nit from @bharathv: https://github.com/redpanda-data/docs/pull/1656#discussion_r3157217547

## Preview pages

- [Public Metrics](https://deploy-preview-1687--redpanda-docs-preview.netlify.app/current/reference/public-metrics-reference/) (updated)

## Test plan

- [x] `git diff` shows only the intended one-word addition in `modules/reference/pages/public-metrics-reference.adoc`
- [ ] CI (link checker, lint) green
- [ ] Reviewer confirms wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)