### PR TITLE
DOC-2237: correct decommission + maintenance mode guidance

### DIFF
--- a/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
+++ b/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
@@ -20,6 +20,8 @@ There are two ways to decommission brokers in Redpanda:
 
 Both methods permanently remove the broker from the cluster. Decommissioned brokers cannot rejoin.
 
+NOTE: Entering xref:manage:node-management.adoc[maintenance mode] before decommissioning is optional. Decommissioning drains partition leadership gracefully on its own.
+
 == What happens when a broker is decommissioned?
 
 When a broker is decommissioned, the controller leader creates a reallocation plan for all partition replicas that are allocated to that broker. By default, this reallocation is done in batches of 50 to avoid overwhelming the remaining brokers with Raft recovery. See xref:reference:tunable-properties.adoc#partition_autobalancing_concurrent_moves[`partition_autobalancing_concurrent_moves`].

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -25,6 +25,8 @@ There are two ways to decommission brokers in Redpanda:
 
 Both methods permanently remove the broker from the cluster. Decommissioned brokers cannot rejoin.
 
+NOTE: Entering xref:manage:node-management.adoc[maintenance mode] before decommissioning is optional. Decommissioning drains partition leadership gracefully on its own.
+
 == Prerequisites
 
 You must have the following:

--- a/modules/manage/pages/node-management.adoc
+++ b/modules/manage/pages/node-management.adoc
@@ -6,7 +6,7 @@
 
 Maintenance mode lets you take a Redpanda broker offline temporarily while minimizing disruption to client operations. When a broker is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, system maintenance or a xref:manage:cluster-maintenance/rolling-upgrade.adoc[rolling upgrade].
 
-CAUTION: A broker cannot be decommissioned while it's in maintenance mode. Take the broker out of maintenance mode first by running `rpk cluster maintenance disable <node-id>`.
+NOTE: Putting a broker into maintenance mode before decommissioning is optional. Decommissioning gracefully drains partition leadership on its own, so you can decommission a broker directly without first entering maintenance mode.
 
 When a broker is placed in maintenance mode, if the replication factor is greater than one, it reassigns partition leadership to other brokers in the cluster. The broker is not eligible for partition leadership again until it is taken out of maintenance mode.
 

--- a/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
@@ -102,10 +102,10 @@ The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to mon
 [NOTE]
 ====
 ifdef::rolling-upgrade[]
-You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before proceeding with other operations, such as decommissioning or retrying the rolling upgrade:
+You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before retrying the rolling upgrade:
 endif::[]
 ifdef::rolling-restart[]
-You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before proceeding with other operations, such as decommissioning or retrying the rolling restart:
+You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before retrying the rolling restart:
 endif::[]
 
 ```bash


### PR DESCRIPTION
## Summary

The Maintenance Mode page incorrectly states that a broker cannot be decommissioned while in maintenance mode. Per [DOC-2237](https://redpandadata.atlassian.net/browse/DOC-2237), that restriction only applied in 22.x and older. From 24.1.15 / 24.2.1 onward, decommission gracefully drains partition leadership on its own; maintenance mode beforehand is optional.

## Changes

- **`modules/manage/pages/node-management.adoc`** — replace the `CAUTION: A broker cannot be decommissioned while it's in maintenance mode` block with a `NOTE` clarifying that maintenance mode before decommission is optional and decommission handles leadership transfer.
- **`modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc`** — drop `decommissioning or` from the troubleshooting notes (both rolling-upgrade and rolling-restart variants) so they no longer imply maintenance mode blocks decommissioning. The troubleshooting advice itself is unchanged.
- **`modules/manage/pages/cluster-maintenance/decommission-brokers.adoc`** + **`modules/manage/pages/kubernetes/k-decommission-brokers.adoc`** — add a matching positive-framing `NOTE` on the decommission side so readers landing there see the same accurate guidance.

## Preview pages

- [Maintenance Mode](https://deploy-preview-1735--redpanda-docs-preview.netlify.app/streaming/current/manage/node-management/) (updated)
- [Decommission Brokers](https://deploy-preview-1735--redpanda-docs-preview.netlify.app/streaming/current/manage/cluster-maintenance/decommission-brokers/) (updated)
- [Decommission Brokers in Kubernetes](https://deploy-preview-1735--redpanda-docs-preview.netlify.app/streaming/current/manage/kubernetes/k-decommission-brokers/) (updated)
## Companion PRs

Per docs team policy this fix is being backported to every maintained branch where the wrong claim appears:

- v/25.3, v/25.2, v/25.1, v/24.3 — same wording as main (post-cutoff).
- v/24.2, v/24.1, v/23.3 — softer wording ("recommended but not required") because these branches span the 24.1.15 / 24.2.1 behavior change.
- 22.x EOL branches are not changed — the original wording is correct for those versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-2237]: https://redpandadata.atlassian.net/browse/DOC-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ