### PR TITLE
chore(netlify): force clean node_modules on every preview build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,27 @@
+# Netlify configuration for the redpanda-docs-preview site (PR previews of
+# redpanda-data/docs). The production site docs.redpanda.com is built from
+# redpanda-data/docs-site, not from this repo, so this file does not affect
+# production.
+#
+# Why this file exists
+# --------------------
+# Netlify preserves node_modules across builds via its persistent cache.
+# A poisoned cache snapshot taken in early June 2026 causes npm 10.9.3
+# to fail with ERR_INVALID_ARG_TYPE ("The 'from' argument must be of
+# type string. Received undefined") when reconciling the cached
+# node_modules against the current package-lock.json on certain
+# v/* base branches (notably v/25.1 and v/25.2). The error fires within
+# ~5 seconds of npm install starting, before Antora even loads.
+#
+# Manually clicking "Retry without cache" in the Netlify UI works for a
+# single deploy, but the next push to the same PR restores the same
+# poisoned snapshot and the build fails again. The cache is keyed at
+# the project / deploy-context level and survives across builds even
+# when individual deploys clear it.
+#
+# Forcing a clean node_modules every build (rm + fresh npm install)
+# bypasses the cached state entirely. This costs ~30-60s per build
+# but eliminates the cache poisoning problem for every PR.
+
+[build]
+  command = "rm -rf node_modules && npm install --prefer-online --no-audit --no-fund && npm run build"


### PR DESCRIPTION
## Summary

Adds a `netlify.toml` to the root of the docs repo that forces a clean `node_modules` install on every preview build. Closes the cache-poisoning class of failures that has been blocking PRs against `v/25.1` and `v/25.2`.

## Problem

Netlify's persistent build cache keeps a poisoned `node_modules` snapshot from early June 2026. With `npm 10.9.3` (the version Node 22.20.0 ships with), reconciling that cached state against the current `package-lock.json` fails with:

```
npm error code ERR_INVALID_ARG_TYPE
npm error The "from" argument must be of type string. Received undefined
```

The build crashes within ~5 seconds of `npm install`, before Antora loads. Symptoms observed across this session:

- **PR 1739** (v/24.3, DOC-2237 backport): npm install crash → manual cache clear via "Retry without cache" → next push restored the same snapshot → crash returned.
- **PR 1737, 1738** (v/25.2, v/25.1): same fingerprint, multiple cycles of Retry-without-cache required to get even one green build per push.

Clean `npm install` always works (verified by cloning fresh and running locally). The problem is exclusively the cached state Netlify restores.

## Fix

Override the build command in `netlify.toml`:

```toml
[build]
  command = "rm -rf node_modules && npm install --prefer-online --no-audit --no-fund && npm run build"
```

- `rm -rf node_modules` discards Netlify's restored cache.
- `npm install --prefer-online` forces npm to bypass its own metadata cache.
- `npm run build` then runs the existing Antora playbook unchanged.

Cost: ~30-60 seconds per build for the install (was effectively free when cache wasn't poisoned). Benefit: no more per-push manual cache clears.

## Scope

- Affects only the `redpanda-docs-preview` Netlify site (this repo's PR previews).
- The production `docs.redpanda.com` site is built from `redpanda-data/docs-site`, not from this repo, and is **not affected** by this change.
- Adding `netlify.toml` means PRs against `main` pick up the fix automatically once this lands. PRs against version branches won't get the fix until either (a) this commit is backported to those branches, or (b) each PR explicitly includes the file.

## Not included

- A post-build grep that fails the build on `ERROR (asciidoctor)` lines (mentioned earlier in DOC-2237 discussion). That's a separate consideration — there are currently a number of pre-existing cross-component errors from cloud-docs/main and rp-connect-docs/main that would need cleanup before strict-error mode can land. Worth doing as a follow-up after those are resolved.

## Verification

Once merged, the next preview build on any PR against `main` should:
1. Skip the cache restore (or restore it and immediately delete it).
2. Do a fresh `npm install`.
3. Build cleanly without `ERR_INVALID_ARG_TYPE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)