### PR TITLE
docs: add DESCRIBE_CONFIGS to migrator source topic ACLs

### DIFF
--- a/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
@@ -269,9 +269,9 @@ This grants:
 ====
 **Schema Registry ACLs are only for Schema Registry operations.** For complete data migration, you must also use Kafka ACLs:
 
-* **Topics:** READ, DESCRIBE_CONFIGS (source); WRITE/CREATE/DESCRIBE/ALTER/DESCRIBE_CONFIGS (target)
-* **Consumer groups:** READ (source), CREATE/READ (target)
-* **Cluster:** DESCRIBE (both), CREATE (target)
+* **Topics:** `READ`, `DESCRIBE_CONFIGS` (source); `WRITE`/`CREATE`/`DESCRIBE`/`ALTER`/`DESCRIBE_CONFIGS` (target)
+* **Consumer groups:** `READ` (source), `CREATE`/`READ` (target)
+* **Cluster:** `DESCRIBE` (both), `CREATE` (target)
 
 `READ` on a topic implicitly grants `DESCRIBE`, but not `DESCRIBE_CONFIGS`. Redpanda Migrator reads each source topic's configuration (`DESCRIBE_CONFIGS`) to recreate it on the target, so a consumer-only ACL on the source is not sufficient: without `DESCRIBE_CONFIGS` on the source topics, topic creation fails with `TOPIC_AUTHORIZATION_FAILED`.
 

--- a/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-authorization.adoc
@@ -269,9 +269,11 @@ This grants:
 ====
 **Schema Registry ACLs are only for Schema Registry operations.** For complete data migration, you must also use Kafka ACLs:
 
-* **Topics:** READ (source), WRITE/CREATE/DESCRIBE/ALTER (target)
+* **Topics:** READ, DESCRIBE_CONFIGS (source); WRITE/CREATE/DESCRIBE/ALTER/DESCRIBE_CONFIGS (target)
 * **Consumer groups:** READ (source), CREATE/READ (target)
 * **Cluster:** DESCRIBE (both), CREATE (target)
+
+`READ` on a topic implicitly grants `DESCRIBE`, but not `DESCRIBE_CONFIGS`. Redpanda Migrator reads each source topic's configuration (`DESCRIBE_CONFIGS`) to recreate it on the target, so a consumer-only ACL on the source is not sufficient: without `DESCRIBE_CONFIGS` on the source topics, topic creation fails with `TOPIC_AUTHORIZATION_FAILED`.
 
 See xref:manage:security/authorization/acl.adoc[Configure Access Control Lists] for Kafka ACL configuration.
 ====


### PR DESCRIPTION
## What

Corrects the Kafka ACL note on the Schema Registry Authorization page (currently the only place migrator Kafka ACLs are documented). The note listed only `READ` on source topics; this adds `DESCRIBE_CONFIGS` (source and target) and an explanatory note.

## Why

Redpanda Migrator issues `DescribeConfigs` against the source to read each topic's configuration for replication. `READ` grants `DESCRIBE` but not `DESCRIBE_CONFIGS`, so a consumer-only ACL on the source fails topic creation with `TOPIC_AUTHORIZATION_FAILED`.

Companion to redpanda-data/rp-connect-docs#451, which documents the full source/destination migrator ACL set in the Connect docs.

## Preview pages

- [Schema Registry Authorization](https://deploy-preview-1770--redpanda-docs-preview.netlify.app/streaming/current/manage/schema-reg/schema-reg-authorization/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
