### PR TITLE
docs: Fix cloud-divergent xrefs in single-sourced Cloud Topics content

### DIFF
--- a/modules/develop/pages/manage-topics/cloud-topics.adoc
+++ b/modules/develop/pages/manage-topics/cloud-topics.adoc
@@ -6,6 +6,8 @@
 :learning-objective-2: Create a Cloud Topic using rpk after enabling Cloud Topics on your cluster
 :learning-objective-3: Identify Cloud Topics limitations and configurations that reduce cross-AZ networking costs
 // tag::single-source[]
+ifdef::env-cloud[:producers-page: develop:topics/configure-producers-for-cloud-topics.adoc]
+ifndef::env-cloud[:producers-page: develop:manage-topics/configure-producers-for-cloud-topics.adoc]
 
 ifndef::env-cloud[]
 [NOTE]
@@ -83,6 +85,6 @@ You can make a topic a Cloud Topic only at topic creation time.
 
 In addition to replication, cross-AZ ingress (producer) and egress (consumer) traffic can also contribute substantially to cloud networking costs. When running multi-AZ clusters in general, Redpanda strongly recommends using xref:develop:consume-data/follower-fetching.adoc[Follower Fetching], which allows consumers to avoid crossing network zones. When possible, you can use xref:develop:produce-data/leader-pinning.adoc[leader pinning], which positions a topic's partition leader close to the producers, providing a similar benefit for ingress traffic. These features can add additional savings to the replication cost savings of Cloud Topics.
 
-For client-side tuning guidance, see xref:develop:manage-topics/configure-producers-for-cloud-topics.adoc[Configure producers for Cloud Topics].
+For client-side tuning guidance, see xref:{producers-page}[Configure producers for Cloud Topics].
 
 // end::single-source[]

--- a/modules/develop/partials/cloud-topics-overview.adoc
+++ b/modules/develop/partials/cloud-topics-overview.adoc
@@ -1,7 +1,7 @@
 // tag::intro[]
 Starting in v26.1, Redpanda provides glossterm:Cloud Topic[,Cloud Topics] to support multi-modal streaming workloads in the most cost-effective way possible: as a per-topic configuration running mixed latency workloads. While standard Redpanda
 ifdef::env-cloud[]
-xref:get-started:config-topics.adoc[topics]
+xref:develop:topics/config-topics.adoc[topics]
 endif::[]
 ifndef::env-cloud[]
 xref:develop:manage-topics/config-topics.adoc[topics]


### PR DESCRIPTION
## What

Fixes two xrefs inside the single-sourced Cloud Topics content that pointed at paths which only exist in the self-managed docs, so they would resolve as broken links when the page is single-sourced into cloud-docs.

- `modules/develop/pages/manage-topics/cloud-topics.adoc`: the producers-page link used `develop:manage-topics/...`, but cloud-docs serves that page at `develop:topics/...`. Now switched via an `env-cloud` attribute so each variant resolves.
- `modules/develop/partials/cloud-topics-overview.adoc`: the `env-cloud` branch pointed at `get-started:config-topics.adoc`, but cloud-docs serves it at `develop:topics/config-topics.adoc`. Updated the cloud branch target.

Self-managed output is unchanged (both fixes are inside `env-cloud` guards / attribute switches).

## Why

The cloud-docs Cloud Topics page was rendering blank because its stub was never wired up for single-sourcing. The companion cloud-docs PR wires it up; these xref fixes ensure the resulting page has no broken links.

## Companion PR

- redpanda-data/cloud-docs#604: wires up the single-sourced stub.

## Verification

Built cloud-docs locally against this branch. The Cloud Topics page renders in full, the cloud-only Prerequisites branch shows (self-managed-only content excluded), and all outbound links resolve to real cloud-docs pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview pages

- [Manage Cloud Topics](https://deploy-preview-1722--redpanda-docs-preview.netlify.app/streaming/current/develop/manage-topics/cloud-topics/) (updated)