### PR TITLE
Rename ROOT to streaming component (v23.3)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,8 +11,13 @@ asciidoc:
     page-eol: true
     # Only used in the main branch (latest version)
     page-header-data:
+      title: "Streaming"
+      section: "Data Platform"
+      parent-component: "self-managed"
+      description: "Redpanda broker and rpk CLI for self-managed deployments."
+      color: "#125d56"
       order: 2
-      color: '#125d56'
+      icon: "activity"
     # Fallback versions
     # We try to fetch the latest from GitHub at build time
     # --

--- a/antora.yml
+++ b/antora.yml
@@ -88,7 +88,7 @@ asciidoc:
       - title: 'Redpanda Connect'
         image: redpanda-connect.png
         description: 'Redpanda Connect provides an ecosystem of 220+ open source connectors.'
-        url: 'connect:ROOT:about.adoc'
+        url: 'connect:home:index.adoc'
         learn-text: true
       - title: 'Use rpk'
         image: rpk-commands.png

--- a/antora.yml
+++ b/antora.yml
@@ -6,7 +6,6 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    page-use-parent-context: true
     # Product name used throughout the documentation
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22

--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,8 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    # Product name used throughout the documentation
+    product-name: Redpanda Streaming
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22
     page-eol: true

--- a/antora.yml
+++ b/antora.yml
@@ -1,4 +1,4 @@
-name: ROOT
+name: streaming
 title: Enterprise
 version: 23.3
 start_page: get-started:intro-to-events.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: streaming
-title: Enterprise
+title: Streaming
 version: 23.3
 start_page: get-started:intro-to-events.adoc
 nav:

--- a/antora.yml
+++ b/antora.yml
@@ -11,9 +11,8 @@ asciidoc:
     page-release-date: 2023-12-22
     page-eol: true
     # Only used in the main branch (latest version)
-    page-header-data:
+    component-metadata:
       title: "Streaming"
-      section: "Data Platform"
       parent-component: "self-managed"
       description: "Redpanda broker and rpk CLI for self-managed deployments."
       color: "#125d56"

--- a/antora.yml
+++ b/antora.yml
@@ -6,6 +6,7 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
+    page-use-parent-context: true
     # Product name used throughout the documentation
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22

--- a/antora.yml
+++ b/antora.yml
@@ -83,7 +83,7 @@ asciidoc:
       - title: 'Redpanda Connect'
         image: redpanda-connect.png
         description: 'Redpanda Connect provides an ecosystem of 220+ open source connectors.'
-        url: 'redpanda-connect:ROOT:about.adoc'
+        url: 'connect:ROOT:about.adoc'
         learn-text: true
       - title: 'Use rpk'
         image: rpk-commands.png
@@ -98,5 +98,5 @@ asciidoc:
       - title: 'Labs'
         image: labs.png
         description: 'Explore real-world examples in Redpanda Labs.'
-        url: 'redpanda-labs:ROOT:index.adoc'
+        url: 'labs:ROOT:index.adoc'
         learn-text: true

--- a/antora.yml
+++ b/antora.yml
@@ -8,6 +8,7 @@ asciidoc:
   attributes:
     # Product name used throughout the documentation
     product-name: Redpanda Streaming
+    cloud-product-name: Redpanda Cloud
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22
     page-eol: true

--- a/antora.yml
+++ b/antora.yml
@@ -10,6 +10,9 @@ asciidoc:
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22
     page-eol: true
+    # Version selector footer links
+    page-whats-new-doc: get-started:whats-new.adoc
+    page-upgrade-doc: upgrade:index.adoc
     # Only used in the main branch (latest version)
     component-metadata:
       title: "Streaming"

--- a/antora.yml
+++ b/antora.yml
@@ -7,8 +7,6 @@ nav:
 asciidoc:
   attributes:
     # Product name used throughout the documentation
-    product-name: Redpanda Streaming
-    cloud-product-name: Redpanda Cloud
     # Date of release in the format YYYY-MM-DD
     page-release-date: 2023-12-22
     page-eol: true

--- a/modules/deploy/partials/kubernetes/guides/next-steps.adoc
+++ b/modules/deploy/partials/kubernetes/guides/next-steps.adoc
@@ -1,6 +1,6 @@
 = Next steps
 
-* xref:labs:streaming:index.adoc[Try an example in Redpanda Labs]
+* xref:labs:ROOT:index.adoc[Try an example in Redpanda Labs]
 * xref:manage:console/index.adoc[Learn more about Redpanda Console]
 * xref:get-started:rpk-install.adoc[Learn more about rpk]
 

--- a/modules/deploy/partials/kubernetes/guides/next-steps.adoc
+++ b/modules/deploy/partials/kubernetes/guides/next-steps.adoc
@@ -1,6 +1,6 @@
 = Next steps
 
-* xref:redpanda-labs:ROOT:index.adoc[Try an example in Redpanda Labs]
+* xref:labs:streaming:index.adoc[Try an example in Redpanda Labs]
 * xref:manage:console/index.adoc[Learn more about Redpanda Console]
 * xref:get-started:rpk-install.adoc[Learn more about rpk]
 

--- a/modules/develop/pages/http-proxy.adoc
+++ b/modules/develop/pages/http-proxy.adoc
@@ -102,7 +102,7 @@ Curl is likely already installed on your system. If not, see https://curl.se/dow
 NodeJS::
 +
 --
-NOTE: This is based on the assumption that you're in the root directory of an existing NodeJS project. See xref:redpanda-labs:clients:docker-nodejs.adoc[] for an example of a NodeJS project.
+NOTE: This is based on the assumption that you're in the root directory of an existing NodeJS project. See xref:labs:clients:docker-nodejs.adoc[] for an example of a NodeJS project.
 
 In a terminal window, run:
 

--- a/modules/get-started/pages/intro-to-events.adoc
+++ b/modules/get-started/pages/intro-to-events.adoc
@@ -71,7 +71,7 @@ Redpanda Cloud releases on a continuous basis and uptakes Redpanda platform vers
 * To spin up a Redpanda cluster to try it out, see xref:./quick-start.adoc[Redpanda Quickstart].
 * To learn more about Redpanda, see xref:./architecture.adoc[How Redpanda Works].
 * For information about a self-hosted Redpanda platform deployment, see xref:./licenses.adoc[Redpanda Licensing].
-* For information about a Redpanda Cloud deployment, see xref:redpanda-cloud:get-started:cloud-overview.adoc[].
+* For information about a Redpanda Cloud deployment, see xref:cloud-data-platform:get-started:cloud-overview.adoc[].
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/get-started/pages/intro-to-rpk.adoc
+++ b/modules/get-started/pages/intro-to-rpk.adoc
@@ -15,7 +15,7 @@ In general, `rpk` commands can be divided into these categories:
 
 The `rpk` binary is bundled with Redpanda, so it is automatically installed on each Redpanda broker. In addition, you can install `rpk` on your local machine as a xref:./rpk-install.adoc[standalone binary]. This method can be used for self-hosted and cloud deployments, as well as Kubernetes deployments.
 
-After you install `rpk`, you can use it to interact with a Redpanda cluster. The cluster can run on your local machine, or it can run externally on a remote server or on xref:redpanda-cloud:deploy:deployment-option/cloud/index.adoc[Redpanda Cloud], for example.
+After you install `rpk`, you can use it to interact with a Redpanda cluster. The cluster can run on your local machine, or it can run externally on a remote server or on xref:cloud-data-platform:deploy:deployment-option/cloud/index.adoc[Redpanda Cloud], for example.
 
 The following diagram shows how `rpk` communicates with a Redpanda broker installed on your local machine. The `rpk` binary is installed as part of the Redpanda bundle.
 

--- a/modules/get-started/pages/licenses.adoc
+++ b/modules/get-started/pages/licenses.adoc
@@ -2,7 +2,7 @@
 :description: Redpanda is free and source-available at the Redpanda GitHub repo. Additional features are included with an enterprise license.
 :page-aliases: introduction:licenses.adoc
 
-You can deploy Redpanda in a self-hosted environment (Redpanda platform) or as a fully-managed cloud service (Redpanda Cloud). For more information about Redpanda Cloud deployments, see the xref:redpanda-cloud:get-started:cloud-overview.adoc[].
+You can deploy Redpanda in a self-hosted environment (Redpanda platform) or as a fully-managed cloud service (Redpanda Cloud). For more information about Redpanda Cloud deployments, see the xref:cloud-data-platform:get-started:cloud-overview.adoc[].
 
 To self-host Redpanda platform, select either the Community Edition or the Enterprise Edition:
 

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -47,7 +47,7 @@ For production environments where you need more resilience, a three-broker setup
 Single Broker::
 +
 --
-. xref:redpanda-labs:docker-compose:attachment$single-broker/docker-compose.yml[Download] the following `docker-compose.yml` file on your local file system.
+. xref:labs:docker-compose:attachment$single-broker/docker-compose.yml[Download] the following `docker-compose.yml` file on your local file system.
 +
 .Reveal the YAML content
 [%collapsible]
@@ -55,7 +55,7 @@ Single Broker::
 .`docker-compose.yml`
 [,yaml,subs="attributes+"]
 ----
-include::redpanda-labs:docker-compose:attachment$single-broker/docker-compose.yml[]
+include::labs:docker-compose:attachment$single-broker/docker-compose.yml[]
 ----
 ====
 
@@ -78,7 +78,7 @@ Three Brokers::
 +
 --
 
-. xref:redpanda-labs:docker-compose:attachment$three-brokers/docker-compose.yml[Download] the following `docker-compose.yml` file on your local file system.
+. xref:labs:docker-compose:attachment$three-brokers/docker-compose.yml[Download] the following `docker-compose.yml` file on your local file system.
 +
 .Reveal the YAML content
 [%collapsible]
@@ -86,7 +86,7 @@ Three Brokers::
 .`docker-compose.yml`
 [,yaml,subs="attributes+"]
 ----
-include::redpanda-labs:docker-compose:attachment$three-brokers/docker-compose.yml[]
+include::labs:docker-compose:attachment$three-brokers/docker-compose.yml[]
 ----
 ====
 
@@ -299,7 +299,7 @@ docker compose down -v
 
 == Next steps
 
-- xref:redpanda-labs:ROOT:index.adoc[Try more examples in Redpanda Labs]
+- xref:labs:streaming:index.adoc[Try more examples in Redpanda Labs]
 - xref:manage:console/index.adoc[Learn more about Redpanda Console]
 - xref:rpk-install.adoc[Learn more about rpk]
 - xref:deploy:deployment-option/self-hosted/manual/production/index.adoc[Deploy for development or production]

--- a/modules/get-started/pages/quick-start.adoc
+++ b/modules/get-started/pages/quick-start.adoc
@@ -299,7 +299,7 @@ docker compose down -v
 
 == Next steps
 
-- xref:labs:streaming:index.adoc[Try more examples in Redpanda Labs]
+- xref:labs:ROOT:index.adoc[Try more examples in Redpanda Labs]
 - xref:manage:console/index.adoc[Learn more about Redpanda Console]
 - xref:rpk-install.adoc[Learn more about rpk]
 - xref:deploy:deployment-option/self-hosted/manual/production/index.adoc[Deploy for development or production]

--- a/modules/get-started/pages/whats-new.adoc
+++ b/modules/get-started/pages/whats-new.adoc
@@ -4,7 +4,7 @@
 
 This topic summarizes new content added in version 23.3. For a complete list of all product updates, see the https://github.com/redpanda-data/redpanda/releases/[Redpanda release notes^]. 
 
-See also: xref:redpanda-cloud:get-started:whats-new-cloud.adoc[]
+See also: xref:cloud-data-platform:get-started:whats-new-cloud.adoc[]
 
 == Data transforms
 


### PR DESCRIPTION
Renames the component from ROOT to streaming in antora.yml for version 23.3.

Part of unified navigation implementation - aligns with other version branches.