### PR TITLE
[v/25.3] manage: document rpk OAUTHBEARER (OIDC) for Kafka/Admin/SR APIs

### DIFF
--- a/modules/manage/partials/authentication.adoc
+++ b/modules/manage/partials/authentication.adoc
@@ -405,7 +405,7 @@ Before enabling authorization in Redpanda, which can happen implicitly when you 
 
 IMPORTANT: Enabling authorization without a superuser can result in being locked out of the cluster, as you would not have the necessary permissions to manage the cluster's settings or users.
 
-A superuser can either be a SCRAM user or it can be provided by external authentication mechanisms, such as OIDC. However, `rpk` can only communicate with the Admin API using HTTP basic authentication, which requires a SCRAM user. This means that for administrative tasks executed through `rpk`, you must have a SCRAM user with superuser privileges.
+A superuser can either be a SCRAM user or it can be provided by external authentication mechanisms, such as OIDC. For administrative tasks executed through `rpk`, you can authenticate to the Admin API either with a SCRAM superuser (HTTP basic authentication) or, starting with `rpk` v26.1.7, with an OIDC access token (`-X sasl.mechanism=OAUTHBEARER`) whose principal has superuser privileges.
 
 . Specify the username of a superuser.
 +
@@ -1132,6 +1132,81 @@ rpk cluster config set oidc_keys_refresh_interval 3600
 ----
 endif::[]
 
+[[oidc-rpk]]
+===== Connect to Redpanda with OIDC using rpk
+
+Starting with `rpk` v26.1.7 (also available in v25.3.x and v25.2.x patches), `rpk` supports the `OAUTHBEARER` SASL mechanism for Kafka API authentication. After you enable OIDC on a Kafka listener, you can authenticate `rpk` to Kafka with an OIDC access token issued by your IdP instead of a SASL/SCRAM username and password.
+
+NOTE: Confirm your `rpk` version with `rpk version`. Earlier versions reject `-X sasl.mechanism=OAUTHBEARER` as an unknown mechanism.
+
+Before you connect, make sure that:
+
+* `OAUTHBEARER` is in xref:reference:properties/cluster-properties.adoc#sasl_mechanisms[`sasl_mechanisms`], or is set on the target listener through xref:reference:properties/cluster-properties.adoc#sasl_mechanisms_overrides[`sasl_mechanisms_overrides`].
+* You have an access token from your IdP whose claims satisfy `oidc_token_audience`, `oidc_discovery_url`, and `oidc_principal_mapping`. For the claims that Redpanda validates, see <<oidc-credentials-flow-and-access-token-validation, OIDC credentials flow and access token validation>>.
+* xref:manage:security/authorization/index.adoc#acls[ACLs] grant the principal extracted from the token the operations you intend to run.
+
+[[oidc-rpk-token]]
+Pass the token using xref:reference:rpk/rpk-x-options.adoc[`-X` options]. Set `sasl.mechanism=OAUTHBEARER` and supply the token through `pass`, either as a raw value or in `token:<TOKEN>` form:
+
+[,bash]
+----
+export OIDC_TOKEN="<access-token>"
+
+rpk topic list \
+  -X brokers=<broker-host>:<oidc-listener-port> \
+  -X tls.enabled=true \
+  -X tls.ca=<path-to-ca-cert> \
+  -X sasl.mechanism=OAUTHBEARER \
+  -X pass="token:$OIDC_TOKEN"
+----
+
+The same `-X sasl.mechanism` and `-X pass` options work for any `rpk` command that talks to the Kafka API (for example, `rpk topic create`, `rpk topic produce`, `rpk topic consume`, `rpk group list`, `rpk cluster info`, and `rpk security acl list`).
+
+Because `rpk` applies the same SASL configuration to its Admin API and Schema Registry clients, the same OIDC token also authenticates Admin API requests (for example, `rpk cluster health`) and Schema Registry requests when those listeners have OIDC enabled.
+
+To avoid repeating connection flags, store them in an xref:reference:rpk/rpk-profile/rpk-profile-create.adoc[`rpk profile`]:
+
+[,bash]
+----
+rpk profile create oidc \
+  --set kafka_api.brokers=<broker-host>:<oidc-listener-port> \
+  --set kafka_api.tls.ca_file=<path-to-ca-cert> \
+  --set kafka_api.sasl.mechanism=OAUTHBEARER \
+  --set kafka_api.sasl.password="token:$OIDC_TOKEN"
+
+rpk topic list
+----
+
+[[oidc-rpk-validate]]
+===== Validate OIDC authentication
+
+To confirm that OIDC authentication works end to end, run a read-only command against the OIDC listener and verify that it succeeds:
+
+[,bash]
+----
+rpk cluster info \
+  -X brokers=<broker-host>:<oidc-listener-port> \
+  -X tls.enabled=true \
+  -X tls.ca=<path-to-ca-cert> \
+  -X sasl.mechanism=OAUTHBEARER \
+  -X pass="token:$OIDC_TOKEN"
+----
+
+A successful response lists the cluster's brokers and topics, which confirms that Redpanda validated the token's signature and claims, mapped it to a principal, and authorized the request.
+
+If the command fails instead, use these checks:
+
+If `rpk` returns `OAUTHBEARER requires a token`, the password is empty or contains only the `token:` prefix with no value.
+
+If the broker rejects the token, verify that:
+
+* The `aud` claim matches `oidc_token_audience`
+* The `iss` claim matches the issuer at `oidc_discovery_url`
+* `exp` is in the future within `oidc_clock_skew_tolerance` 
+* The signature is valid against the JWK set published at the discovery URL
+
+See <<oidc-credentials-flow-and-access-token-validation, OIDC credentials flow and access token validation>> for the full list of validated claims.
+
 ifndef::env-kubernetes[]
 [[kerberos]]
 ==== GSSAPI (Kerberos)
@@ -1469,7 +1544,7 @@ To enable basic authentication for the Admin API:
 
 . <<create-superusers,create a SCRAM superuser>> so that you can use `rpk` to create ACLs.
 +
-`rpk` supports only basic authentication for the Admin API.
+`rpk` v26.1.7+ can authenticate to the Admin API with an OIDC access token (`-X sasl.mechanism=OAUTHBEARER`); earlier versions support only HTTP basic authentication, which requires a SCRAM user.
 
 . Enable authentication for the Admin API:
 +
@@ -1591,7 +1666,7 @@ You can configure the HTTP APIs to authenticate users with the OIDC bearer token
 
 See <<Enable OIDC>> to configure the required OIDC cluster configuration properties before enabling OIDC for the HTTP APIs. You can configure OIDC without enabling it for the Kafka API.
 
-NOTE: If you enable OIDC authentication for the Admin API, you must also <<create-superusers,create a SCRAM superuser>> so that you can use `rpk` to create ACLs. `rpk` supports only basic authentication for the Admin API. See <<Authentication for the HTTP APIs>>.
+NOTE: To run administrative `rpk` commands against the Admin API when OIDC is enabled, either use an OIDC access token whose principal is a superuser (`rpk` v26.1.7+ supports `-X sasl.mechanism=OAUTHBEARER` for the Admin API) or <<create-superusers,create a SCRAM superuser>>. See <<Authentication for the HTTP APIs>>.
 
 To enable OIDC for the HTTP API listeners as well as basic authentication, include OIDC in the `http_authentication` cluster property list:
 

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -238,13 +238,15 @@ The SASL mechanism to use for authentication.
 
 *Default*: ""
 
-*Acceptable values*: `SCRAM-SHA-256`, `SCRAM-SHA-512`, `PLAIN`
+*Acceptable values*: `SCRAM-SHA-256`, `SCRAM-SHA-512`, `PLAIN`, `OAUTHBEARER`
 
 NOTE: With Redpanda, the Admin API can be configured to require basic authentication with your Kafka API SASL credentials. This defaults to `SCRAM-SHA-256` if no mechanism is specified.
 
+For `OAUTHBEARER`, set `pass` to an OIDC access token (raw value, or prefixed with `token:`) instead of a SASL password, and leave `user` unset. `rpk` uses this mechanism and token for its Kafka API, Admin API, and Schema Registry clients, so the same token authenticates all three when the corresponding listeners have OIDC enabled. Support for `OAUTHBEARER` was added in rpk v26.1.7 (also backported to v25.3.x and v25.2.x). For end-to-end steps, see xref:manage:security/authentication.adoc#oidc-rpk[Connect to Redpanda with OIDC using rpk].
+
 *Example*: `sasl.mechanism=SCRAM-SHA-256`
 
-*Usage*: 
+*Usage*:
 ```
 rpk topic list -X sasl.mechanism=<mechanism>
 ```
@@ -253,7 +255,7 @@ rpk topic list -X sasl.mechanism=<mechanism>
 
 === user
 
-The SASL username to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
+The SASL username to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication. The `OAUTHBEARER` mechanism does not use `user`; leave it unset and pass the token through <<pass,`pass`>>.
 
 *Type*: string
 
@@ -270,7 +272,7 @@ rpk topic list -X user=<username>
 
 === pass
 
-The SASL password to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication.
+The SASL password to use for authentication. It's also used for the Admin API if you have configured it to require basic authentication. For the `OAUTHBEARER` mechanism, set `pass` to an OIDC access token (a raw token, or one prefixed with `token:`) rather than a SASL password. See <<sasl-mechanism>>.
 
 *Type*: string
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build.environment]
+NODE_VERSION = "20"
+NODE_OPTIONS = "--max-old-space-size=6144"


### PR DESCRIPTION
Backports the rpk **OAUTHBEARER** documentation to **v/25.3**. rpk OAUTHBEARER (redpanda-data/redpanda#30169) was backported to the v25.3.x release line, so it should be documented here.

A literal cherry-pick of #1762 wasn't possible — the foundational OAUTHBEARER content #1762 refines doesn't exist on this branch (authentication.adoc is ~490 lines behind main). This PR ports the self-contained OAUTHBEARER feature docs instead (the [scope chosen with the author]):

- **rpk `-X` reference** (`rpk-x-options.adoc`): `OAUTHBEARER` added to `sasl.mechanism` acceptable values + note (token via `pass`, leave `user` unset, applies to Kafka/Admin/SR clients), and `user`/`pass` cross-notes.
- **authentication partial**: adds the `[[oidc-rpk]]` **"Connect to Redpanda with OIDC using rpk"** section (with a **Validate OIDC authentication** step) to the existing OAUTHBEARER (OIDC) section; corrects **three** stale "rpk only supports basic auth for the Admin API" notes. The GBAC xref from main is omitted (`gbac.adoc` doesn't exist on this branch).
- **`netlify.toml`**: pins `NODE_VERSION = "20"` (matching `.github/workflows/test-docs.yml`) so the new Netlify image doesn't default to node 22 / npm 10.9.3 and fail `npm install`.

Verified: delimited blocks balanced, both anchors present, all xref targets resolve on this branch (`#acls`, `sasl_mechanisms_overrides`, `oidc-credentials-flow…`), no stale claims remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)