### PR TITLE
Add ADP-specific glossary terms for GA

### DIFF
--- a/modules/terms/partials/ai-agent.adoc
+++ b/modules/terms/partials/ai-agent.adoc
@@ -1,6 +1,6 @@
 === AI agent
 :term-name: AI agent
-:hover-text: An autonomous program that uses AI models to interpret requests, make decisions, and interact with tools and data sources.
+:hover-text: A system built around a large language model (LLM) that interprets user intent, selects the right tools, and chains multiple steps into a workflow.
 :category: Agentic Data Plane
 
 AI agents can understand natural language instructions, reason about tasks, invoke tools through MCP servers, and coordinate multiple operations to accomplish complex workflows.

--- a/modules/terms/partials/byoa.adoc
+++ b/modules/terms/partials/byoa.adoc
@@ -1,4 +1,4 @@
 === BYOA (bring your own agent)
-:term-name: BYOA (bring your own agent)
+:term-name: BYOA
 :hover-text: An agent built and run by you (in your own runtime, in any language) that registers with Redpanda for governance, observability, and gateway access. The runtime is yours; the policy and audit trail are Redpanda's.
 :category: Agentic Data Plane

--- a/modules/terms/partials/byoa.adoc
+++ b/modules/terms/partials/byoa.adoc
@@ -1,0 +1,4 @@
+=== BYOA (bring your own agent)
+:term-name: BYOA (bring your own agent)
+:hover-text: An agent built and run by you (in your own runtime, in any language) that registers with Redpanda for governance, observability, and gateway access. The runtime is yours; the policy and audit trail are Redpanda's.
+:category: Agentic Data Plane

--- a/modules/terms/partials/byoa.adoc
+++ b/modules/terms/partials/byoa.adoc
@@ -1,4 +1,4 @@
 === BYOA
 :term-name: BYOA
-:hover-text: An agent you build and run yourself, in your own runtime and language. You register it with ADP for governance and observability. ADP tracks and attributes its telemetry and cost but does not host or proxy it.
+:hover-text: Bring Your Own Agent (BYOA) is an agent you build and run yourself, in your own runtime and language. You register it with ADP for governance and observability. ADP tracks and attributes its telemetry and cost but does not host or proxy it.
 :category: Agentic Data Plane

--- a/modules/terms/partials/byoa.adoc
+++ b/modules/terms/partials/byoa.adoc
@@ -1,4 +1,4 @@
-=== BYOA (bring your own agent)
+=== BYOA
 :term-name: BYOA
-:hover-text: An agent built and run by you (in your own runtime, in any language) that registers with Redpanda for governance, observability, and gateway access. The runtime is yours; the policy and audit trail are Redpanda's.
+:hover-text: An agent you build and run yourself, in your own runtime and language. You register it with ADP for governance and observability. ADP tracks and attributes its telemetry and cost but does not host or proxy it.
 :category: Agentic Data Plane

--- a/modules/terms/partials/declarative-agent.adoc
+++ b/modules/terms/partials/declarative-agent.adoc
@@ -1,4 +1,4 @@
 === declarative agent
 :term-name: declarative agent
-:hover-text: An AI agent declared in YAML and run by Redpanda's managed runtime. The platform handles execution, model routing, and tool invocation; you describe the behavior, system prompt, and tool attachments.
+:hover-text: An AI agent declared in YAML and run by Redpanda's managed runtime. The platform handles execution, model routing, and tool invocation. You describe the behavior, system prompt, and tool attachments.
 :category: Agentic Data Plane

--- a/modules/terms/partials/declarative-agent.adoc
+++ b/modules/terms/partials/declarative-agent.adoc
@@ -1,4 +1,4 @@
 === declarative agent
 :term-name: declarative agent
-:hover-text: An AI agent declared in YAML and run by Redpanda's managed runtime. The platform handles execution, model routing, and tool invocation. You describe the behavior, system prompt, and tool attachments.
+:hover-text: An AI agent that runs in Redpanda's managed runtime, where you configure its behavior (LLM, system prompt, and attached tools) instead of writing agent code. Contrast with a BYOA agent, which you build and run in your own runtime.
 :category: Agentic Data Plane

--- a/modules/terms/partials/declarative-agent.adoc
+++ b/modules/terms/partials/declarative-agent.adoc
@@ -1,0 +1,4 @@
+=== declarative agent
+:term-name: declarative agent
+:hover-text: An AI agent declared in YAML and run by Redpanda's managed runtime. The platform handles execution, model routing, and tool invocation; you describe the behavior, system prompt, and tool attachments.
+:category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
-=== Governance dashboard
+=== governance dashboard
 :term-name: Governance dashboard
 :hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
 :category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,0 +1,4 @@
+=== Governance Dashboard
+:term-name: Governance Dashboard
+:hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. V0 (GA) composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
+:category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
 === Governance dashboard
-:term-name: Governance Dashboard
+:term-name: Governance dashboard
 :hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
 :category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
-=== Governance Dashboard
+=== Governance dashboard
 :term-name: Governance Dashboard
 :hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
 :category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
 === governance dashboard
-:term-name: Governance dashboard
+:term-name: governance dashboard
 :hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
 :category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
 === governance dashboard
 :term-name: governance dashboard
-:hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
+:hover-text: Cross-tenant overview for platform and finance teams showing agent activity, spending, MCP server inventory, and authorization events. It brings AI Gateway usage and agent inventory into one view, down to per-provider spending and the authorization decisions that gate each tool invocation.
 :category: Agentic Data Plane

--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,4 @@
 === Governance Dashboard
 :term-name: Governance Dashboard
-:hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. V0 (GA) composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
+:hover-text: Cross-tenant overview UI showing spending, agent activity, MCP server inventory, and authorization events. The dashboard composes data from `SpendingService`, `AgentRegistryService`, and `MCPServerService`.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
 === OAuth Client
 :term-name: OAuth Client
-:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth Authorization Server. Distinct from an OAuth Provider.
+:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth Authorization Server. Distinct from an OAuth provider.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
 === OAuth client
 :term-name: OAuth client
-:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth authorization server. Distinct from an OAuth provider.
+:hover-text: An ADP resource that governs inbound authentication: an external app (Claude Desktop, ChatGPT, Copilot Studio) authenticating to AI Gateway so its users can invoke MCP tools. Separate from an OAuth provider, which governs outbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,0 +1,4 @@
+=== OAuth Client
+:term-name: OAuth Client
+:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth Authorization Server. Distinct from an OAuth Provider.
+:category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
 === OAuth client
 :term-name: OAuth client
-:hover-text: An ADP resource that governs inbound authentication: an external app (Claude Desktop, ChatGPT, Copilot Studio) authenticating to AI Gateway so its users can invoke MCP tools. Separate from an OAuth provider, which governs outbound authentication.
+:hover-text: An ADP resource that governs inbound authentication: an external app (Claude Desktop, ChatGPT, Copilot Studio) authenticating to AI Gateway so the app's users can invoke MCP tools. Separate from an OAuth provider, which governs outbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
 === OAuth Client
 :term-name: OAuth Client
-:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth Authorization Server. Distinct from an OAuth provider.
+:hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth authorization server. Distinct from an OAuth provider.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
-=== OAuth Client
-:term-name: OAuth Client
+=== OAuth client
+:term-name: OAuth client
 :hover-text: An admin-registered external tool (such as Claude.ai, ChatGPT, or Cursor) authorized to request tokens from the in-dataplane OAuth authorization server. Distinct from an OAuth provider.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-connection.adoc
+++ b/modules/terms/partials/oauth-connection.adoc
@@ -1,4 +1,4 @@
-=== OAuth Connection
-:term-name: OAuth Connection
-:hover-text: A per-user OAuth connection to a third-party provider, created by completing the consent flow. Connections store the user's access and refresh tokens in the Token Vault and are used by agents on behalf of that user.
+=== OAuth connection
+:term-name: OAuth connection
+:hover-text: A per-user OAuth connection to a third-party provider, created by completing the consent flow. Connections store the user's access and refresh tokens in the token vault and are used by agents on behalf of that user.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-connection.adoc
+++ b/modules/terms/partials/oauth-connection.adoc
@@ -1,4 +1,4 @@
 === OAuth connection
 :term-name: OAuth connection
-:hover-text: A per-user OAuth connection to a third-party provider, created by completing the consent flow. Connections store the user's access and refresh tokens in the token vault and are used by agents on behalf of that user.
+:hover-text: A stored authorization that links a user to a third-party provider, created when the user completes the OAuth consent flow. OAuth connections hold access and refresh tokens in the token vault for agents to use on the user's behalf.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-connection.adoc
+++ b/modules/terms/partials/oauth-connection.adoc
@@ -1,0 +1,4 @@
+=== OAuth Connection
+:term-name: OAuth Connection
+:hover-text: A per-user OAuth connection to a third-party provider, created by completing the consent flow. Connections store the user's access and refresh tokens in the Token Vault and are used by agents on behalf of that user.
+:category: Agentic Data Plane

--- a/modules/terms/partials/oauth-provider.adoc
+++ b/modules/terms/partials/oauth-provider.adoc
@@ -1,4 +1,4 @@
 === OAuth provider
 :term-name: OAuth provider
-:hover-text: An ADP resource that governs outbound authentication: AI Gateway authenticating to an upstream system (GitHub, Slack, Salesforce, and so on) on a user's behalf so MCP servers can call that upstream. Separate from an OAuth client, which governs inbound authentication.
+:hover-text: An ADP resource that governs outbound authentication: AI Gateway authenticating to an upstream system (GitHub, Slack, Salesforce, and so on) on a user's behalf so MCP servers can call it. Separate from an OAuth client, which governs inbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-provider.adoc
+++ b/modules/terms/partials/oauth-provider.adoc
@@ -1,4 +1,4 @@
-=== OAuth Provider
-:term-name: OAuth Provider
-:hover-text: An admin-registered upstream OAuth identity (such as Slack, Workday, or a custom IdP) that ADP users can connect to by completing the consent flow. Distinct from an OAuth Client.
+=== OAuth provider
+:term-name: OAuth provider
+:hover-text: An admin-registered upstream OAuth identity (such as Slack, Workday, or a custom IdP) that ADP users can connect to by completing the consent flow. Distinct from an OAuth client.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-provider.adoc
+++ b/modules/terms/partials/oauth-provider.adoc
@@ -1,0 +1,4 @@
+=== OAuth Provider
+:term-name: OAuth Provider
+:hover-text: An admin-registered upstream OAuth identity (such as Slack, Workday, or a custom IdP) that ADP users can connect to by completing the consent flow. Distinct from an OAuth Client.
+:category: Agentic Data Plane

--- a/modules/terms/partials/oauth-provider.adoc
+++ b/modules/terms/partials/oauth-provider.adoc
@@ -1,4 +1,4 @@
 === OAuth provider
 :term-name: OAuth provider
-:hover-text: An admin-registered upstream OAuth identity (such as Slack, Workday, or a custom IdP) that ADP users can connect to by completing the consent flow. Distinct from an OAuth client.
+:hover-text: An ADP resource that governs outbound authentication: AI Gateway authenticating to an upstream system (GitHub, Slack, Salesforce, and so on) on a user's behalf so MCP servers can call that upstream. Separate from an OAuth client, which governs inbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/resource.adoc
+++ b/modules/terms/partials/resource.adoc
@@ -1,4 +1,4 @@
 === resource
 :term-name: resource
-:hover-text: Read-only data exposed by an MCP server, fetchable by an agent through a URI. Resources surface things like file contents, database rows, or API responses without performing side effects.
+:hover-text: Read-only data that an MCP server exposes and agents can fetch by URI. Resources provide file contents, database rows, or API responses without performing side effects.
 :category: Agentic Data Plane

--- a/modules/terms/partials/resource.adoc
+++ b/modules/terms/partials/resource.adoc
@@ -1,4 +1,4 @@
 === resource
 :term-name: resource
-:hover-text: Read-only data exposed by an MCP server that an agent can fetch by URI. Resources surface things like file contents, database rows, or API responses without performing side effects.
+:hover-text: Read-only data exposed by an MCP server, fetchable by an agent through a URI. Resources surface things like file contents, database rows, or API responses without performing side effects.
 :category: Agentic Data Plane

--- a/modules/terms/partials/resource.adoc
+++ b/modules/terms/partials/resource.adoc
@@ -1,0 +1,4 @@
+=== resource
+:term-name: resource
+:hover-text: Read-only data exposed by an MCP server that an agent can fetch by URI. Resources surface things like file contents, database rows, or API responses without performing side effects.
+:category: Agentic Data Plane

--- a/modules/terms/partials/spending-event.adoc
+++ b/modules/terms/partials/spending-event.adoc
@@ -1,0 +1,4 @@
+=== spending event
+:term-name: spending event
+:hover-text: A per-LLM-request cost record produced by the AI Gateway, carrying input, output, cached, and cache-write token counts plus tenant, provider, model, organization, and user identifiers. Cost is calculated downstream; the event itself carries raw token counts.
+:category: Agentic Data Plane

--- a/modules/terms/partials/spending-event.adoc
+++ b/modules/terms/partials/spending-event.adoc
@@ -1,4 +1,4 @@
 === spending event
 :term-name: spending event
-:hover-text: A record produced by the AI Gateway for every LLM call. Each event captures input, output, and cached token counts, the total cost in microcents, request count, and the provider, model, user, and organization context the call ran under.
+:hover-text: A record produced by the AI Gateway for every LLM call. Each event captures input, output, and cached token counts, the total cost in microcents, request count, and the provider, model, user, and organization context that the call ran under.
 :category: Agentic Data Plane

--- a/modules/terms/partials/spending-event.adoc
+++ b/modules/terms/partials/spending-event.adoc
@@ -1,4 +1,4 @@
 === spending event
 :term-name: spending event
-:hover-text: A per-LLM-request cost record produced by the AI Gateway, carrying input, output, cached, and cache-write token counts plus tenant, provider, model, organization, and user identifiers. Cost is calculated downstream; the event itself carries raw token counts.
+:hover-text: A per-LLM-request cost record produced by the AI Gateway, carrying input, output, cached, and cache-write token counts plus tenant, provider, model, organization, and user identifiers. Cost is calculated downstream. The event itself carries raw token counts.
 :category: Agentic Data Plane

--- a/modules/terms/partials/spending-event.adoc
+++ b/modules/terms/partials/spending-event.adoc
@@ -1,4 +1,4 @@
 === spending event
 :term-name: spending event
-:hover-text: A per-LLM-request cost record produced by the AI Gateway, carrying input, output, cached, and cache-write token counts plus tenant, provider, model, organization, and user identifiers. Cost is calculated downstream. The event itself carries raw token counts.
+:hover-text: A record produced by the AI Gateway for every LLM call. Each event captures input, output, and cached token counts, the total cost in microcents, request count, and the provider, model, user, and organization context the call ran under.
 :category: Agentic Data Plane

--- a/modules/terms/partials/token-vault.adoc
+++ b/modules/terms/partials/token-vault.adoc
@@ -1,4 +1,4 @@
-=== Token Vault
-:term-name: Token Vault
+=== token vault
+:term-name: token vault
 :hover-text: Encrypted store for per-user OAuth tokens used to access third-party providers. Supports admin-level connection revocation and data-encryption-key rotation.
 :category: Agentic Data Plane

--- a/modules/terms/partials/token-vault.adoc
+++ b/modules/terms/partials/token-vault.adoc
@@ -1,0 +1,4 @@
+=== Token Vault
+:term-name: Token Vault
+:hover-text: Encrypted store for per-user OAuth tokens used to access third-party providers. Supports admin-level connection revocation and data-encryption-key rotation.
+:category: Agentic Data Plane

--- a/modules/terms/partials/token-vault.adoc
+++ b/modules/terms/partials/token-vault.adoc
@@ -1,4 +1,4 @@
 === token vault
 :term-name: token vault
-:hover-text: Encrypted store for per-user OAuth tokens used to access third-party providers. Supports admin-level connection revocation and data-encryption-key rotation.
+:hover-text: Encrypted per-user store for the OAuth access and refresh tokens used to access third-party providers. Redpanda injects a user's token at call time and refreshes it automatically; connections persist until the user revokes them.
 :category: Agentic Data Plane

--- a/modules/terms/partials/tool.adoc
+++ b/modules/terms/partials/tool.adoc
@@ -1,0 +1,4 @@
+=== tool
+:term-name: tool
+:hover-text: A capability exposed by an MCP server that an AI agent can discover at runtime and invoke through structured JSON-RPC calls. Tools encapsulate operations such as querying a database, calling an API, or sending a message.
+:category: Agentic Data Plane


### PR DESCRIPTION
## Summary

Adds 10 new term partials to the canonical Redpanda glossary so the Agentic Data Plane (ADP) docs render `glossterm:` tooltips correctly at GA on 2026-06-15.

Closes the §3A R1 commitment in the [ADP Docs Plan](https://redpandadata.atlassian.net/wiki/spaces/DOC/pages/1845461009).

### What's added

| Term | Source of truth |
| --- | --- |
| `tool` | `mcp_server.proto` `MCPTool` |
| `resource` | MCP spec via `mcp_server.proto` |
| `declarative agent` | `agent.proto` `Agent.managed.AgentManagedConfiguration` |
| `BYOA (bring your own agent)` | `agent.proto` `Agent.self_managed` |
| `OAuth Provider` | `oauth_provider.proto` |
| `OAuth Client` | `oauth_client.proto` (RFC 005) |
| `OAuth Connection` | `oauth_connection.proto` |
| `Token Vault` | `token_vault_admin.proto` |
| `spending event` | `spending_event.proto` |
| `Governance Dashboard` | Governance V0 PRD + RFC 006 |

All entries use the existing `Agentic Data Plane` category. Hover text was drafted against the cited proto comments; lowercase concept terms (`tool`, `resource`, `declarative agent`, `spending event`) and proper-cased product nouns (`OAuth Provider`, `Token Vault`, `Governance Dashboard`) follow established glossary conventions.

### Why these specifically

- **`tool` / `resource`** are already used as `glossterm:tool[]` / `glossterm:resource[]` across `adp-docs` MCP pages (`mcp/test-tools.adoc`, `mcp/create-server.adoc`, `mcp/managed/managed-catalog.adoc`, `mcp/overview.adoc`) but currently resolve to nothing. Bug fix.
- The other 8 are ADP GA terms with no entry yet. Without them, OAuth/Token Vault/Spending Event concepts ship at GA without definitions.

### Deliberately deferred

- `agent network` — defer until Governance Dashboard V1 lands (post-GA).
- `virtual provider` / `virtual model` — hold until the AI Gateway routing redesign settles in protos under `adp/v1alpha1/`.
- `guardrail` — hold until the proto pivot (`e0a1ba0cee` / `7eff2ecbbf`) is reflected in `aigw/v1alpha1/`.
- `ACU`, `BYOM`, `Capacity-Based Hybrid` — strategy/billing terms; not in proto and not surfaced in customer-facing UI/CLI at GA.

## Test plan

- [ ] After merge, `https://redpanda-agentic-data-plane.netlify.app/redpanda-adp/` resolves the new tooltips on existing `glossterm:tool[]` and `glossterm:resource[]` usages.
- [ ] No build warnings on the canonical glossary index at https://docs.redpanda.com/current/reference/glossary/.
- [ ] Companion adp-docs PR (replacing the glossary stub with an index page) opens against `redpanda-data/adp-docs` `main` after this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
