### PR TITLE
DOC-2254: Add Shadowing and Schema Registry context glossary terms

### DIFF
--- a/modules/terms/partials/schema-registry-context.adoc
+++ b/modules/terms/partials/schema-registry-context.adoc
@@ -2,5 +2,3 @@
 :term-name: Schema Registry context
 :hover-text: An independent namespace for subjects within a Schema Registry. Contexts let multiple groups of schemas coexist in one registry without naming conflicts. The default context is named ".".
 :category: Redpanda features
-
-For more information, see xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts].

--- a/modules/terms/partials/schema-registry-context.adoc
+++ b/modules/terms/partials/schema-registry-context.adoc
@@ -1,0 +1,6 @@
+=== Schema Registry context
+:term-name: Schema Registry context
+:hover-text: An independent namespace for subjects within a Schema Registry. Contexts let multiple groups of schemas coexist in one registry without naming conflicts. The default context is named ".".
+:category: Redpanda features
+
+For more information, see xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts].

--- a/modules/terms/partials/shadow-cluster.adoc
+++ b/modules/terms/partials/shadow-cluster.adoc
@@ -2,5 +2,3 @@
 :term-name: shadow cluster
 :hover-text: A read-only Redpanda cluster that continuously receives replicated data from a source cluster through a shadow link. During a disaster, you can fail over to the shadow cluster so it handles production traffic.
 :category: Redpanda features
-
-For more information, see xref:manage:disaster-recovery/shadowing/overview.adoc[Shadowing Overview].

--- a/modules/terms/partials/shadow-cluster.adoc
+++ b/modules/terms/partials/shadow-cluster.adoc
@@ -1,0 +1,6 @@
+=== shadow cluster
+:term-name: shadow cluster
+:hover-text: A read-only Redpanda cluster that continuously receives replicated data from a source cluster through a shadow link. During a disaster, you can fail over to the shadow cluster so it handles production traffic.
+:category: Redpanda features
+
+For more information, see xref:manage:disaster-recovery/shadowing/overview.adoc[Shadowing Overview].

--- a/modules/terms/partials/shadow-link.adoc
+++ b/modules/terms/partials/shadow-link.adoc
@@ -1,0 +1,6 @@
+=== shadow link
+:term-name: shadow link
+:hover-text: A persistent connection between two Redpanda clusters that continuously replicates topic data, metadata, consumer offsets, ACLs, and Schema Registry content from a source cluster to a shadow cluster for disaster recovery.
+:category: Redpanda features
+
+For more information, see xref:manage:disaster-recovery/shadowing/overview.adoc[Shadowing Overview].

--- a/modules/terms/partials/shadow-link.adoc
+++ b/modules/terms/partials/shadow-link.adoc
@@ -2,5 +2,3 @@
 :term-name: shadow link
 :hover-text: A persistent connection between two Redpanda clusters that continuously replicates topic data, metadata, consumer offsets, ACLs, and Schema Registry content from a source cluster to a shadow cluster for disaster recovery.
 :category: Redpanda features
-
-For more information, see xref:manage:disaster-recovery/shadowing/overview.adoc[Shadowing Overview].


### PR DESCRIPTION
## Description

Adds three glossary terms used by the new Confluent Schema Registry migration page in #1776:

- `shadow link` (Redpanda features)
- `shadow cluster` (Redpanda features)
- `Schema Registry context` (Redpanda features)

Related to https://redpandadata.atlassian.net/browse/DOC-2254

> **Note**: DOC-1660 (Add Shadow Linking and DR terms to Glossary) is In Progress and may cover the two shadow terms. If that work already has definitions drafted, prefer those and drop the duplicates here.

**Merge order**: This PR should merge before or together with #1776, which uses `glossterm:shadow link[]` and `glossterm:shadow cluster[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview pages

This PR changes term partials only, so the rendered surface is the glossary page:

- [Glossary](https://deploy-preview-1777--redpanda-docs-preview.netlify.app/streaming/25.3/reference/glossary) (updated — all three new terms verified rendering in this preview: `shadow link`, `shadow cluster`, `Schema Registry context`)

Note: this shared-branch preview assembles the 25.3 build; the `shared` branch feeds every version, so the terms will appear in all versions' glossaries once merged.
