### PR TITLE
Update setup scripts domain to pull Redpanda packages from the new Artifact Registry

### DIFF
--- a/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-tune-workers.adoc
+++ b/modules/deploy/pages/deployment-option/self-hosted/kubernetes/k-tune-workers.adoc
@@ -23,7 +23,7 @@ Fedora/RedHat::
 [,bash]
 ----
 # Run the setup script to download and install the repo
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | sudo -E bash && \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.rpm.sh' | sudo -E bash && \
 # Use yum to install redpanda
 sudo yum install redpanda -y
 ----
@@ -35,7 +35,7 @@ Debian/Ubuntu::
 [,bash]
 ----
 # Run the setup script to download and install the repo
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | sudo -E bash && \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.deb.sh' | sudo -E bash && \
 # Use apt to install redpanda
 sudo apt install redpanda -y
 ----

--- a/modules/deploy/partials/linux/install-console.adoc
+++ b/modules/deploy/partials/linux/install-console.adoc
@@ -11,7 +11,7 @@ Fedora/RedHat::
 --
 [,bash]
 ----
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.rpm.sh' | \
 sudo -E bash && sudo yum install redpanda-console -y
 ----
 
@@ -21,7 +21,7 @@ Debian/Ubuntu::
 --
 [,bash]
 ----
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.deb.sh' | \
 sudo -E bash && sudo apt-get install redpanda-console -y
 ----
 

--- a/modules/deploy/partials/linux/install-fips.adoc
+++ b/modules/deploy/partials/linux/install-fips.adoc
@@ -27,7 +27,7 @@ To install Redpanda for FIPS compliance, run:
 
 [,bash]
 ----
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.rpm.sh' | \
 sudo -E bash && sudo yum install redpanda -y
 ----
 

--- a/modules/deploy/partials/linux/install-redpanda.adoc
+++ b/modules/deploy/partials/linux/install-redpanda.adoc
@@ -27,7 +27,7 @@ Fedora/RedHat::
 --
 [,bash]
 ----
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' | \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.rpm.sh' | \
 sudo -E bash && sudo yum install redpanda -y
 ----
 
@@ -70,7 +70,7 @@ Debian/Ubuntu::
 --
 [,bash]
 ----
-curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | \
+curl -1sLf 'https://linux.pkg.redpanda.com/setup-redpanda.deb.sh' | \
 sudo -E bash && sudo apt install redpanda -y
 ----
 

--- a/modules/get-started/pages/install-beta.adoc
+++ b/modules/get-started/pages/install-beta.adoc
@@ -116,7 +116,7 @@ Fedora/RedHat/Amazon Linux::
 +
 ```bash
 curl -1sLf \
-  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh'
+  'https://linux.pkg.redpanda.com/setup-redpanda-unstable.rpm.sh'
 ```
 +
 . Install Redpanda:
@@ -131,7 +131,7 @@ Debian/Ubuntu::
 +
 ```bash
 curl -1sLf \
-  'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh'
+  'https://linux.pkg.redpanda.com/setup-redpanda-unstable.deb.sh'
 ```
 +
 . Get updated package information for your machine:


### PR DESCRIPTION
## Description
Update the domain used to download Redpanda setup scripts in the install documentation. The scripts configure the system package manager (APT/YUM) to pull Redpanda packages from the new Artifact Registry.

Resolves https://redpandadata.atlassian.net/browse/DEVPROD-4222
Review deadline: 22.06.2026

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
