### PR TITLE
Add rpk cloud auth token reference partial

### DIFF
--- a/modules/reference/partials/rpk-cloud/rpk-cloud-auth-token.adoc
+++ b/modules/reference/partials/rpk-cloud/rpk-cloud-auth-token.adoc
@@ -1,0 +1,30 @@
+= rpk cloud auth token
+// tag::single-source[]
+
+The `rpk cloud auth token` command prints the auth token for the currently selected cloud authentication to stdout. This is useful for piping the token into other commands or scripts that need to authenticate with Redpanda Cloud. For an example, see xref:sql:connect-to-sql/authenticate.adoc[Authenticate to Redpanda SQL].
+
+== Usage
+
+[,bash]
+----
+rpk cloud auth token [flags]
+----
+
+== Flags
+
+[cols="1m,1a,2a"]
+|===
+|*Value* |*Type* |*Description*
+
+|-h, --help |- |Help for token.
+
+|--config |string |Redpanda or `rpk` config file; default search paths are `/var/lib/redpanda/.config/rpk/rpk.yaml`, `$PWD/redpanda.yaml`, and `/etc/redpanda/redpanda.yaml`.
+
+|-X, --config-opt |stringArray |Override `rpk` configuration settings. See xref:reference:rpk/rpk-x-options.adoc[`rpk -X`] or execute `rpk -X help` for inline detail or `rpk -X list` for terser detail.
+
+|--profile |string |Profile to use. See xref:reference:rpk/rpk-profile.adoc[`rpk profile`] for more details.
+
+|-v, --verbose |- |Enable verbose logging.
+|===
+
+// end::single-source[]


### PR DESCRIPTION
## Description

This pull request adds documentation for the `rpk cloud auth token` command, providing details on its usage, flags, and purpose. The documentation explains how to retrieve the current authentication token for Redpanda Cloud and describes the available command-line options.

New documentation:

* Added a new partial, `rpk-cloud-auth-token.adoc`, documenting the `rpk cloud auth token` command, its usage, and available flags.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

https://deploy-preview-605--rp-cloud.netlify.app/cloud-data-platform/reference/rpk/rpk-cloud/rpk-cloud-auth-token/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
