### PR TITLE
docs: remove governance dashboard glossary term

### DIFF
--- a/modules/terms/partials/governance-dashboard.adoc
+++ b/modules/terms/partials/governance-dashboard.adoc
@@ -1,4 +1,0 @@
-=== governance dashboard
-:term-name: governance dashboard
-:hover-text: Cross-tenant overview for platform and finance teams showing agent activity, spending, MCP server inventory, and authorization events. It brings AI Gateway usage and agent inventory into one view, down to per-provider spending and the authorization decisions that gate each tool invocation.
-:category: Agentic Data Plane


### PR DESCRIPTION
## What changed

Deletes `modules/terms/partials/governance-dashboard.adoc` from the shared glossary terms.

## Why

The governance dashboard surface is not available in the ADP product (the UI exists in code but is feature-flag gated off), so the term should not resolve in the glossary or as a `glossterm:` tooltip. Follow-up to [adp-docs#83](https://github.com/redpanda-data/adp-docs/pull/83), which removes the page documenting it and all `glossterm:governance dashboard[]` usages.

## Sequencing

Merge **after** adp-docs#83. Until that PR merges, three pages on adp-docs `main` (`budgets.adoc`, `adp-overview.adoc`, `adp-quickstart.adoc`) still reference `glossterm:governance dashboard[]`, which would log unresolved-term warnings in builds once this definition is gone. No other repo uses the term (verified against `docs`, `cloud-docs`, and `rp-connect-docs` main branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)