### PR TITLE
architecture: Don't mention SMP

### DIFF
--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -71,7 +71,7 @@ Examples of platform and kernel features that Redpanda uses to optimize its perf
 [[tpc]]
 == Thread-per-core model
 
-Redpanda implements a thread-per-core programming model through its use of the https://seastar.io/[Seastar^] library. This allows Redpanda to pin each of its application threads to a CPU core to avoid context switching and blocking. It combines this with structured message passing (SMP) to asynchronously communicate between the pinned threads. With this, Redpanda avoids the overhead of context switching and expensive locking operations to improve processing performance and efficiency.
+Redpanda implements a thread-per-core programming model through its use of the https://seastar.io/[Seastar^] library. This allows Redpanda to pin each of its application threads to a CPU core to avoid context switching and blocking. It combines this with message passing to asynchronously communicate between the pinned threads. With this, Redpanda avoids the overhead of context switching and expensive locking operations to improve processing performance and efficiency.
 
 From a sizing perspective, Redpanda's ability to efficiently use all available hardware enables it to scale up to get the most out of your infrastructure, before you're forced to scale out to meet the demands of your workload. Redpanda delivers better performance with a smaller footprint, resulting in reduced operational costs and complexity.
 


### PR DESCRIPTION
This confuses SMP. SMP in the context of seastar always refers to symmetric multiprocessing / shared-memory multiprocessing (and the respective --smp seastar flag).

## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)
