### PR TITLE
Add Cloud Topics to Enterprise Feature License table

### DIFF
--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -111,7 +111,7 @@ The following table lists the enterprise features for Redpanda and how Redpanda 
 
 | xref:develop/manage-topics/cloud-topics.adoc[Cloud Topics]
 | A Redpanda topic type that uses durable object storage as the primary backing store instead of local disk replication.
-| Cloud Topics cannot be created. Existing Cloud Topics cannot be modified. Additional partitions cannot be added to existing Cloud Topics. Major upgrades are blocked when in a violation state.
+| New Cloud Topics cannot be created. Existing Cloud Topics cannot be modified (including the addition or modification of partitions for existing Cloud Topics). Major upgrades are blocked when in a violation state.
 
 | xref:manage:cluster-maintenance/continuous-data-balancing.adoc[Continuous Data Balancing]
 | Automatically balances partitions across a cluster to optimize resource use and performance.

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -109,6 +109,10 @@ The following table lists the enterprise features for Redpanda and how Redpanda 
 | Records detailed logs of cluster activities for compliance and monitoring.
 | Read access to the audit log topic is denied, but logging continues.
 
+| xref:develop/manage-topics/cloud-topics.adoc[Cloud Topics]
+| A Redpanda topic type that uses durable object storage as the primary backing store instead of local disk replication.
+| Cloud Topics cannot be created. Existing Cloud Topics cannot be modified. Additional partitions cannot be added to existing Cloud Topics. Major upgrades are blocked when in a violation state.
+
 | xref:manage:cluster-maintenance/continuous-data-balancing.adoc[Continuous Data Balancing]
 | Automatically balances partitions across a cluster to optimize resource use and performance.
 

--- a/modules/get-started/pages/licensing/overview.adoc
+++ b/modules/get-started/pages/licensing/overview.adoc
@@ -109,9 +109,9 @@ The following table lists the enterprise features for Redpanda and how Redpanda 
 | Records detailed logs of cluster activities for compliance and monitoring.
 | Read access to the audit log topic is denied, but logging continues.
 
-| xref:develop/manage-topics/cloud-topics.adoc[Cloud Topics]
+| xref:develop:manage-topics/cloud-topics.adoc[Cloud Topics]
 | A Redpanda topic type that uses durable object storage as the primary backing store instead of local disk replication.
-| New Cloud Topics cannot be created. Existing Cloud Topics cannot be modified (including the addition or modification of partitions for existing Cloud Topics). Major upgrades are blocked when in a violation state.
+| New Cloud Topics cannot be created. Existing Cloud Topics cannot be modified, including adding or modifying partitions. Major upgrades are blocked when in a violation state.
 
 | xref:manage:cluster-maintenance/continuous-data-balancing.adoc[Continuous Data Balancing]
 | Automatically balances partitions across a cluster to optimize resource use and performance.


### PR DESCRIPTION
## Description

No ticket for this. This content was not included in the 26.1 GA release of Cloud Topics. Adding now.
Review deadline:

## Page previews

[Redpanda enterprise features](https://deploy-preview-1708--redpanda-docs-preview.netlify.app/current/get-started/licensing/overview/#self-managed)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
