### PR TITLE
DOC-1936: Note SR authorization is on by default for Redpanda Cloud

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -1151,7 +1151,12 @@ You can put either a single subject or the entire Schema Registry into import mo
 
 To enable import mode, you must have:
 
+ifndef::env-cloud[]
 * Either superuser access, or a Schema Registry ACL with the `alter_configs` operation on the `registry` resource. See xref:manage:schema-reg/schema-reg-authorization.adoc#enable-schema-registry-authorization[Enable Schema Registry Authorization] to learn how to enable schema registry authorization for your cluster.
+endif::[]
+ifdef::env-cloud[]
+* Either admin access, or a Schema Registry ACL with the `alter_configs` operation on the `registry` resource. See xref:manage:schema-reg/schema-reg-authorization.adoc[Schema Registry Authorization] for details on managing Schema Registry ACLs.
+endif::[]
 * An empty registry or subject. That is, either no schemas have ever been registered, or you must <<hard-delete-a-schema,hard-delete>> all schemas that were registered.
 +
 To bypass the check for an empty registry when setting the global mode to import:

--- a/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
@@ -13,6 +13,15 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 endif::[]
 
+ifdef::env-cloud[]
+[NOTE]
+====
+On BYOC and Dedicated clusters, Schema Registry Authorization is enabled by default. The xref:reference:properties/cluster-properties.adoc#schema_registry_enable_authorization[`schema_registry_enable_authorization`] cluster property is set to `true` automatically when the cluster is provisioned, and the predefined Admin, Writer, and Reader roles include Schema Registry permissions. See xref:security:authorization/rbac/rbac.adoc#predefined-roles[Predefined roles] for the operations granted by each role.
+
+You do not need to enable Schema Registry Authorization manually. Use the rest of this page to learn how to define custom Schema Registry ACLs and roles for your users and applications.
+====
+endif::[]
+
 == About Schema Registry Authorization
 
 Schema Registry Authorization allows you to control which users and applications can perform specific operations within the Redpanda Schema Registry. This ensures that only authorized entities can read, write, modify, delete, or configure schemas and their settings.
@@ -28,10 +37,10 @@ You can manage Schema Registry Authorization in the following ways:
 - **rpk**: Use the xref:reference:rpk/rpk-security/rpk-security-acl-create.adoc[`rpk security acl create`] command, just like you would for other Kafka ACLs.
 - **Schema Registry API**: Use the link:/api/doc/schema-registry/operation/operation-get_security_acls[Redpanda Schema Registry API] endpoints.
 ifndef::env-cloud[]
-- **{ui}**: After enabling Schema Registry Authorization for your cluster, you can use {ui} to manage Schema Registry ACLs. See xref:manage:security/authorization/acl.adoc[]. 
+- **{ui}**: After enabling Schema Registry Authorization for your cluster, you can use {ui} to manage Schema Registry ACLs. See xref:manage:security/authorization/acl.adoc[].
 endif::[]
 ifdef::env-cloud[]
-- **{ui}**: After enabling Schema Registry Authorization for your cluster, you can use {ui} to manage Schema Registry ACLs. See xref:security:/authorization/acl.adoc[]. 
+- **{ui}**: Use {ui} to manage Schema Registry ACLs. See xref:security:authorization/acl.adoc[].
 endif::[]
 
 === Schema Registry ACL resource types
@@ -402,32 +411,34 @@ Redpanda recommends using the topic naming strategy where subjects follow the pa
 Example: `--registry-subject "orders-" --resource-pattern-type prefixed` grants access to both `orders-key` and `orders-value` subjects.
 ====
 
+ifdef::env-cloud[]
+== Manage Schema Registry ACLs
+
+=== Prerequisites
+
+Before you can create or manage Schema Registry ACLs, you must have:
+
+* `rpk` v25.2+ installed. For installation instructions, see xref:manage:rpk/rpk-install.adoc[rpk installation].
+* Cluster administrator permissions to modify Schema Registry ACLs.
+  For example, to delegate ACL management to the principal `schema_registry_admin`, run:
+  +
+  [,bash]
+  ----
+  rpk security acl create --allow-principal schema_registry_admin --cluster --operation alter
+  ----
+endif::[]
+
+ifndef::env-cloud[]
 == Enable Schema Registry Authorization
 
 === Prerequisites
 
 Before you can enable Schema Registry Authorization, you must have:
 
-ifndef::env-cloud[]
 * A valid Redpanda Enterprise license.
-endif::[]
-
-ifdef::env-cloud[]
-* `rpk` v25.2+ installed. For installation instructions, see xref:manage:rpk/rpk-install.adoc[rpk installation].
-endif::[]
-
-ifndef::env-cloud[]
 * `rpk` v25.2+ installed. For installation instructions, see xref:get-started:rpk-install.adoc[rpk installation].
-endif::[]
-
-ifndef::env-cloud[]
 * Authentication enabled using `schema_registry_api.authn_method`, which specifies how clients must authenticate when accessing the Schema Registry API. See xref:reference:properties/broker-properties.adoc#schema-registry[Schema Registry broker properties].
-endif::[]
-
-ifndef::env-cloud[]
 * If you have listeners configured for Schema Registry, ensure you xref:manage:security/authentication.adoc#basic-authentication[configure authentication] for them and that your configuration points to the correct Schema Registry address (correct scheme, host, and port) for the same cluster you are targeting with your Kafka brokers.
-endif::[]
-
 * Cluster administrator permissions to modify cluster configurations.
   For example, to enable management of Schema Registry ACLs by the principal `schema_registry_admin`, run:
   +
@@ -446,6 +457,7 @@ rpk cluster config set schema_registry_enable_authorization true
 ----
 
 For details, see xref:reference:properties/cluster-properties.adoc#schema_registry_enable_authorization[`schema_registry_enable_authorization`].
+endif::[]
 
 == Create and manage Schema Registry ACLs
 

--- a/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
@@ -421,11 +421,11 @@ Before you can create or manage Schema Registry ACLs, you must have:
 * `rpk` v25.2+ installed. For installation instructions, see xref:manage:rpk/rpk-install.adoc[rpk installation].
 * Cluster administrator permissions to modify Schema Registry ACLs.
   For example, to delegate ACL management to the principal `schema_registry_admin`, run:
-  +
-  [,bash]
-  ----
-  rpk security acl create --allow-principal schema_registry_admin --cluster --operation alter
-  ----
++
+[,bash]
+----
+rpk security acl create --allow-principal schema_registry_admin --cluster --operation alter
+----
 endif::[]
 
 ifndef::env-cloud[]
@@ -441,11 +441,11 @@ Before you can enable Schema Registry Authorization, you must have:
 * If you have listeners configured for Schema Registry, ensure you xref:manage:security/authentication.adoc#basic-authentication[configure authentication] for them and that your configuration points to the correct Schema Registry address (correct scheme, host, and port) for the same cluster you are targeting with your Kafka brokers.
 * Cluster administrator permissions to modify cluster configurations.
   For example, to enable management of Schema Registry ACLs by the principal `schema_registry_admin`, run:
-  +
-  [,bash]
-  ----
-  rpk security acl create --allow-principal schema_registry_admin --cluster --operation alter
-  ----
++
+[,bash]
+----
+rpk security acl create --allow-principal schema_registry_admin --cluster --operation alter
+----
 
 === Enable authorization
 


### PR DESCRIPTION
## Summary

Schema Registry Authorization is now enabled fleet-wide on Redpanda Cloud BYOC and Dedicated clusters: `schema_registry_enable_authorization` is set automatically at provisioning, and predefined Cloud roles include Schema Registry permissions.

This PR updates the single-sourced `schema-reg-authorization.adoc` page so the Cloud rendering reflects this:

- Adds a Cloud-only intro NOTE explaining the default behavior and pointing to the predefined-roles section.
- Splits the *Prerequisites* / *Enable authorization* section so the Cloud branch shows only the prerequisites for managing ACLs, while self-managed users continue to see the full enable-authorization flow (including the `rpk cluster config set schema_registry_enable_authorization true` step).
- Fixes a broken xref in the Cloud branch (`security:/authorization/acl` → `security:authorization/acl`) and removes a stale "After enabling Schema Registry Authorization for your cluster" preamble in the Cloud Console step.
- Fixes list continuation indentation for code block in prerequisites.

Self-managed content is unchanged.

Closes [DOC-1936](https://redpandadata.atlassian.net/browse/DOC-1936).

## Related PR

Companion cloud-docs PR with predefined-roles, Account impersonation, and What's New updates: redpanda-data/cloud-docs#581

## Preview pages

- [Schema Registry Authorization](https://deploy-preview-1694--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-authorization/#prerequisites) (updated)
- [Use the Schema Registry API](https://deploy-preview-1694--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-api/) (updated)

## Test plan

- [ ] Build the cloud-docs site (which single-sources this page) and verify the Cloud rendering of `manage/schema-reg/schema-reg-authorization` shows the new "enabled by default" NOTE and the *Manage Schema Registry ACLs* prerequisites section.
- [ ] Build the docs site for self-managed and verify the *Enable Schema Registry Authorization* section is unchanged for non-Cloud builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-1936]: https://redpandadata.atlassian.net/browse/DOC-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ