### PR TITLE
Fix Operator-mode PVCUnbinder and BrokerDecommissioner instructions

### DIFF
--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -578,6 +578,8 @@ When scaling in (removing brokers), remove only one broker at a time. If you red
 Operator::
 +
 --
+The Decommission controller is already running in the Redpanda Operator (enabled in the earlier `additionalCmdFlags={--additional-controllers="decommission"}` step). To trigger a decommission, change only the StatefulSet replica count on the Redpanda resource — do not add `sideCars.brokerDecommissioner` here, as that field is not part of the Redpanda CRD and is silently dropped when the resource is applied.
+
 .`redpanda-cluster.yaml`
 [,yaml,lines=9]
 ----
@@ -589,15 +591,10 @@ spec:
   chartRef: {}
   clusterSpec:
     statefulset:
-      replicas: 6
-      sideCars:
-        brokerDecommissioner:
-          enabled: true
-          decommissionAfter: 60s
-          decommissionRequeueTimeout: 10s
-    rbac:
-      enabled: true
+      replicas: 6 <1>
 ----
++
+<1> `statefulset.replicas`: Reduce by one. The Decommission controller in the operator detects the change and decommissions the broker on the highest-ordinal Pod.
 
 ```bash
 kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
@@ -643,11 +640,20 @@ The BrokerDecommissioner detects when the number of replicas decreases and decom
 kubectl exec redpanda-0 --namespace <namespace> -- rpk cluster health
 ```
 +
-It may take some time for the BrokerDecommissioner to reconcile. You can check the progress by looking at the logs:
+It may take some time for the BrokerDecommissioner to reconcile. You can check the progress by looking at the controller's logs.
++
+For a Helm-only deployment, the controller runs in the broker Pod's `sidecars` container:
 +
 [,bash]
 ----
 kubectl logs <pod-name> --namespace <namespace> -c sidecars
+----
++
+For an Operator-managed deployment, the controller runs in the Redpanda Operator Pod:
++
+[,bash]
+----
+kubectl logs deployment/redpanda-controller --namespace <operator-namespace>
 ----
 
 You can repeat this procedure to continue to scale down.

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -578,7 +578,7 @@ When scaling in (removing brokers), remove only one broker at a time. If you red
 Operator::
 +
 --
-The Decommission controller is already running in the Redpanda Operator (enabled in the earlier `additionalCmdFlags={--additional-controllers="decommission"}` step). To trigger a decommission, change only the StatefulSet replica count on the Redpanda resource — do not add `sideCars.brokerDecommissioner` here, as that field is not part of the Redpanda CRD and is silently dropped when the resource is applied.
+The Decommission controller is already running in the Redpanda Operator (enabled in the earlier `additionalCmdFlags={--additional-controllers="decommission"}` step). To trigger a decommission, change only the StatefulSet replica count on the Redpanda resource. Do not add `sideCars.brokerDecommissioner` here, as that field is not part of the Redpanda CRD and is silently dropped when the resource is applied.
 
 .`redpanda-cluster.yaml`
 [,yaml,lines=9]

--- a/modules/manage/pages/kubernetes/k-nodewatcher.adoc
+++ b/modules/manage/pages/kubernetes/k-nodewatcher.adoc
@@ -49,30 +49,45 @@ Operator::
 +
 --
 
-To enable the PVCUnbinder:
+In Operator-managed deployments, the PVCUnbinder runs as a controller inside the Redpanda Operator process, not as a sidecar in each Redpanda broker Pod. Enable it by passing `--unbind-pvcs-after` to the operator binary through the operator chart's `additionalCmdFlags`.
 
-.`redpanda-cluster.yaml`
+[IMPORTANT]
+====
+The Redpanda custom resource (`cluster.redpanda.com/v1alpha2`) does *not* expose a `clusterSpec.statefulset.sideCars.pvcUnbinder` field. The Kubernetes API server silently drops the key when the CR is applied, so setting it there has no effect. Enable the PVCUnbinder on the operator deployment itself, as shown below.
+====
+
+[tabs]
+====
+--values::
++
+.`operator-values.yaml`
 [,yaml]
 ----
-apiVersion: cluster.redpanda.com/v1alpha2
-kind: Redpanda
-metadata:
-  name: redpanda
-spec:
-  chartRef: {}
-  clusterSpec:
-    statefulset:
-      sideCars:
-        pvcUnbinder:
-          enabled: true <1>
-          unbindAfter: 60s <2>
-    rbac:
-      enabled: true <3>
+additionalCmdFlags:
+  - --unbind-pvcs-after=60s <1>
 ----
++
+<1> `--unbind-pvcs-after`: How long a Redpanda Pod must be stuck in `Pending` with a volume node-affinity scheduling failure before the operator unbinds its PVC. A value of `0` (the default) disables the controller.
 
-<1> `statefulset.sideCars.pvcUnbinder.enabled`: Enables the PVCUnbinder sidecar.
-<2> `statefulset.sideCars.pvcUnbinder.unbindAfter`: Sets the time in seconds after which the PVCUnbinder sidecar removes the PVC after the Node resource is deleted.
-<3> `rbac.enabled`: Creates the required RBAC rules for the PVCUnbinder to monitor the Node resources and update PVCs and PVs.
+--set::
++
+[,bash]
+----
+helm upgrade --install redpanda-controller redpanda/operator \
+  --namespace <namespace> \
+  --create-namespace \
+  --set 'additionalCmdFlags={--unbind-pvcs-after=60s}' <1>
+----
++
+<1> `--unbind-pvcs-after`: How long a Redpanda Pod must be stuck in `Pending` with a volume node-affinity scheduling failure before the operator unbinds its PVC. A value of `0` (the default) disables the controller.
+====
+
+Optional flags you can append to `additionalCmdFlags`:
+
+* `--allow-pv-rebinding`: After unbinding the PVC, also clear the PV's `claimRef` so that the PV can be re-bound if the original node returns. Avoid when using `LocalPathProvisioner` or `hostPath` volumes.
+* `--unbinder-label-selector=<selector>`: Restrict the PVCUnbinder to Pods matching the given Kubernetes label selector.
+
+NOTE: The operator chart's default RBAC bundle already includes the permissions the PVCUnbinder needs to read Pods and PVCs and to patch PVs, so you do not need to enable any additional RBAC toggles.
 
 --
 Helm::
@@ -129,11 +144,20 @@ kubectl delete node <node-name>
 +
 NOTE: This step is for testing purposes only.
 
-. Monitor the logs of the PVCUnbinder sidecar:
+. Monitor the PVCUnbinder logs.
++
+For a Helm-only deployment, the controller runs in the broker Pod's `sidecars` container:
 +
 [,bash]
 ----
 kubectl logs <pod-name> --namespace <namespace> -c sidecars
+----
++
+For an Operator-managed deployment, the controller runs in the Redpanda Operator Pod:
++
+[,bash]
+----
+kubectl logs deployment/redpanda-controller --namespace <operator-namespace>
 ----
 +
 You should see that the PVCUnbinder successfully deleted the PVC of the Pod that was running on the deleted Node resource.

--- a/modules/manage/pages/kubernetes/k-nodewatcher.adoc
+++ b/modules/manage/pages/kubernetes/k-nodewatcher.adoc
@@ -53,7 +53,7 @@ In Operator-managed deployments, the PVCUnbinder runs as a controller inside the
 
 [IMPORTANT]
 ====
-The Redpanda custom resource (`cluster.redpanda.com/v1alpha2`) does *not* expose a `clusterSpec.statefulset.sideCars.pvcUnbinder` field. The Kubernetes API server silently drops the key when the CR is applied, so setting it there has no effect. Enable the PVCUnbinder on the operator deployment itself, as shown below.
+The Redpanda custom resource (`cluster.redpanda.com/v1alpha2`) does not expose a `clusterSpec.statefulset.sideCars.pvcUnbinder` field. The Kubernetes API server silently drops the key when the CR is applied, so setting it there has no effect. Enable the PVCUnbinder on the operator deployment itself, as shown below.
 ====
 
 [tabs]

--- a/modules/manage/pages/kubernetes/k-nodewatcher.adoc
+++ b/modules/manage/pages/kubernetes/k-nodewatcher.adoc
@@ -133,7 +133,7 @@ helm upgrade --install redpanda redpanda/redpanda \
 --
 ======
 
-== Test the PVCUnbinder sidecar
+== Test the PVCUnbinder
 
 . Test the PVCUnbinder sidecar by deleting a Node resource:
 +


### PR DESCRIPTION
## Summary

Two Kubernetes management pages told Operator users to set fields under `clusterSpec.statefulset.sideCars` on the Redpanda CR (`cluster.redpanda.com/v1alpha2`) that do **not** exist on the CRD. The Kubernetes API server silently prunes the keys when the CR is applied, so the examples we ship have no effect for Operator-managed deployments.

### What was broken, and where

`SideCars` in [`operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go`](https://github.com/redpanda-data/redpanda-operator/blob/release/v25.3.x/operator/api/redpanda/v1alpha2/redpanda_clusterspec_types.go) only exposes: `image`, `extraVolumeMounts`, `resources`, `securityContext`, `args`, `configWatcher`, `rpkStatus`, `controllers`. No `pvcUnbinder` and no `brokerDecommissioner`. (Verified identical on `release/v25.2.x`, `release/v25.3.x`, and `release/v26.1.x`.)

Two pages were affected:

1. **`k-nodewatcher.adoc` — "Enable the PVCUnbinder" → Operator tab.** Showed a CR with `clusterSpec.statefulset.sideCars.pvcUnbinder.{enabled, unbindAfter}` and `clusterSpec.rbac.enabled`. None of those reach the operator.
2. **`k-decommission-brokers.adoc` — "Decrease the number of replicas" → Operator tab.** Showed a CR with `clusterSpec.statefulset.sideCars.brokerDecommissioner.{enabled, decommissionAfter, decommissionRequeueTimeout}` and `clusterSpec.rbac.enabled`. This also made the page internally inconsistent: the earlier "Enable the BrokerDecommissioner" Operator tab on the same page correctly omits these fields.

In both cases the corresponding **Helm-only** tabs are correct — `statefulset.sideCars.pvcUnbinder` and `statefulset.sideCars.brokerDecommissioner` are valid keys in the `redpanda` chart's `values.yaml` when installing the chart directly.

### Fix pattern

In Operator-managed deployments, both controllers run inside the Redpanda Operator process — not as sidecars in the broker Pods. They are enabled on the operator binary via flags passed through the operator chart's `additionalCmdFlags`:

| Controller | Operator flag(s) | Chart-only equivalent (Helm path) |
|---|---|---|
| **PVCUnbinder** (`pvcunbinder.Controller`) | `--unbind-pvcs-after=<duration>` (+ optional `--allow-pv-rebinding`, `--unbinder-label-selector`) | `statefulset.sideCars.pvcUnbinder.*` |
| **BrokerDecommissioner** (`decommissioning.StatefulSetDecommissioner`) | `--additional-controllers=decommission` (+ `rbac.createAdditionalControllerCRs=true`) | `statefulset.sideCars.brokerDecommissioner.*` |

### Changes

**Commit 1 — `k-nodewatcher.adoc`:**
- Rewrote the Operator tab to use `--values` / `--set` sub-tabs against the **operator chart**, mirroring the pattern already used correctly by the "Enable the BrokerDecommissioner" Operator tab.
- Added an `IMPORTANT` admonition calling out the CRD-pruning behavior so users searching the old docs land on the corrected instructions.
- Listed related optional flags (`--allow-pv-rebinding`, `--unbinder-label-selector`).
- Noted that the operator chart's default RBAC bundle already covers the PVCUnbinder (`operator/chart/rbac.go` puts `pvcunbinder.{ClusterRole,Role}.yaml` in the always-on bundle), so no extra RBAC toggle is needed.
- Updated the "Test the PVCUnbinder" log-tailing step so Operator users tail the operator Pod's logs rather than a `sidecars` container that doesn't exist in that mode.

**Commit 2 — `k-decommission-brokers.adoc`:**
- Replaced the broken `sideCars.brokerDecommissioner` / `rbac.enabled` block in the "Decrease the number of replicas" Operator tab with a CR that changes only `statefulset.replicas`, and added a short callout pointing back to the earlier "Enable" step.
- Updated the log-tailing step so Operator users tail the operator Pod's logs.
- The Helm-only tab and the earlier "Enable the BrokerDecommissioner" Operator tab are unchanged.

### Why the right PVCUnbinder flag is `--unbind-pvcs-after`, not `--additional-controllers=nodeWatcher`

The operator binary actually exposes two related controllers:

| Controller | Flag | Trigger | Status |
|---|---|---|---|
| **PVCUnbinder** (`pvcunbinder.Controller`) | `--unbind-pvcs-after=<duration>` | Pod `Pending` with volume-affinity scheduling failure | Current |
| **NodeWatcher** (`nodewatcher.RedpandaNodePVCReconciler`) | `--additional-controllers=nodeWatcher` | Node deletion event | `node-watcher.{ClusterRole,Role}.yaml` is explicitly marked _"Deprecated but not yet removed"_ in `operator/chart/rbac.go` |

Despite the page's URL slug (`k-nodewatcher`), the page title and described behavior match the **PVCUnbinder**, and the chart's `Sidecars.PVCUnbinder.UnbindAfter` value maps directly to `--unbind-pvcs-after`. This PR uses the current flag.

### Verified on

- `redpanda-data/redpanda-operator` `release/v25.3.x`, `release/v26.1.x`, `release/v25.2.x`: the CRD has the same `SideCars` schema (no `pvcUnbinder` and no `brokerDecommissioner`) on all three branches, and the operator flags are the same.

### Backports

Same bugs exist on the 25.3 and 25.2 doc versions. I'll open follow-up backport PRs once this lands.

### Out of scope

- The operator binary also has `--enable-ghost-broker-decommissioner` (+ `--ghost-broker-decommissioner-sync-period`), which is a separate controller from `--additional-controllers=decommission` (it covers IDs the cluster knows about that aren't in the StatefulSet). The decommission page doesn't mention it; whether to document that is an editorial call for a follow-up.

## Preview pages

- [Decommission Brokers in Kubernetes](https://deploy-preview-1717--redpanda-docs-preview.netlify.app/current/manage/kubernetes/k-decommission-brokers/) (updated)
- [Enable the PVCUnbinder](https://deploy-preview-1717--redpanda-docs-preview.netlify.app/current/manage/kubernetes/k-nodewatcher/) (updated)

## Test plan

- [ ] `npm run build` / Antora build is clean
- [ ] Netlify preview renders both pages cleanly, including the new `--values`/`--set` sub-tabs on the nodewatcher page
- [ ] Spot-check that the rewritten flows can be followed end-to-end against an operator-managed cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)
