### PR TITLE
DOC-2237: correct decommission + maintenance mode guidance (v/24.2 backport)

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -23,6 +23,9 @@ content:
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
     branches: main
+  - url: https://github.com/redpanda-data/docs-site
+    branches: main
+    start_paths: [home, data-platform, self-managed]
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
+++ b/modules/manage/pages/cluster-maintenance/decommission-brokers.adoc
@@ -11,6 +11,8 @@ When you decommission a broker, its partition replicas are reallocated across th
 
 CAUTION: When a broker is decommissioned, it cannot rejoin the cluster. If a broker with the same ID tries to rejoin the cluster, it is rejected.
 
+NOTE: Entering xref:manage:node-management.adoc[maintenance mode] before decommissioning is recommended but not required. Maintenance mode reassigns partition leadership up front, which can be smoother for clients than draining leadership during decommissioning.
+
 == What happens when a broker is decommissioned?
 
 When a broker is decommissioned, the controller leader creates a reallocation plan for all partition replicas that are allocated to that broker. By default, this reallocation is done in batches of 50 to avoid overwhelming the remaining brokers with Raft recovery. See xref:reference:tunable-properties.adoc#partition_autobalancing_concurrent_moves[`partition_autobalancing_concurrent_moves`].

--- a/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
+++ b/modules/manage/pages/kubernetes/k-decommission-brokers.adoc
@@ -14,6 +14,8 @@ When you decommission a broker, its partition replicas are reallocated across th
 
 NOTE: When a broker is decommissioned, it cannot rejoin the cluster. If a broker with the same ID tries to rejoin the cluster, it is rejected.
 
+NOTE: Entering xref:manage:node-management.adoc[maintenance mode] before decommissioning is recommended but not required. Maintenance mode reassigns partition leadership up front, which can be smoother for clients than draining leadership during decommissioning.
+
 == Prerequisites
 
 You must have the following:

--- a/modules/manage/pages/node-management.adoc
+++ b/modules/manage/pages/node-management.adoc
@@ -6,7 +6,7 @@
 
 Maintenance mode lets you take a Redpanda broker offline temporarily while minimizing disruption to client operations. When a broker is in maintenance mode, you can safely perform operations that require the Redpanda process to be temporarily stopped; for example, system maintenance or a xref:manage:cluster-maintenance/rolling-upgrade.adoc[rolling upgrade].
 
-CAUTION: A broker cannot be decommissioned while it's in maintenance mode. Take the broker out of maintenance mode first by running `rpk cluster maintenance disable <node-id>`.
+NOTE: Putting a broker into maintenance mode before decommissioning is recommended but not required. Maintenance mode reassigns partition leadership up front, which can be smoother for clients than draining leadership during decommissioning.
 
 When a broker is placed in maintenance mode, if the replication factor is greater than one, it reassigns partition leadership to other brokers in the cluster. The broker is not eligible for partition leadership again until it is taken out of maintenance mode.
 

--- a/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
+++ b/modules/upgrade/partials/rolling-upgrades/enable-maintenance-mode.adoc
@@ -74,10 +74,10 @@ The combination of the `--watch` and `--exit-when-healthy` flags tell rpk to mon
 [NOTE]
 ====
 ifdef::rolling-upgrade[]
-You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before proceeding with other operations, such as decommissioning or retrying the rolling upgrade:
+You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before retrying the rolling upgrade:
 endif::[]
 ifdef::rolling-restart[]
-You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before proceeding with other operations, such as decommissioning or retrying the rolling restart:
+You can also evaluate xref:manage:monitoring.adoc[metrics] to determine cluster health. If the cluster has any issues, take the broker out of maintenance mode by running the following command before retrying the rolling restart:
 endif::[]
 
 ```bash


### PR DESCRIPTION
Backports [DOC-2237](https://redpandadata.atlassian.net/browse/DOC-2237) to `v/24.2`. The Maintenance Mode page incorrectly stated that a broker cannot be decommissioned while in maintenance mode; from 24.1.15 / 24.2.1 onward, decommission gracefully drains partition leadership on its own.

Companion PR on `main`: https://github.com/redpanda-data/docs/pull/1735

## Preview pages

- [Maintenance Mode](https://deploy-preview-1740--redpanda-docs-preview.netlify.app/streaming/24.2/manage/node-management/) (updated)
- [Decommission Brokers](https://deploy-preview-1740--redpanda-docs-preview.netlify.app/streaming/24.2/manage/cluster-maintenance/decommission-brokers/) (updated)
- [Decommission Brokers in Kubernetes](https://deploy-preview-1740--redpanda-docs-preview.netlify.app/streaming/24.2/manage/kubernetes/k-decommission-brokers/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2237]: https://redpandadata.atlassian.net/browse/DOC-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ