### PR TITLE
Hide self-managed release notes prerequisite from cloud build

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -65,6 +65,7 @@ Before using Schema Registry contexts, ensure that:
 ifndef::env-cloud[]
 * You are running xref:get-started:release-notes/redpanda.adoc[Redpanda v26.1] or later.
 endif::env-cloud[]
+
 * The xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster configuration property is set to `true`.
 +
 [IMPORTANT]

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -64,7 +64,7 @@ Before using Schema Registry contexts, ensure that:
 
 ifndef::env-cloud[]
 * You are running xref:get-started:release-notes/redpanda.adoc[Redpanda v26.1] or later.
-endif::[]
+endif::env-cloud[]
 * The xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster configuration property is set to `true`.
 +
 [IMPORTANT]
@@ -778,10 +778,5 @@ curl -s -X DELETE http://localhost:8081/contexts/.staging
 * xref:manage:schema-reg/schema-reg-authorization.adoc[]
 * link:/api/doc/schema-registry/[Schema Registry API reference]
 * xref:reference:public-metrics-reference.adoc[]
-ifndef::env-cloud[]
-* xref:reference:cluster-properties.adoc[]
-endif::env-cloud[]
-ifdef::env-cloud[]
 * xref:reference:properties/cluster-properties.adoc[]
-endif::env-cloud[]
 // end::single-source[]

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -62,7 +62,9 @@ endif::env-cloud[]
 
 Before using Schema Registry contexts, ensure that:
 
+ifndef::env-cloud[]
 * You are running xref:get-started:release-notes/redpanda.adoc[Redpanda v26.1] or later.
+endif::[]
 * The xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster configuration property is set to `true`.
 +
 [IMPORTANT]


### PR DESCRIPTION
## Summary

Wraps the "Redpanda v26.1 or later" prerequisite bullet on the Schema Registry contexts page in `ifndef::env-cloud[]` so it appears only in the self-managed build. The bullet links to `xref:get-started:release-notes/redpanda.adoc[]`, which exists in the `ROOT` (self-managed) component but not in `redpanda-cloud`. When `modules/manage/pages/schema-reg/schema-reg-contexts.adoc` is single-sourced into cloud-docs via `include::ROOT:manage:schema-reg/schema-reg-contexts.adoc[tag=single-source]`, the xref resolves against `redpanda-cloud` and breaks the cloud-docs build. The version prerequisite also doesn't apply to cloud users — Redpanda Cloud manages versions.

## Why this fix is needed

@Feediver1 — your recent PRs #1658 (DOC-1996: Schema Registry Contexts) and #1690 (DOC-1790: Schema Registry Metadata Properties) introduced xrefs inside the single-sourced section of `modules/manage/pages/schema-reg/schema-reg-contexts.adoc` that point at pages that exist only in the self-managed `ROOT` component. Three xrefs broke the cloud-docs build:

1. `xref:get-started:release-notes/redpanda.adoc[]` — fixed in this PR.
2. `xref:reference:rpk/rpk-registry/rpk-registry-context-list.adoc[]` — fixed in the companion cloud-docs PR redpanda-data/cloud-docs#588 (adds wrapper pages).
3. `xref:reference:rpk/rpk-registry/rpk-registry-context-delete.adoc[]` — fixed in the companion cloud-docs PR redpanda-data/cloud-docs#588 (adds wrapper pages).

In Antora, xrefs inside included content resolve in the **including** page's component, not the source component. For pages that exist only in the self-managed component, the xref must either be wrapped in `ifndef::env-cloud[]` (this PR) or, if the linked content is cloud-relevant, a wrapper page must be added on the cloud-docs side (the companion PR).

## Preview pages

- [Schema Registry Contexts](https://deploy-preview-1707--redpanda-docs-preview.netlify.app/current/manage/schema-reg/schema-reg-contexts/) (updated)
- [same prereqs section in Cloud](https://deploy-preview-1707--redpanda-docs-preview.netlify.app/redpanda-cloud/manage/schema-reg/schema-reg-contexts/#prerequisites)

## Test plan

- [x] Cloud-docs local build (with this branch as the docs source) confirms the three Schema Registry contexts xref errors are gone.
- [ ] Self-managed standalone build still renders the prerequisite bullet on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)