### PR TITLE
fix(v/25.2): align playbook with streaming component (finish #1703 rename)

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Redpanda Docs
-  start_page: 25.2@ROOT:get-started:intro-to-events.adoc
+  start_page: 25.2@streaming:get-started:intro-to-events.adoc
   url: http://localhost:5002
   robots: disallow
   keys:
@@ -59,7 +59,7 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/archive-attachments'
     data:
       archives:
-        - component: 'ROOT'
+        - component: 'streaming'
           output_archive: 'redpanda-quickstart.tar.gz'
           file_patterns:
             - '**/test-resources/**/docker-compose/**'
@@ -67,7 +67,7 @@ antora:
     data:
       replacements:
         - components:
-            - 'ROOT'
+            - 'streaming'
             - 'redpanda-labs'
           file_patterns:
             - '**/docker-compose.yaml'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -51,7 +51,7 @@ antora:
     data:
       sets:
         docker_labs:
-          component: redpanda-labs
+          component: labs
           family: page
           filter: docker-compose
           env_type: Docker
@@ -68,7 +68,7 @@ antora:
       replacements:
         - components:
             - 'streaming'
-            - 'redpanda-labs'
+            - 'labs'
           file_patterns:
             - '**/docker-compose.yaml'
             - '**/docker-compose.yml'


### PR DESCRIPTION
## What

Aligns `local-antora-playbook.yml` on `v/25.2` with the component names actually published today, finishing two half-applied per-branch renames.

| Setting | Before | After | Severity |
|---|---|---|---|
| `site.start_page` | `25.2@ROOT:get-started:intro-to-events.adoc` | `25.2@streaming:...` | **Fatal** (deploy fails) |
| `archive-attachments` source | `component: 'ROOT'` | `component: 'streaming'` | latent |
| `replace-attributes` components | `- 'ROOT'` | `- 'streaming'` | latent |
| `generate-index-data` docker_labs | `component: redpanda-labs` | `component: labs` | latent |
| `replace-attributes` components | `- 'redpanda-labs'` | `- 'labs'` | latent |

## Why

Two component renames were applied to `v/25.2`'s `antora.yml` / content sources over time but never reflected in the playbook:

1. **`ROOT → streaming`** (PR #1703, 2026-05-26): `antora.yml` became `name: streaming`, but the playbook still pointed at `ROOT`. `site.start_page` aimed at the now-nonexistent `ROOT` component, so Antora can't resolve the site start page and the **Netlify deploy preview fails**. This has broken **every v/25.2 PR deploy since 2026-05-26**; later PRs (#1737, #1752) merged anyway because the preview isn't a required check. It's currently blocking David Yu's backports #1765 and #1767, neither of which touches the playbook.

2. **`redpanda-labs → labs`**: the redpanda-labs repo publishes its component as `name: labs` (`docs/antora.yml`), and `main`'s playbook already uses `labs`. v/25.2 still referenced `redpanda-labs` in two labs-extension configs. Non-fatal — the configs just match no component, so the docker-labs index attribute and labs attachment replacements silently no-op on v/25.2 — but a real correctness gap.

The content-source repo URL (`github.com/redpanda-data/redpanda-labs`) is unchanged: that's the repo name, not the component name.

## Testing

- [ ] Netlify preview builds clean. Because v/25.2 has a backlog of merged-but-never-cleanly-built PRs, don't trust a green SUCCESS alone — grep the deploy log for `ERROR (asciidoctor)` to confirm no remaining build errors surface once the start page resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)