### PR TITLE
docs(glossary): drop trademarked "ADP" acronym from Agentic Data Plane term

### DIFF
--- a/modules/terms/partials/adp.adoc
+++ b/modules/terms/partials/adp.adoc
@@ -1,5 +1,5 @@
-=== Agentic Data Plane (ADP)
-:term-name: Agentic Data Plane (ADP)
+=== Agentic Data Plane
+:term-name: Agentic Data Plane
 :hover-text: Infrastructure layer that enables AI agents to discover, connect to, and interact with data sources and tools through standardized protocols.
 :category: Agentic Data Plane
 


### PR DESCRIPTION
## What

The **ADP** acronym is trademarked by another company, so it must not appear in our docs. This renames the glossary term in `modules/terms/partials/adp.adoc`:

- `:term-name: Agentic Data Plane (ADP)` → `:term-name: Agentic Data Plane` (and the `===` heading)

The `hover-text`, body, and `category` already use "Agentic Data Plane" without the acronym, so no other change is needed.

## Coordination

This pairs with adp-docs PR redpanda-data/adp-docs#116, which replaces the prose acronym throughout the Agentic Data Plane docs.

The **only** references to this glossterm in any repo are 2 macros in adp-docs (`cli/index.adoc`, `cli/gitops.adoc`), intentionally left as `glossterm:Agentic Data Plane (ADP)[]` in #116. **Merge order:** land this PR first, then update those 2 macros to `glossterm:Agentic Data Plane[]` and merge #116, so there is no unresolved-glossterm window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
