### PR TITLE
requirements: Remove line about selinux

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -183,8 +183,6 @@ endif::[]
 
 Before deploying Redpanda to production, each node that runs Redpanda must be tuned to optimize the Linux kernel for Redpanda processes. 
 
-As part of your system tuning, be aware that enabling SELinux (Security-Enhanced Linux) can introduce performance overhead. If SELinux is not required for your environment, Redpanda Data recommends disabling it for optimal performance.
-
 ifdef::env-kubernetes[]
 See xref:deploy:redpanda/kubernetes/k-tune-workers.adoc[].
 endif::[]


### PR DESCRIPTION
Some renewed throughput benchmarks show no measurable impact of selinux.

Remove it to avoid questions about it.

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
