### PR TITLE
all: Remove 16k IOPS recommendation

### DIFF
--- a/modules/deploy/pages/redpanda/kubernetes/k-production-readiness.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/k-production-readiness.adoc
@@ -527,9 +527,6 @@ Ensure storage classes provide adequate IOPS and throughput for your workload by
 **Performance specifications:**
 
 * Use NVMe-based storage classes for production deployments
-* Specify a minimum 16,000 IOPS (Input/Output Operations Per Second)
-* Consider provisioned IOPS where available to meet or exceed the minimum
-* Enable xref:develop:manage-topics/config-topics.adoc#configure-write-caching[write caching] to help Redpanda perform better in environments with disks that don't meet the recommended IOPS
 * NFS (Network File System) is not supported
 * Test storage performance under load
 

--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -133,8 +133,6 @@ endif::[]
 *Requirements*:
 
 - NVMe (Non-Volatile Memory Express) drives are required for production deployments. NVMe drives provide the high throughput and low latency needed for optimal Redpanda performance.
-
-- At least 16,000 IOPS (Input/Output Operations Per Second).
 +
 See also: xref:manage:cluster-maintenance/cluster-diagnostics.adoc#self-test[Disk and network self-test benchmarks].
 

--- a/modules/deploy/partials/self-test.adoc
+++ b/modules/deploy/partials/self-test.adoc
@@ -3,5 +3,3 @@
 To understand the performance capabilities of your Redpanda cluster, Redpanda offers built-in self-test features that evaluate the performance of both disk and network operations.
 
 For more information, see xref:manage:cluster-maintenance/cluster-diagnostics.adoc#self-test[Disk and network self-test benchmarks].
-
-When using the storage bandwidth test, ensure that your results show at least 16,000 IOPS (Input/Output Operations Per Second) for production environments. If your test results are below this threshold, your storage may not be suitable for production Redpanda workloads.


### PR DESCRIPTION
This minimum performance recommendation was fairly arbitrary and doesn't really work in practice.

Remove it everywhere it's mentioned.

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
