### PR TITLE
DOC-2254: Add Confluent Schema Registry schema migration via Shadowing

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -220,6 +220,7 @@
 *** xref:manage:disaster-recovery/shadowing/index.adoc[Shadowing]
 **** xref:manage:disaster-recovery/shadowing/overview.adoc[Overview]
 **** xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing]
+**** xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent]
 **** xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing]
 **** xref:manage:disaster-recovery/shadowing/failover.adoc[Failover]
 **** xref:manage:disaster-recovery/shadowing/failover-runbook.adoc[Failover Runbook]

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -20,7 +20,7 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 endif::[]
 
-Replicate glossterm:schema[,schemas] from a Confluent Schema Registry into a Redpanda glossterm:shadow cluster[] automatically and continuously. Schema replication through a glossterm:shadow link[] keeps subjects, versions, and compatibility settings synchronized with the source registry, so your applications keep working after a cutover without a separate schema migration step.
+Redpanda allows you to replicate glossterm:schema[,schemas] from a Confluent Schema Registry into a Redpanda glossterm:shadow cluster[] automatically and continuously. Schema replication through a glossterm:shadow link[] keeps subjects, versions, and compatibility settings synchronized with the source registry, so your applications keep working after a cutover without a separate schema migration step.
 
 After reading this page, you will be able to:
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -1,0 +1,272 @@
+= Migrate Schemas from Confluent Schema Registry
+:description: Replicate subjects, versions, and compatibility settings from a Confluent Schema Registry into a Redpanda shadow cluster.
+:env-linux: true
+:page-topic-type: how-to
+:page-categories: Management, High Availability, Disaster Recovery
+:learning-objective-1: Configure a shadow link that continuously replicates schemas from a Confluent Schema Registry
+:learning-objective-2: Filter replication by context or subject and map source contexts to destination contexts
+:learning-objective-3: Monitor schema replication status and resolve validation errors
+// tag::single-source[]
+
+// DRAFT-VERIFY (DOC-2254): This page documents an unreleased v26.2 feature (ENG-1171).
+// Engineering PRs redpanda#30999 (HTTP source reader) and redpanda#30984 (failover) were
+// still open when this draft was written (2026-07-02). Re-verify every DRAFT-VERIFY item
+// against merged code and a running 26.2 build before publishing. SME: @pgellert.
+
+ifndef::env-cloud[]
+[NOTE]
+====
+include::shared:partial$enterprise-license.adoc[]
+====
+endif::[]
+
+Replicate glossterm:schema[,schemas] from a Confluent Schema Registry into a Redpanda glossterm:shadow cluster[] automatically and continuously. Schema replication through a glossterm:shadow link[] keeps subjects, versions, and compatibility settings synchronized with the source registry, so your applications keep working after a cutover without a separate schema migration step.
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
+
+== How schema replication works
+
+When you configure a shadow link with the `shadow_schema_registry_api` option, the shadow cluster polls the source Schema Registry over HTTP and imports changes into its own glossterm:Schema Registry[]. Two sync cycles keep the registries in step:
+
+* *Tail syncs* run frequently (default: every 10 seconds) to pick up incremental changes.
+* *Full syncs* scan all selected subjects (default: every 5 minutes) to catch anything a tail sync missed.
+
+Replicated schemas keep their original glossterm:subject[] names and version IDs, so producers and consumers that reference schemas by ID continue to work after failover. Schemas that reference other schemas import in dependency order.
+
+Before importing a schema, Redpanda validates it against the Redpanda Schema Registry implementation. If a schema uses features that Redpanda does not support, the sync either reports an error and skips the schema, or removes the unsupported fields and imports the rest, depending on the <<choose-a-validation-policy,validation policy>> you choose.
+
+While the link is active, the destination contexts that the link replicates into are read-only: the shadow cluster rejects client writes to those contexts so that replicated schemas remain identical to the source. Contexts outside the link's filter remain writable.
+
+[NOTE]
+====
+This API-based mode is an alternative to the byte-for-byte `_schemas` topic replication described in xref:manage:disaster-recovery/shadowing/setup.adoc#schema-registry-synchronization[Configure Shadowing]. A shadow link uses one Schema Registry sync mode or the other, not both. Use the API-based mode when the source is a Confluent Schema Registry, or when you need to replicate only selected contexts or subjects.
+
+Schema replication does not add any cluster configuration properties. All settings live in the shadow link configuration.
+====
+
+== Use cases
+
+* *Migrate from Confluent to Redpanda*: Replicate schemas continuously while xref:manage:disaster-recovery/shadowing/setup.adoc[Shadowing] replicates your topic data, then cut applications over to Redpanda once both are in sync. No separate schema migration tooling is required.
+* *Phased migration*: Use context and subject filters to migrate one team, application, or environment at a time.
+* *Registry reorganization*: Map source contexts to different destination contexts to restructure your Schema Registry as part of the migration.
+
+== Prerequisites
+
+* A shadow cluster running Redpanda version 26.2 or later. The schema replication feature activates after all brokers complete the upgrade.
+* Network connectivity from the shadow cluster to the source Schema Registry HTTP endpoint.
+* Credentials for the source registry with permission to read subjects, versions, and configuration. For Confluent Cloud, use a Schema Registry API key and secret.
+* A shadow link to the source cluster, or a plan to create one. See xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing].
+
+// DRAFT-VERIFY (DOC-2254): Confirm with @pgellert whether the destination Schema Registry
+// (_schemas topic) must be empty before enabling API-mode sync, or whether the destination
+// bootstrap in redpanda#30999 relaxes this. Topic mode requires it; API mode is unconfirmed.
+
+== Limitations
+
+* HTTP basic authentication is the only supported authentication method for the source registry.
+* A shadow link replicates Schema Registry data in one mode only: either `shadow_schema_registry_topic` or `shadow_schema_registry_api`.
+* Replication is one way, from the source registry to the shadow cluster. Destination contexts owned by the link are read-only until failover.
+* Schemas that use Confluent features not supported by the Redpanda Schema Registry are not replicated as-is. Choose a <<choose-a-validation-policy,validation policy>> to control whether these schemas are skipped or imported without the unsupported fields.
+
+// DRAFT-VERIFY (DOC-2254): Get the exact list of unsupported Confluent schema features
+// (rule sets? metadata tags?) from @pgellert and document them here.
+// DRAFT-VERIFY (DOC-2254): ENG-1171 mentions wildcard support in filters, but the rpk
+// source shows plain string lists for contexts/subjects. Confirm whether wildcards or
+// patterns are accepted before documenting either behavior.
+
+== Configure schema replication
+
+Add the `shadow_schema_registry_api` option to the `schema_registry_sync_options` section of your shadow link configuration file.
+
+=== Generate a configuration template
+
+Generate a configuration file template that includes all available fields with comments:
+
+[,bash]
+----
+rpk shadow config generate --print-template -o shadow-config-template.yaml
+----
+
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-config-generate.adoc[`rpk shadow config generate`].
+
+=== Connect to the source registry
+
+Configure the connection to the source Schema Registry:
+
+[,yaml]
+----
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    source_url: https://psrc-xxxxx.us-east-1.aws.confluent.cloud  # Source Schema Registry endpoint
+    auth_options:
+      basic:
+        username: <sr-api-key>                # Confluent Schema Registry API key
+        password: <sr-api-secret>             # Confluent Schema Registry API secret
+    tls_settings:
+      enabled: true                           # Use TLS for the connection
+      tls_file_settings:
+        ca_path: /path/to/ca.crt              # Optional: CA certificate for custom trust
+    tail_interval: 10s                        # How often to poll for incremental changes
+    full_sync_interval: 5m                    # How often to run a full scan
+    max_source_requests_per_second: 30        # Rate limit for requests to the source registry
+----
+
+The intervals and rate limit are optional. If you omit them, Redpanda uses the defaults shown above.
+
+// DRAFT-VERIFY (DOC-2254): Defaults (10s / 5m / 30 rps) are from
+// src/v/cluster_link/model/types.h on dev. Re-check at code-complete.
+
+=== Select contexts and subjects
+
+By default, the link replicates the entire source registry. To replicate a subset, add a `source_filter` with the contexts or subjects to include:
+
+[,yaml]
+----
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    # ...connection settings...
+    source_filter:
+      contexts:
+      - "."                                   # The default context
+      - ".prod"                               # A named context
+      subjects:
+      - orders-value                          # A subject in the default context
+----
+
+Schema Registry contexts provide independent namespaces for subjects within one registry. The default context is named `.`. For more information, see xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts].
+
+=== Map source contexts to destination contexts
+
+Choose how replicated contexts are named on the shadow cluster:
+
+* `identity`: Keep the source context names (default behavior for migrations).
+* `exact`: Map each source context to a different destination context.
+
+[,yaml]
+----
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    # ...connection settings and filters...
+    destination:
+      identity: {}                            # Keep source context names
+----
+
+To rename contexts during replication:
+
+[,yaml]
+----
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    # ...connection settings and filters...
+    destination:
+      exact:
+        mappings:
+        - source: "."                         # Source context
+          destination: ".shadow"              # Destination context on the shadow cluster
+----
+
+[[choose-a-validation-policy]]
+=== Choose a validation policy
+
+The `unsupported_schema_feature_policy` setting controls what happens when a source schema uses features that the Redpanda Schema Registry does not support:
+
+[cols="1,3"]
+|===
+| Policy | Behavior
+
+| `FAIL` (default)
+| The schema is not replicated. The sync records an error, reports it in the link status, and continues with the remaining schemas.
+
+| `REMOVE`
+| The unsupported fields are removed and the rest of the schema is imported. The sync counts each modification in the link status.
+|===
+
+[,yaml]
+----
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    # ...connection settings, filters, and destination...
+    unsupported_schema_feature_policy: FAIL
+----
+
+=== Create the shadow link
+
+Create the shadow link with your completed configuration file:
+
+[,bash]
+----
+rpk shadow create <link-name> --config-file shadow-config.yaml
+----
+
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
+
+To change the schema replication settings on an existing link, see xref:reference:rpk/rpk-shadow/rpk-shadow-update.adoc[`rpk shadow update`].
+
+// DRAFT-VERIFY (DOC-2254): Confirm the exact `rpk shadow create` argument order
+// (link name vs --config-file only) against the 26.2 rpk build.
+
+== Verify the configuration
+
+Confirm that the link is configured for API-based schema replication:
+
+[,bash]
+----
+rpk shadow describe <link-name>
+----
+
+The output includes the shadowing mode, source URL, sync intervals, validation policy, and your context and subject filters. For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-describe.adoc[`rpk shadow describe`].
+
+== Monitor replication status
+
+Check schema replication progress and errors for a link:
+
+[,bash]
+----
+rpk shadow status <link-name>
+----
+
+The Schema Registry section of the output reports:
+
+[cols="1,3"]
+|===
+| Field | Description
+
+| Inventory
+| The number of selected subjects and subject versions on the source, compared with the number of subjects and versions on the destination. The registries are synchronized when the destination counts match the selected source counts. A destination that is behind the source indicates that replication is still in progress.
+
+| Current sync
+| The type of the sync in progress (`FULL` or `TAIL`) and the number of subject versions, compatibility configurations, and modes it has changed, including how many unsupported features were removed and how many errors occurred.
+
+| Last full sync
+| Start time, finish time, and change counts for the most recent completed full sync.
+
+| Totals since task start
+| Cumulative change and error counts since the schema replication task started.
+
+| Last error
+| The most recent replication error. With the `FAIL` validation policy, schemas that fail validation appear here.
+|===
+
+For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`]. For general link monitoring, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing].
+
+== Fail over
+
+When you fail over a shadow link, schema replication from the source registry stops and the write-blocked destination contexts become writable, so your applications can register new schemas on the promoted cluster.
+
+// DRAFT-VERIFY (DOC-2254): Failover behavior (single `paused` field pauses the sync task
+// and lifts per-context write blocks) is from open PR redpanda#30984. Confirm the final
+// mechanism and whether any manual steps apply to schema replication during failover.
+
+For the complete failover procedure, see xref:manage:disaster-recovery/shadowing/failover.adoc[Failover].
+
+== Next steps
+
+* xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing] to replicate topic data, consumer offsets, and ACLs alongside your schemas.
+* xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing]
+* xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts]
+
+// end::single-source[]

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -43,7 +43,10 @@ While the link is active, the destination contexts that the link replicates into
 
 [NOTE]
 ====
-This API-based mode is an alternative to the byte-for-byte `_schemas` topic replication described in xref:manage:disaster-recovery/shadowing/setup.adoc#schema-registry-synchronization[Configure Shadowing]. A shadow link uses one Schema Registry sync mode or the other, not both. Use the API-based mode when the source is a Confluent Schema Registry, or when you need to replicate only selected contexts or subjects.
+This API-based mode is an alternative to the byte-for-byte `_schemas` topic replication described in xref:manage:disaster-recovery/shadowing/setup.adoc#schema-registry-synchronization[Configure Shadowing]. A shadow link uses one Schema Registry sync mode or the other, not both:
+
+* Use *topic mode* (`shadow_schema_registry_topic`) when the source is another Redpanda cluster and you want an exact, complete replica of its Schema Registry. Topic mode shadows the `_schemas` topic byte for byte, so it does not filter, remap, or validate schemas.
+* Use *API mode* (`shadow_schema_registry_api`) when the source is a Confluent Schema Registry, or when you need to replicate only selected contexts or subjects, map source contexts to different destination contexts, or control how schemas that use unsupported features are handled with a validation policy.
 
 Schema replication does not add any cluster configuration properties. All settings live in the shadow link configuration.
 ====

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -82,9 +82,11 @@ Schema replication does not add any cluster configuration properties. All settin
 
 Add the `shadow_schema_registry_api` option to the `schema_registry_sync_options` section of your shadow link configuration file.
 
-The following sample configuration file creates a shadow link that shadows all source topics and replicates schemas from a Confluent Schema Registry. The sections that follow explain each schema replication setting.
+The following sample configuration file creates a shadow link that shadows all source topics and replicates schemas from a Confluent Schema Registry. The highlighted lines show the schema replication settings, which the sections that follow explain.
 
-[,yaml]
+// NOTE: keep the lines= range pointing at the schema_registry_sync_options block
+// if you edit this sample.
+[,yaml,lines=20-38]
 ----
 # Sample shadow link configuration with API-mode Schema Registry replication
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -20,7 +20,7 @@ include::shared:partial$enterprise-license.adoc[]
 ====
 endif::[]
 
-Redpanda allows you to replicate glossterm:schema[,schemas] from a Confluent Schema Registry into a Redpanda glossterm:shadow cluster[] automatically and continuously. Schema replication through a glossterm:shadow link[] keeps subjects, versions, and compatibility settings synchronized with the source registry, so your applications keep working after a cutover without a separate schema migration step.
+When you migrate to Redpanda from a deployment that uses a Confluent Schema Registry, your producers and consumers depend on the glossterm:schema[,schemas] stored in that registry. Shadowing removes this migration obstacle: a glossterm:shadow link[] continuously replicates schemas from the source Confluent Schema Registry into the glossterm:Schema Registry[] built into the Redpanda glossterm:shadow cluster[], preserving glossterm:subject[] names, versions, and compatibility settings. Because both registries stay synchronized until cutover, your applications keep working on Redpanda without a separate schema migration step. Use this approach when you migrate from Confluent to Redpanda, or when you maintain a Redpanda disaster recovery cluster for a system that keeps its schemas in a Confluent Schema Registry.
 
 After reading this page, you will be able to:
 
@@ -30,12 +30,12 @@ After reading this page, you will be able to:
 
 == How schema replication works
 
-When you configure a shadow link with the `shadow_schema_registry_api` option, the shadow cluster polls the source Schema Registry over HTTP and imports changes into its own glossterm:Schema Registry[]. Two sync cycles keep the registries in step:
+When you configure a shadow link with the `shadow_schema_registry_api` option, the shadow cluster polls the source Schema Registry over HTTP and imports changes into its own Schema Registry. Two sync cycles keep the registries in step:
 
 * *Tail syncs* run frequently (default: every 10 seconds) to pick up incremental changes.
 * *Full syncs* scan all selected subjects (default: every 5 minutes) to catch anything a tail sync missed.
 
-Replicated schemas keep their original glossterm:subject[] names and version IDs, so producers and consumers that reference schemas by ID continue to work after failover. Schemas that reference other schemas import in dependency order.
+Replicated schemas keep their original subject names and version IDs, so producers and consumers that reference schemas by ID continue to work after failover. Schemas that reference other schemas import in dependency order.
 
 Before importing a schema, Redpanda validates it against the Redpanda Schema Registry implementation. If a schema uses features that Redpanda does not support, the sync either reports an error and skips the schema, or removes the unsupported fields and imports the rest, depending on the <<choose-a-validation-policy,validation policy>> you choose.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -8,10 +8,6 @@
 :learning-objective-3: Monitor schema replication status and resolve validation errors
 // tag::single-source[]
 
-// DRAFT-VERIFY (DOC-2254): This page documents an unreleased v26.2 feature (ENG-1171).
-// SME review feedback from @pgellert applied 2026-07-16 (PR #1776). One DRAFT-VERIFY item
-// remains (sync defaults); re-check it against a running 26.2 build before publishing.
-
 ifndef::env-cloud[]
 [NOTE]
 ====
@@ -154,9 +150,6 @@ schema_registry_sync_options:
 The intervals and rate limit are optional. If you omit them, Redpanda uses the defaults shown above.
 
 To authenticate to the source registry with mTLS instead of HTTP basic authentication, omit `auth_options` and provide a client certificate and key in `tls_settings`.
-
-// DRAFT-VERIFY (DOC-2254): Defaults (10s / 5m / 30 rps) are from
-// src/v/cluster_link/model/types.h on dev. Re-check at code-complete.
 
 === Select contexts and subjects
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -9,9 +9,8 @@
 // tag::single-source[]
 
 // DRAFT-VERIFY (DOC-2254): This page documents an unreleased v26.2 feature (ENG-1171).
-// Engineering PRs redpanda#30999 (HTTP source reader) and redpanda#30984 (failover) were
-// still open when this draft was written (2026-07-02). Re-verify every DRAFT-VERIFY item
-// against merged code and a running 26.2 build before publishing. SME: @pgellert.
+// SME review feedback from @pgellert applied 2026-07-16 (PR #1776). One DRAFT-VERIFY item
+// remains (sync defaults); re-check it against a running 26.2 build before publishing.
 
 ifndef::env-cloud[]
 [NOTE]
@@ -48,7 +47,7 @@ This API-based mode is an alternative to the byte-for-byte `_schemas` topic repl
 * Use *topic mode* (`shadow_schema_registry_topic`) when the source is another Redpanda cluster and you want an exact, complete replica of its Schema Registry. Topic mode shadows the `_schemas` topic byte for byte, so it does not filter, remap, or validate schemas.
 * Use *API mode* (`shadow_schema_registry_api`) when the source is a Confluent Schema Registry, or when you need to replicate only selected contexts or subjects, map source contexts to different destination contexts, or control how schemas that use unsupported features are handled with a validation policy.
 
-Schema replication does not add any cluster configuration properties. All settings live in the shadow link configuration.
+Schema replication settings live in the shadow link configuration. Two cluster properties, `schema_registry_sync_memory_bytes` and `schema_registry_sync_parallelism`, tune how much memory and concurrency the shadow cluster uses while importing schemas. The defaults suit most deployments.
 ====
 
 == Use cases
@@ -63,33 +62,26 @@ Schema replication does not add any cluster configuration properties. All settin
 * Network connectivity from the shadow cluster to the source Schema Registry HTTP endpoint.
 * Credentials for the source registry with permission to read subjects, versions, and configuration. For Confluent Cloud, use a Schema Registry API key and secret.
 * A shadow link to the source cluster, or a plan to create one. See xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing].
-
-// DRAFT-VERIFY (DOC-2254): Confirm with @pgellert whether the destination Schema Registry
-// (_schemas topic) must be empty before enabling API-mode sync, or whether the destination
-// bootstrap in redpanda#30999 relaxes this. Topic mode requires it; API mode is unconfirmed.
+* The destination contexts that the link replicates into, as determined by your `source_filter` and `destination` mapping, must be empty on the shadow cluster. The rest of the shadow cluster's Schema Registry does not need to be empty: contexts outside the link's mappings are unaffected.
+* To replicate contexts other than the default context, the xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster property must be enabled on the shadow cluster (the default). See xref:manage:schema-reg/schema-reg-contexts.adoc#prerequisites[Schema Registry Contexts].
 
 == Limitations
 
-* HTTP basic authentication is the only supported authentication method for the source registry.
+* HTTP basic authentication and mTLS are the supported authentication methods for the source registry.
 * A shadow link replicates Schema Registry data in one mode only: either `shadow_schema_registry_topic` or `shadow_schema_registry_api`.
 * Replication is one way, from the source registry to the shadow cluster. Destination contexts owned by the link are read-only until failover.
 * Schemas that use Confluent features not supported by the Redpanda Schema Registry are not replicated as-is. Choose a <<choose-a-validation-policy,validation policy>> to control whether these schemas are skipped or imported without the unsupported fields.
-
-// DRAFT-VERIFY (DOC-2254): Get the exact list of unsupported Confluent schema features
-// (rule sets? metadata tags?) from @pgellert and document them here.
-// DRAFT-VERIFY (DOC-2254): ENG-1171 mentions wildcard support in filters, but the rpk
-// source shows plain string lists for contexts/subjects. Confirm whether wildcards or
-// patterns are accepted before documenting either behavior.
+* Topic data replication and schema replication are not coordinated with each other. Records serialized in the Confluent SerDes wire format can arrive on the shadow cluster before the schema IDs they contain have been replicated.
 
 == Configure schema replication
 
 Add the `shadow_schema_registry_api` option to the `schema_registry_sync_options` section of your shadow link configuration file.
 
-The following sample configuration file creates a shadow link that shadows all source topics and replicates schemas from a Confluent Schema Registry. The highlighted lines show the schema replication settings, which the sections that follow explain.
+The following sample configuration file creates a shadow link that replicates schemas from a Confluent Schema Registry. The highlighted lines show the schema replication settings, which the sections that follow explain.
 
 // NOTE: keep the lines= range pointing at the schema_registry_sync_options block
 // if you edit this sample.
-[,yaml,lines=20-38]
+[,yaml,lines=13-31]
 ----
 # Sample shadow link configuration with API-mode Schema Registry replication
 
@@ -102,13 +94,6 @@ client_options:
   # For the TLS and authentication settings that the shadow cluster uses to
   # connect to the source Kafka cluster, see the complete configuration file
   # reference in Configure Shadowing.
-
-topic_metadata_sync_options:
-  interval: 30s                              # How often to sync topic metadata
-  auto_create_shadow_topic_filters:
-  - pattern_type: LITERAL
-    filter_type: INCLUDE
-    name: '*'                                # Shadow all source topics
 
 schema_registry_sync_options:
   shadow_schema_registry_api:                # API mode: replicate from a Confluent Schema Registry
@@ -168,6 +153,8 @@ schema_registry_sync_options:
 
 The intervals and rate limit are optional. If you omit them, Redpanda uses the defaults shown above.
 
+To authenticate to the source registry with mTLS instead of HTTP basic authentication, omit `auth_options` and provide a client certificate and key in `tls_settings`.
+
 // DRAFT-VERIFY (DOC-2254): Defaults (10s / 5m / 30 rps) are from
 // src/v/cluster_link/model/types.h on dev. Re-check at code-complete.
 
@@ -187,6 +174,8 @@ schema_registry_sync_options:
       subjects:
       - orders-value                          # A subject in the default context
 ----
+
+The `contexts` and `subjects` lists accept literal names only. Wildcard and prefix patterns are not supported.
 
 Schema Registry contexts provide independent namespaces for subjects within one registry. The default context is named `.`. For more information, see xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts].
 
@@ -220,10 +209,20 @@ schema_registry_sync_options:
           destination: ".shadow"              # Destination context on the shadow cluster
 ----
 
+[IMPORTANT]
+====
+With `exact` mapping, the mappings must cover every context that the link replicates. If the link encounters a source context that has no mapping, the schema replication task fails. If new contexts might be created on the source registry after you set up the link, scope the `source_filter` `contexts` list to the mapped contexts so that an unexpected context cannot stop replication.
+====
+
 [[choose-a-validation-policy]]
 === Choose a validation policy
 
-The `unsupported_schema_feature_policy` setting controls what happens when a source schema uses features that the Redpanda Schema Registry does not support:
+The `unsupported_schema_feature_policy` setting controls what happens when a source schema uses features that the Redpanda Schema Registry does not support. The unsupported Confluent Schema Registry features are:
+
+* In schema definitions: rule sets and metadata tags.
+* In subject configurations: override metadata, override rule sets, default metadata, default rule sets, and compatibility groups. Compatibility groups are not the same as compatibility levels, which do replicate.
+
+The policy determines how the sync handles a schema or configuration that uses these features:
 
 [cols="1,3"]
 |===
@@ -299,15 +298,13 @@ The Schema Registry section of the output reports:
 | The most recent replication error. With the `FAIL` validation policy, schemas that fail validation appear here.
 |===
 
+The schema replication task runs on the broker and shard that hosts the leader of the `_schemas` topic's partition. The counters in the status output are not persisted: expect them to reset to zero when that broker restarts or when leadership of the `_schemas` partition moves to another broker.
+
 For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`]. For general link monitoring, see xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitor Shadowing].
 
 == Fail over
 
-When you fail over a shadow link, schema replication from the source registry stops and the write-blocked destination contexts become writable, so your applications can register new schemas on the promoted cluster.
-
-// DRAFT-VERIFY (DOC-2254): Failover behavior (single `paused` field pauses the sync task
-// and lifts per-context write blocks) is from open PR redpanda#30984. Confirm the final
-// mechanism and whether any manual steps apply to schema replication during failover.
+Failing over shadow topics does not stop schema replication. As part of failover, pause the schema replication task by setting `paused: true` in the `schema_registry_sync_options` section of the link configuration. Pausing the task stops further syncing from the source registry and makes the write-blocked destination contexts writable, so your applications can register new schemas on the promoted cluster.
 
 For the complete failover procedure, see xref:manage:disaster-recovery/shadowing/failover.adoc[Failover].
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -23,7 +23,7 @@ After reading this page, you will be able to:
 * [ ] {learning-objective-2}
 * [ ] {learning-objective-3}
 
-== How schema replication works
+== How HTTP API schema replication works
 
 When you configure a shadow link with the `shadow_schema_registry_api` option, the shadow cluster polls the source Schema Registry over HTTP and imports changes into its own Schema Registry. Two sync cycles keep the registries in step:
 
@@ -54,10 +54,10 @@ Schema replication settings live in the shadow link configuration. Two cluster p
 
 == Prerequisites
 
-* A shadow cluster running Redpanda version 26.2 or later. The schema replication feature activates after all brokers complete the upgrade.
+* A cluster running Redpanda version 26.2 or later. The schema replication feature activates after all brokers complete the upgrade.
 * Network connectivity from the shadow cluster to the source Schema Registry HTTP endpoint.
 * Credentials for the source registry with permission to read subjects, versions, and configuration. For Confluent Cloud, use a Schema Registry API key and secret.
-* A shadow link to the source cluster, or a plan to create one. See xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing].
+* Basic Shadow link settings. See xref:manage:disaster-recovery/shadowing/setup.adoc[Configure Shadowing].
 * The destination contexts that the link replicates into, as determined by your `source_filter` and `destination` mapping, must be empty on the shadow cluster. The rest of the shadow cluster's Schema Registry does not need to be empty: contexts outside the link's mappings are unaffected.
 * To replicate contexts other than the default context, the xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster property must be enabled on the shadow cluster (the default). See xref:manage:schema-reg/schema-reg-contexts.adoc#prerequisites[Schema Registry Contexts].
 
@@ -225,7 +225,7 @@ The policy determines how the sync handles a schema or configuration that uses t
 | The schema is not replicated. The sync records an error, reports it in the link status, and continues with the remaining schemas.
 
 | `REMOVE`
-| The unsupported fields are removed and the rest of the schema is imported. The sync counts each modification in the link status.
+| The unsupported fields are removed and the rest of the schema is imported. The sync records each modification in the link status.
 |===
 
 [,yaml]
@@ -297,7 +297,7 @@ For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-statu
 
 == Fail over
 
-Failing over shadow topics does not stop schema replication. As part of failover, pause the schema replication task by setting `paused: true` in the `schema_registry_sync_options` section of the link configuration. Pausing the task stops further syncing from the source registry and makes the write-blocked destination contexts writable, so your applications can register new schemas on the promoted cluster.
+For best results, shadow links should be failed over as a single unit, which prevents partial failover scenarios and unexpected results. Selective failover, such as topics only, does not stop schema replication. As part of failover, pause the schema replication task by setting `paused: true` in the `schema_registry_sync_options` section of the link configuration. Pausing the task stops further syncing from the source registry and makes the write-blocked destination contexts writable, so your applications can register new schemas on the promoted cluster.
 
 For the complete failover procedure, see xref:manage:disaster-recovery/shadowing/failover.adoc[Failover].
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -250,15 +250,12 @@ Create the shadow link with your completed configuration file:
 
 [,bash]
 ----
-rpk shadow create <link-name> --config-file shadow-config.yaml
+rpk shadow create --config-file shadow-config.yaml
 ----
 
 For detailed command options, see xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`].
 
 To change the schema replication settings on an existing link, see xref:reference:rpk/rpk-shadow/rpk-shadow-update.adoc[`rpk shadow update`].
-
-// DRAFT-VERIFY (DOC-2254): Confirm the exact `rpk shadow create` argument order
-// (link name vs --config-file only) against the 26.2 rpk build.
 
 == Verify the configuration
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -68,6 +68,7 @@ Schema replication settings live in the shadow link configuration. Two cluster p
 * Replication is one way, from the source registry to the shadow cluster. Destination contexts owned by the link are read-only until failover.
 * Schemas that use Confluent features not supported by the Redpanda Schema Registry are not replicated as-is. Choose a <<choose-a-validation-policy,validation policy>> to control whether these schemas are skipped or imported without the unsupported fields.
 * Topic data replication and schema replication are not coordinated with each other. Records serialized in the Confluent SerDes wire format can arrive on the shadow cluster before the schema IDs they contain have been replicated.
+* Deleting and recreating a subject: A hard delete on the source replicates on the next sync, not instantly. Wait until the subject is removed from the shadow cluster before registering a new schema under the same name, as recreating it too soon prevents the sync job from detecting the subject/subject-version change.
 
 == Configure schema replication
 

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -82,6 +82,52 @@ Schema replication does not add any cluster configuration properties. All settin
 
 Add the `shadow_schema_registry_api` option to the `schema_registry_sync_options` section of your shadow link configuration file.
 
+The following sample configuration file creates a shadow link that shadows all source topics and replicates schemas from a Confluent Schema Registry. The sections that follow explain each schema replication setting.
+
+[,yaml]
+----
+# Sample shadow link configuration with API-mode Schema Registry replication
+
+name: confluent-migration                    # Unique name for this shadow link
+
+client_options:
+  bootstrap_servers:                         # Source Kafka cluster brokers
+  - <source-broker-1>:<port>                 # Example: "pkc-xxxxx.us-east-1.aws.confluent.cloud:9092"
+  - <source-broker-2>:<port>
+  # For the TLS and authentication settings that the shadow cluster uses to
+  # connect to the source Kafka cluster, see the complete configuration file
+  # reference in Configure Shadowing.
+
+topic_metadata_sync_options:
+  interval: 30s                              # How often to sync topic metadata
+  auto_create_shadow_topic_filters:
+  - pattern_type: LITERAL
+    filter_type: INCLUDE
+    name: '*'                                # Shadow all source topics
+
+schema_registry_sync_options:
+  shadow_schema_registry_api:                # API mode: replicate from a Confluent Schema Registry
+    source_url: https://psrc-xxxxx.us-east-1.aws.confluent.cloud   # Source Schema Registry endpoint
+    auth_options:
+      basic:
+        username: <sr-api-key>               # Confluent Schema Registry API key
+        password: <sr-api-secret>            # Confluent Schema Registry API secret
+    tls_settings:
+      enabled: true                          # Use TLS for the connection
+    tail_interval: 10s                       # Optional: poll for incremental changes (default: 10s)
+    full_sync_interval: 5m                   # Optional: full source scan interval (default: 5m)
+    max_source_requests_per_second: 30       # Optional: rate limit for source requests (default: 30)
+    source_filter:
+      contexts:
+      - "."                                  # The default context
+      subjects: []                           # Empty: all subjects in the selected contexts
+    destination:
+      identity: {}                           # Keep source context names
+    unsupported_schema_feature_policy: FAIL  # FAIL (default) or REMOVE
+----
+
+For the complete configuration file, including consumer offset and security synchronization options, see xref:manage:disaster-recovery/shadowing/setup.adoc#create-a-shadow-link[Configure Shadowing].
+
 === Generate a configuration template
 
 Generate a configuration file template that includes all available fields with comments:

--- a/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/migrate-schemas-confluent.adoc
@@ -67,7 +67,7 @@ Schema replication settings live in the shadow link configuration. Two cluster p
 * A shadow link replicates Schema Registry data in one mode only: either `shadow_schema_registry_topic` or `shadow_schema_registry_api`.
 * Replication is one way, from the source registry to the shadow cluster. Destination contexts owned by the link are read-only until failover.
 * Schemas that use Confluent features not supported by the Redpanda Schema Registry are not replicated as-is. Choose a <<choose-a-validation-policy,validation policy>> to control whether these schemas are skipped or imported without the unsupported fields.
-* Topic data replication and schema replication are not coordinated with each other. Records serialized in the Confluent SerDes wire format can arrive on the shadow cluster before the schema IDs they contain have been replicated.
+* Topic data replication and schema replication are not coordinated with each other. Records serialized in the Confluent SerDes wire format can arrive on the shadow cluster before the schema IDs they contain have been replicated. This does not cause replication errors, because schema IDs are not validated during topic data replication, but consumers that look up those schema IDs on the shadow cluster fail until the schemas arrive. Wait for schema replication to catch up before consuming schema-dependent shadow topics. See <<monitor-replication-status,Monitor replication status>>.
 * Deleting and recreating a subject: A hard delete on the source replicates on the next sync, not instantly. Wait until the subject is removed from the shadow cluster before registering a new schema under the same name, as recreating it too soon prevents the sync job from detecting the subject/subject-version change.
 
 == Configure schema replication
@@ -163,11 +163,18 @@ schema_registry_sync_options:
     # ...connection settings...
     source_filter:
       contexts:
-      - "."                                   # The default context
-      - ".prod"                               # A named context
+      - ".prod"                               # Replicate this entire context
       subjects:
-      - orders-value                          # A subject in the default context
+      - orders-value                          # One subject from the default context
 ----
+
+The two lists combine as a union:
+
+* `contexts` selects entire contexts: every subject in each listed context replicates.
+* `subjects` selects individual subjects, using qualified subject syntax: `orders-value` is the subject in the default context, and `:.staging:orders-value` is the subject of the same name in the `.staging` context.
+* When both lists are set, the link replicates everything selected by either list. A subject selected by both lists replicates once.
+
+For example, the preceding filter replicates every subject in the `.prod` context, plus the single `orders-value` subject from the default context.
 
 The `contexts` and `subjects` lists accept literal names only. Wildcard and prefix patterns are not supported.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -158,6 +158,7 @@ endif::[]
 * **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`, `PAUSED`).
 * **Task status**: Health of replication tasks across brokers (`ACTIVE`, `FAULTED`, `NOT_RUNNING`, `LINK_UNAVAILABLE`). For details about shadow link tasks, see xref:manage:disaster-recovery/shadowing/overview.adoc#shadow-link-tasks[Shadow link tasks].
 * **Lag information**: Replication lag per partition showing source vs shadow high watermarks (HWM).
+* **Schema Registry sync status**: For links that replicate schemas through the Schema Registry API, inventory counts for source and destination subjects, sync progress, and the most recent error. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc#monitor-replication-status[Monitor replication status].
 
 include::manage:partial$shadowing/shadow-link-metrics.adoc[]
 

--- a/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/monitor.adoc
@@ -158,7 +158,9 @@ endif::[]
 * **Individual topic states**: Current state of each replicated topic (`ACTIVE`, `FAULTED`, `FAILING_OVER`, `FAILED_OVER`, `PAUSED`).
 * **Task status**: Health of replication tasks across brokers (`ACTIVE`, `FAULTED`, `NOT_RUNNING`, `LINK_UNAVAILABLE`). For details about shadow link tasks, see xref:manage:disaster-recovery/shadowing/overview.adoc#shadow-link-tasks[Shadow link tasks].
 * **Lag information**: Replication lag per partition showing source vs shadow high watermarks (HWM).
+ifndef::env-cloud[]
 * **Schema Registry sync status**: For links that replicate schemas through the Schema Registry API, inventory counts for source and destination subjects, sync progress, and the most recent error. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc#monitor-replication-status[Monitor replication status].
+endif::[]
 
 include::manage:partial$shadowing/shadow-link-metrics.adoc[]
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -28,7 +28,7 @@ Shadowing replicates:
 * **Topic configurations**: Partition counts, retention policies, and other topic properties
 * **Consumer group offsets**: Enables seamless consumer resumption after failover
 * **Access control lists (ACLs)**: User permissions and security policies
-* **Schema Registry data**: Schema definitions and compatibility settings
+* **Schema Registry data**: Schema definitions, versions, and compatibility settings, replicated from another Redpanda cluster or from a Confluent Schema Registry
 
 == How Shadowing fits into disaster recovery
 
@@ -109,6 +109,20 @@ The task is controlled by the `security_sync_options` section in the configurati
 
 By default, all ACLs replicate to ensure your shadow cluster maintains the same security posture as your source cluster.
 --
+
+Schema Registry Sync::
++
+--
+[#schema-registry-sync-task]
+The **Schema Registry Sync task** replicates Schema Registry content so that applications that depend on schemas keep working after failover.
+
+The task is controlled by the `schema_registry_sync_options` section in the configuration file. It supports two modes:
+
+* **Topic mode** (`shadow_schema_registry_topic`): Shadows the `_schemas` system topic for byte-for-byte replication from another Redpanda cluster.
+* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+
+A shadow link uses one mode or the other, not both.
+--
 ====
 
 === Task status and monitoring
@@ -129,7 +143,7 @@ For monitoring task health and troubleshooting task issues, see xref:manage:disa
 
 Shadowing replicates your topic data with complete fidelity, preserving all message records with their original offsets, timestamps, headers, and metadata. The partition structure remains identical between source and shadow clusters, ensuring applications can resume processing from the exact same position after failover.
 
-Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters. Schema Registry data synchronizes schema definitions, versions, and compatibility settings.
+Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters. Schema Registry data synchronizes schema definitions, versions, and compatibility settings, either by shadowing the `_schemas` topic or through the xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Schema Registry API].
 
 Partition count is always replicated to ensure the shadow topic matches the source topic's partition structure.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -121,7 +121,7 @@ The task is controlled by the `schema_registry_sync_options` section in the conf
 * **Topic mode** (`shadow_schema_registry_topic`): Shadows the `_schemas` system topic for byte-for-byte replication from another Redpanda cluster.
 * **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
 
-A shadow link uses one mode or the other, not both.
+A shadow link uses one mode or the other, not both. Only API mode runs as a separate task that appears in the shadow link status. Topic mode adds the `_schemas` topic to the set of shadowed topics, so it is monitored like any other shadow topic rather than as a separate task.
 --
 ====
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -119,7 +119,10 @@ The **Schema Registry Sync task** replicates Schema Registry content so that app
 The task is controlled by the `schema_registry_sync_options` section in the configuration file. It supports two modes:
 
 * **Topic mode** (`shadow_schema_registry_topic`): Shadows the `_schemas` system topic for byte-for-byte replication from another Redpanda cluster.
-* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry.
+ifndef::env-cloud[]
+See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+endif::[]
 
 A shadow link uses one mode or the other, not both. Only API mode runs as a separate task that appears in the shadow link status. Topic mode adds the `_schemas` topic to the set of shadowed topics, so it is monitored like any other shadow topic rather than as a separate task.
 --
@@ -143,7 +146,13 @@ For monitoring task health and troubleshooting task issues, see xref:manage:disa
 
 Shadowing replicates your topic data with complete fidelity, preserving all message records with their original offsets, timestamps, headers, and metadata. The partition structure remains identical between source and shadow clusters, ensuring applications can resume processing from the exact same position after failover.
 
-Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters. Schema Registry data synchronizes schema definitions, versions, and compatibility settings, either by shadowing the `_schemas` topic or through the xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Schema Registry API].
+Consumer group data flows according to your group filters, replicating offsets and membership information for matched groups. ACLs replicate based on your security filters.
+ifndef::env-cloud[]
+Schema Registry data synchronizes schema definitions, versions, and compatibility settings, either by shadowing the `_schemas` topic or through the xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Schema Registry API].
+endif::[]
+ifdef::env-cloud[]
+Schema Registry data synchronizes schema definitions, versions, and compatibility settings by shadowing the `_schemas` topic.
+endif::[]
 
 Partition count is always replicated to ensure the shadow topic matches the source topic's partition structure.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/overview.adoc
@@ -203,10 +203,10 @@ endif::[]
 
 Choose your implementation approach:
 
-* **xref:./setup.adoc[Setup and Configuration]**: Initial shadow configuration, authentication, and topic selection
-* **xref:./monitor.adoc[Monitoring and Operations]**: Health checks, lag monitoring, and operational procedures
-* **xref:./failover.adoc[Planned Failover]**: Controlled disaster recovery testing and migrations
-* **xref:./failover-runbook.adoc[Failover Runbook]**: Rapid disaster response procedures
+* **xref:manage:disaster-recovery/shadowing/setup.adoc[Setup and Configuration]**: Initial shadow configuration, authentication, and topic selection
+* **xref:manage:disaster-recovery/shadowing/monitor.adoc[Monitoring and Operations]**: Health checks, lag monitoring, and operational procedures
+* **xref:manage:disaster-recovery/shadowing/failover.adoc[Planned Failover]**: Controlled disaster recovery testing and migrations
+* **xref:manage:disaster-recovery/shadowing/failover-runbook.adoc[Failover Runbook]**: Rapid disaster response procedures
 
 ifndef::env-cloud[]
 [TIP]
@@ -226,7 +226,7 @@ endif::[]
 
 After setting up Shadowing for your Redpanda clusters, consider these additional steps:
 
-* **Test your disaster recovery procedures**: Regularly practice failover scenarios in a non-production environment. See xref:./failover-runbook.adoc[] for step-by-step disaster procedures.
+* **Test your disaster recovery procedures**: Regularly practice failover scenarios in a non-production environment. See xref:manage:disaster-recovery/shadowing/failover-runbook.adoc[] for step-by-step disaster procedures.
 
 * **Monitor shadow link health**: Set up alerting on the metrics described above to ensure early detection of replication issues.
 

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -487,9 +487,14 @@ consumer_offset_sync_options:
 
 ==== Schema Registry synchronization
 
-Shadowing can replicate Schema Registry data by shadowing the `_schemas` system topic. When enabled, this provides byte-for-byte replication of schema definitions, versions, and compatibility settings.
+Shadowing can replicate Schema Registry data in one of two modes:
 
-To enable Schema Registry synchronization, add the following to your shadow link configuration:
+* **Topic mode** (`shadow_schema_registry_topic`): Shadows the `_schemas` system topic for byte-for-byte replication of schema definitions, versions, and compatibility settings from another Redpanda cluster.
+* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry, or to replicate only part of the source registry. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+
+A shadow link uses one mode or the other, not both.
+
+To enable topic mode, add the following to your shadow link configuration:
 
 [,yaml]
 ----
@@ -497,7 +502,7 @@ schema_registry_sync_options:
   shadow_schema_registry_topic: {}
 ----
 
-Requirements:
+Topic mode requirements:
 
 - The `_schemas` topic must exist on the source cluster
 - The `_schemas` topic must not exist on the shadow cluster, or must be empty

--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -490,7 +490,10 @@ consumer_offset_sync_options:
 Shadowing can replicate Schema Registry data in one of two modes:
 
 * **Topic mode** (`shadow_schema_registry_topic`): Shadows the `_schemas` system topic for byte-for-byte replication of schema definitions, versions, and compatibility settings from another Redpanda cluster.
-* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry, or to replicate only part of the source registry. See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+* **API mode** (`shadow_schema_registry_api`): Polls the source Schema Registry over HTTP and imports selected contexts and subjects, with validation. Use this mode to replicate schemas from a Confluent Schema Registry, or to replicate only part of the source registry.
+ifndef::env-cloud[]
+See xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[Migrate Schemas from Confluent Schema Registry].
+endif::[]
 
 A shadow link uses one mode or the other, not both.
 


### PR DESCRIPTION
Documents the new v26.2 Schema Registry API-mode replication (`shadow_schema_registry_api`) for shadow links:

- New page: Migrate Schemas from Confluent Schema Registry (intro, use cases, prerequisites, limitations, config steps, filtering, context mapping, validation policy, monitoring, failover)
- setup.adoc: present topic mode vs API mode in the Schema Registry synchronization section
- overview.adoc: add Schema Registry Sync task tab and update the replication lists
- monitor.adoc: add Schema Registry sync status bullet
- nav.adoc: add nav entry under Shadowing

## Review deadline: **July14**

## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-2254


## Page previews

- https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/migrate-schemas-confluent/
- https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/setup/
- https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/overview/
- https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/monitor/

## Sources of truth

All YAML field names verified against `src/go/rpk/pkg/cli/shadow/types.go` (dev) and the `types_test.go` example config. Defaults (10s tail / 5m full sync / 30 rps, `FAIL` policy) from `src/v/cluster_link/model/types.h`. Merged engineering PRs: redpanda#30695, #30723, #30764, #30835, #30860, #30905, #30933.

## ⚠️ Verify before merge (unreleased feature, ENG-1171)

Two engineering PRs were still open at draft time. `// DRAFT-VERIFY (DOC-2254)` comments in the new page mark each item:

- [ ] HTTP source reader + destination bootstrap (redpanda#30999): confirm whether the destination Schema Registry must be empty
- [ ] Failover mechanism via `paused` (redpanda#30984)
- [ ] Exact list of unsupported Confluent schema features (SME: @pgellert)
- [ ] Wildcard support in `source_filter` (epic mentions wildcards; rpk source shows plain string lists)
- [ ] `rpk shadow create` argument order against a 26.2 build
- [ ] Re-check defaults at code-complete

## Related

- Cloud twin: DOC-2307 (deferred; new content is wrapped in `single-source` tags with `env-cloud` conditionals, ready for the cloud-docs stub)
  - Note for the DOC-2307 stub: the `:learning-objective-N:` attributes are defined outside the `single-source` tag, but the `{learning-objective-N}` references are inside it. The cloud-docs stub header must define the same three attributes or the cloud build will render the references literally.
- Companion glossary PR (shared branch): #1777 (merge before or with this PR). Overlaps DOC-1660 (in progress).

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Preview pages

- [Migrate Schemas from Confluent Schema Registry](https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/migrate-schemas-confluent/) (new)
- [Configure Shadowing](https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/setup/) (updated)
- [Shadowing Overview](https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/overview/) (updated)
- [Monitor Shadowing](https://deploy-preview-1776--redpanda-docs-preview.netlify.app/streaming/26.2/manage/disaster-recovery/shadowing/monitor/) (updated)
