### PR TITLE
upgrade: document broker restarts during operator upgrades

### DIFF
--- a/modules/upgrade/pages/k-upgrade-operator.adoc
+++ b/modules/upgrade/pages/k-upgrade-operator.adoc
@@ -9,6 +9,8 @@ For complete upgrade instructions, including how to upgrade both the Redpanda Op
 
 In some cases, you might need to upgrade only the Redpanda Operator without upgrading your Redpanda cluster. For example, you might need to apply a patch release that fixes an operator bug.
 
+NOTE: An operator-only upgrade still restarts your broker Pods, even though the Redpanda version does not change. The Redpanda Operator injects its own container images (the configurator init container and the sidecar) into each broker Pod, and these image references track the operator version. When you upgrade the operator, the broker Pod template changes and the brokers roll one at a time. For why this happens and how to plan or stage it, see <<broker-restarts,Broker restarts during operator upgrades>>.
+
 To upgrade only the operator:
 
 . https://github.com/redpanda-data/redpanda-operator/releases[Review the Redpanda Operator release notes^] and xref:upgrade:k-compatibility.adoc[the Kubernetes compatibility matrix].
@@ -50,4 +52,53 @@ kubectl --namespace <namespace> rollout status --watch deployment/redpanda-contr
 ----
 deployment "redpanda-controller-operator" successfully rolled out
 ----
+====
+
+[[broker-restarts]]
+== Broker restarts during operator upgrades
+
+Upgrading the Redpanda Operator restarts your broker Pods, even when the Redpanda version itself does not change. Plan for a rolling restart of every broker on each managed cluster whenever you bump the operator version.
+
+=== Why brokers restart
+
+The Redpanda Operator renders the broker StatefulSet from its own templates. The configurator init container and the sidecar container that run inside each broker Pod use an image whose tag tracks the operator version by default. When you upgrade the operator, those image references change, which changes the broker Pod template. Kubernetes detects the change and the operator performs a rolling restart to bring the Pods in line with the new Pod template.
+
+This restart is safe: the operator places each broker into maintenance mode, restarts it, and waits for the cluster to report healthy before moving to the next broker.
+
+A roll also occurs when a new operator version changes any other part of the broker Pod template, such as adding a sidecar argument, container, or volume mount. These changes are independent of the image tag.
+
+=== Plan the upgrade
+
+Treat every operator version bump as a broker-restarting change:
+
+* Upgrade one cluster at a time, during a maintenance window.
+* Size each window from the number of brokers. Each broker is restarted sequentially and the operator waits for the cluster to become healthy between brokers, so allow a few minutes per broker plus a buffer.
+* Always test the upgrade in a non-production cluster first, and confirm the cluster returns to a healthy state.
+
+[[stage-broker-restart]]
+=== Stage the broker restart separately (advanced)
+
+If you want to apply an operator control-plane fix without immediately restarting your brokers, you can pin the configurator and sidecar image so that upgrading the operator does not change the broker Pod template. You then bump the pinned image in a later, separately scheduled change, which is when the brokers restart.
+
+Pin the image to your current operator version before you upgrade the control plane, by passing the operator's image flags through the chart's `additionalCmdFlags` value:
+
+[source,bash]
+----
+helm upgrade redpanda-controller redpanda/operator \
+  --namespace <namespace> \
+  --version <new-operator-version> \
+  --set crds.enabled=true \
+  --set "additionalCmdFlags={--configurator-base-image=docker.redpanda.com/redpandadata/redpanda-operator,--configurator-tag=<current-operator-version>}"
+----
+
+Replace `<current-operator-version>` with the operator version your brokers are currently running. The operator control plane upgrades to `<new-operator-version>` and its fixes take effect, but the broker Pod template keeps the pinned image, so the brokers do not restart. To restart the brokers on the new image later, repeat the upgrade with `--configurator-tag` set to `<new-operator-version>` (or remove the override so the tag tracks the operator version again).
+
+[WARNING]
+====
+This staging technique has important limitations:
+
+* It only avoids the restart for releases whose *only* broker Pod template change is the image tag. If the new operator version also changes the broker Pod template in another way, such as adding a sidecar argument or container, the brokers restart regardless of the pinned image.
+* While the image is pinned, the operator control plane and the broker sidecar or configurator run different versions. Keep the gap small and reconcile the pinned image with the operator version promptly. Do not run a mismatched control plane and sidecar long term. Review the https://github.com/redpanda-data/redpanda-operator/releases[release notes^] for each version before staging.
+
+Verify the behavior in a non-production cluster before relying on it in production.
 ====

--- a/modules/upgrade/pages/k-upgrade-operator.adoc
+++ b/modules/upgrade/pages/k-upgrade-operator.adoc
@@ -9,7 +9,10 @@ For complete upgrade instructions, including how to upgrade both the Redpanda Op
 
 In some cases, you might need to upgrade only the Redpanda Operator without upgrading your Redpanda cluster. For example, you might need to apply a patch release that fixes an operator bug.
 
-NOTE: An operator-only upgrade still restarts your broker Pods, even though the Redpanda version does not change. The Redpanda Operator injects its own container images (the configurator init container and the sidecar) into each broker Pod, and these image references track the operator version. When you upgrade the operator, the broker Pod template changes and the brokers roll one at a time. For why this happens and how to plan or stage it, see <<broker-restarts,Broker restarts during operator upgrades>>.
+[NOTE]
+====
+An operator-only upgrade still restarts your broker Pods, even though the Redpanda version does not change. The Redpanda Operator injects its own container images (the configurator init container and the sidecar) into each broker Pod, and these image references track the operator version. When you upgrade the operator, the broker Pod template changes and the brokers roll one at a time. For why this happens and how to plan or stage it, see <<broker-restarts,Broker restarts during operator upgrades>>.
+====
 
 To upgrade only the operator:
 
@@ -57,7 +60,7 @@ deployment "redpanda-controller-operator" successfully rolled out
 [[broker-restarts]]
 == Broker restarts during operator upgrades
 
-Upgrading the Redpanda Operator restarts your broker Pods, even when the Redpanda version itself does not change. Plan for a rolling restart of every broker on each managed cluster whenever you bump the operator version.
+Upgrading the Redpanda Operator restarts your broker Pods, even when the Redpanda version itself does not change. Plan for a rolling restart of every broker on each managed cluster whenever you upgrade the operator version.
 
 === Why brokers restart
 
@@ -69,16 +72,16 @@ A roll also occurs when a new operator version changes any other part of the bro
 
 === Plan the upgrade
 
-Treat every operator version bump as a broker-restarting change:
+Treat every operator upgrade as a broker-restarting change:
 
 * Upgrade one cluster at a time, during a maintenance window.
-* Size each window from the number of brokers. Each broker is restarted sequentially and the operator waits for the cluster to become healthy between brokers, so allow a few minutes per broker plus a buffer.
+* Size each window from the number of brokers. The operator restarts each broker sequentially and waits for the cluster to become healthy between brokers, so allow a few minutes per broker plus a buffer.
 * Always test the upgrade in a non-production cluster first, and confirm the cluster returns to a healthy state.
 
 [[stage-broker-restart]]
 === Stage the broker restart separately (advanced)
 
-If you want to apply an operator control-plane fix without immediately restarting your brokers, you can pin the configurator and sidecar image so that upgrading the operator does not change the broker Pod template. You then bump the pinned image in a later, separately scheduled change, which is when the brokers restart.
+To apply an operator control-plane fix without immediately restarting your brokers, you can pin the configurator and sidecar image so that upgrading the operator does not change the broker Pod template. You then update the pinned image in a later, separately scheduled change, which is when the brokers restart.
 
 Pin the image to your current operator version before you upgrade the control plane, by passing the operator's image flags through the chart's `additionalCmdFlags` value:
 


### PR DESCRIPTION
## What

Adds a **Broker restarts during operator upgrades** section to [Upgrade the Redpanda Operator](https://docs.redpanda.com/streaming/current/upgrade/k-upgrade-operator/), plus a `NOTE` in the existing *Operator-only upgrades* section.

## Why

Operator-only upgrades restart every broker Pod even when the Redpanda version doesn't change — the operator re-renders the broker StatefulSet, and the configurator init + sidecar image references it injects into the broker Pod template track the operator version. Users reasonably expect an "operator-only" upgrade to be control-plane-only, so this catches them off guard during prod planning.

This came out of a support thread (USE2 prod, operator bump to v25.3.7 rolled every broker with no Redpanda version change) and was confirmed against the operator source + an end-to-end validation on Kubernetes 1.36 (upgrade from v26.1.4, both v1 `Cluster` and v2 `Redpanda` operators).

## What the section covers

- **Expectation:** plan for a rolling restart of every broker on each operator version bump.
- **Why:** the configurator/sidecar image tag tracks the operator version (`--configurator-tag` defaults to the operator version), so an upgrade changes the broker Pod template → rolling restart. Also notes restarts happen when a release changes other parts of the Pod template (args/containers/mounts).
- **It's safe:** maintenance mode + wait-for-healthy between brokers.
- **Planning:** one cluster at a time, window sized by broker count, test in non-prod first.
- **Advanced staging option:** pin the configurator/sidecar image via the chart's `additionalCmdFlags` so the control-plane upgrade lands *without* rolling brokers, then bump the pinned image in a separate window.

## For reviewers — please sanity-check the advanced section

The "Stage the broker restart separately" subsection documents pinning `--configurator-base-image`/`--configurator-tag`. Two things to confirm before merge:

1. **Support stance.** In the originating thread, the answer to "is there a way to upgrade without rolling brokers" was *"not currently … no supported mechanism."* The pin is real and works (validated), but if the operator team considers it unsupported, we may want to soften/remove the advanced subsection or label it explicitly as unsupported.
2. **Accuracy of caveats.** I've scoped it carefully: the pin only avoids the roll when a release's *sole* broker-Pod-template change is the image tag (true for many patch releases, including the v25.3.7 case), and it temporarily runs a control-plane/sidecar version mismatch (warned against running long-term). Please confirm these match the operator team's guidance on control-plane↔sidecar version skew.

Happy to adjust framing (e.g., keep only the "expected + plan" guidance and drop the staging technique) based on the operator team's call.

## Preview pages

- [Upgrade the Redpanda Operator](https://deploy-preview-1758--redpanda-docs-preview.netlify.app/streaming/current/upgrade/k-upgrade-operator/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
