### PR TITLE
docs: retire BYOA glossary term, add self-managed agent and MCP server terms

### DIFF
--- a/modules/terms/partials/byoa.adoc
+++ b/modules/terms/partials/byoa.adoc
@@ -1,4 +1,0 @@
-=== BYOA
-:term-name: BYOA
-:hover-text: Bring Your Own Agent (BYOA) is an agent you build and run yourself, in your own runtime and language. You register it with ADP for governance and observability. ADP tracks and attributes its telemetry and cost but does not host or proxy it.
-:category: Agentic Data Plane

--- a/modules/terms/partials/declarative-agent.adoc
+++ b/modules/terms/partials/declarative-agent.adoc
@@ -1,4 +1,4 @@
 === declarative agent
 :term-name: declarative agent
-:hover-text: An AI agent that runs in Redpanda's managed runtime, where you configure its behavior (LLM, system prompt, and attached tools) instead of writing agent code. Contrast with a BYOA agent, which you build and run in your own runtime.
+:hover-text: An AI agent that runs in Redpanda's managed runtime, where you configure its behavior (LLM, system prompt, and attached tools) instead of writing agent code. Contrast with a self-managed agent, which you build and run in your own runtime.
 :category: Agentic Data Plane

--- a/modules/terms/partials/self-managed-agent.adoc
+++ b/modules/terms/partials/self-managed-agent.adoc
@@ -1,0 +1,4 @@
+=== self-managed agent
+:term-name: self-managed agent
+:hover-text: An AI agent you build and run yourself, in your own runtime and framework, registered with Redpanda ADP as an identity. The AI Gateway becomes the agent's LLM and MCP endpoint, so ADP attributes spend, tokens, latency, and traces back to the agent. ADP does not host or run the agent. Contrast with a declarative agent, which runs in Redpanda's managed runtime.
+:category: Agentic Data Plane

--- a/modules/terms/partials/self-managed-mcp-server.adoc
+++ b/modules/terms/partials/self-managed-mcp-server.adoc
@@ -1,0 +1,4 @@
+=== self-managed MCP server
+:term-name: self-managed MCP server
+:hover-text: An MCP server you host and operate yourself, registered with Redpanda ADP so the AI Gateway can proxy tool calls to it. Contrast with a managed MCP server, which Redpanda hosts in-process for you.
+:category: Agentic Data Plane


### PR DESCRIPTION
## What

Updates the shared glossary to match adp-docs PR #102 (redpanda-data/adp-docs#102), which retired the BYOA / Bring Your Own Agent pages in favor of a self-managed agent guide.

- Remove the `BYOA` term (`modules/terms/partials/byoa.adoc`).
- Add `self-managed agent` term. The definition corrects a factual point from the old BYOA wording: ADP does not *host or run* the agent, but the AI Gateway *is* its LLM and MCP endpoint (the old term incorrectly said ADP "does not host or proxy it").
- Add `self-managed MCP server` term, paired with the existing managed MCP server concept.
- Update the `declarative agent` term to contrast against "a self-managed agent" instead of "a BYOA agent".

## Why

The BYOA concept and pages were removed in adp-docs#102. No `glossterm:BYOA[]` usages exist in any repo, so removing the term is safe.

## Notes

This should land before redpanda-data/adp-docs#TBD (the adp-docs side), since the adp-docs glossary page auto-aggregates these terms from the `shared` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)