### PR TITLE
DOC-226: Document per-entity client quota metrics (26.2)

### DIFF
--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -727,9 +727,6 @@ TRACE 2024-06-14 15:37:59,195 [shard  2:main] kafka_quotas - connection_context.
 ----
 endif::[]
 
-// DRAFT-VERIFY (DOC-226): This subsection documents ENG-37 (redpanda PR #30832, merged to
-// dev 2026-06-24, targets v26.2). Verify all flagged items against a 26.2 build before
-// publishing. SME: Mateusz Najda (@mnajda-redpanda).
 // DRAFT-VERIFY (DOC-226): Confirm whether Redpanda Cloud exposes the
 // kafka_per_entity_quota_metrics cluster property. Gated to Self-Managed until confirmed.
 ifndef::env-cloud[]

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -735,7 +735,7 @@ endif::[]
 ifndef::env-cloud[]
 ==== Track quota use per entity
 
-When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions: Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name, alert on a workload before it saturates its quota, and right-size quota values based on observed usage.
+When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions: Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name and right-size quota values based on observed usage.
 
 Per-entity quota metrics are disabled by default because each throttled entity adds metric series. To enable them:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -727,6 +727,63 @@ TRACE 2024-06-14 15:37:59,195 [shard  2:main] kafka_quotas - connection_context.
 ----
 endif::[]
 
+// DRAFT-VERIFY (DOC-226): This subsection documents ENG-37 (redpanda PR #30832, merged to
+// dev 2026-06-24, targets v26.2). Verify all flagged items against a 26.2 build before
+// publishing. SME: Mateusz Najda (@mnajda-redpanda).
+// DRAFT-VERIFY (DOC-226): Confirm whether Redpanda Cloud exposes the
+// kafka_per_entity_quota_metrics cluster property. Gated to Self-Managed until confirmed.
+ifndef::env-cloud[]
+==== Track quota use per entity
+
+The quota metrics above aggregate throttling and throughput by quota rule and quota type, so they cannot tell you which specific client is approaching its limit. Per-entity quota metrics label each series with the throttled entity's identity, so you can measure how much of an enforced quota each client actually uses, identify throttled clients by name, and alert on a workload before it saturates its quota.
+
+Per-entity quota metrics are disabled by default because each throttled entity adds metric series. To enable them:
+
+[,bash]
+----
+rpk cluster config set kafka_per_entity_quota_metrics true
+----
+
+The change takes effect without a broker restart.
+
+When enabled, Redpanda exposes two additional counters:
+
+* Total per-entity quota throttling delay, in milliseconds:
+** `/public_metrics` - `redpanda_kafka_quotas_client_quota_throttle_time_ms_by_entity`
+** `/metrics` - `vectorized_kafka_quotas_client_quota_throttle_time_ms_by_entity`
+* Per-entity quota throughput (bytes for produce and fetch quotas, partition mutations for partition mutation quotas):
+** `/public_metrics` - `redpanda_kafka_quotas_client_quota_throughput_by_entity`
+** `/metrics` - `vectorized_kafka_quotas_client_quota_throughput_by_entity`
+
+// DRAFT-VERIFY (DOC-226): Confirm the exposed internal metric names on a 26.2 build, then
+// replace the plain code spans above with xrefs to the regenerated metrics reference pages
+// (anchors do not exist until /gen-metrics runs for 26.2).
+
+Each series is labeled with the entity identity and the quota type:
+
+* `redpanda_quota_type`: Always present. One of `produce_quota`, `fetch_quota`, or `partition_mutation_quota`.
+* `redpanda_quota_user`: The user principal, for user-based quotas.
+* `redpanda_quota_client_id`: The client ID, for client ID-based quotas.
+* `redpanda_quota_group_name`: The client ID prefix, for quotas that apply to a <<group-of-clients-throughput-limit,group of clients>>.
+// DRAFT-VERIFY (DOC-226): Confirm the redpanda_quota_group_name label corresponds to
+// client-id-prefix quotas (not consumer groups) on a live build.
+
+Combined quotas, such as a user with a specific client ID, include each matching label on the same series.
+
+To keep metric cardinality bounded, Redpanda registers a per-entity series only while an entity is actively being throttled, and removes the series after the entity has been idle. An entity appears in these metrics only after it has been throttled at least once. From that point, Redpanda records the entity's throughput on every request, not only on throttled requests, so a Prometheus `rate()` query reflects the entity's actual throughput.
+
+To measure how much of its quota an entity is using, divide the entity's throughput rate by its configured limit. For example, the following query returns the produce throughput rate for each throttled client ID:
+
+[,promql]
+----
+sum by (redpanda_quota_client_id) (
+  rate(redpanda_kafka_quotas_client_quota_throughput_by_entity{redpanda_quota_type="produce_quota"}[5m])
+)
+----
+
+Compare the result with the entity's configured limit from xref:reference:rpk/rpk-cluster/rpk-cluster-quotas-describe.adoc[`rpk cluster quotas describe`]. A ratio close to 1 means the client is saturating its quota and its requests are being delayed.
+endif::[]
+
 == See also
 
 - xref:manage:cluster-maintenance/about-throughput-quotas.adoc[]

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -732,7 +732,7 @@ endif::[]
 ifndef::env-cloud[]
 ==== Track quota use per entity
 
-When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions: Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name and right-size quota values based on observed usage.
+When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions. Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name and right-size quota values based on observed usage.
 
 Per-entity quota metrics are disabled by default because each throttled entity adds metric series. To enable them:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -776,7 +776,7 @@ To measure how much of its quota an entity is using, divide the entity's through
 
 [,promql]
 ----
-sum by (redpanda_quota_client_id) (
+sum by (redpanda_quota_client_id, pod) (
   rate(redpanda_kafka_quotas_client_quota_throughput_by_entity{redpanda_quota_type="produce_quota"}[5m])
 )
 ----

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -752,9 +752,6 @@ When enabled, Redpanda exposes two additional counters:
 ** `/public_metrics` - `redpanda_kafka_quotas_client_quota_throughput_by_entity`
 ** `/metrics` - `vectorized_kafka_quotas_client_quota_throughput_by_entity`
 
-// DRAFT-VERIFY (DOC-226): Confirm the exposed internal metric names on a 26.2 build, then
-// replace the plain code spans above with xrefs to the regenerated metrics reference pages
-// (anchors do not exist until /gen-metrics runs for 26.2).
 
 Each series is labeled with the entity identity and the quota type:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -735,7 +735,7 @@ endif::[]
 ifndef::env-cloud[]
 ==== Track quota use per entity
 
-The quota metrics above aggregate throttling and throughput by quota rule and quota type, so they cannot tell you which specific client is approaching its limit. Per-entity quota metrics label each series with the throttled entity's identity, so you can measure how much of an enforced quota each client actually uses, identify throttled clients by name, and alert on a workload before it saturates its quota.
+When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions: Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name, alert on a workload before it saturates its quota, and right-size quota values based on observed usage.
 
 Per-entity quota metrics are disabled by default because each throttled entity adds metric series. To enable them:
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -734,7 +734,7 @@ When a workload slows down because a client hits its throughput quota, the aggre
 Per-entity quota metrics are disabled by default because each throttled entity adds metric series.
 
 ifndef::env-cloud[]
-To enable them:
+To enable them, run:
 
 [,bash]
 ----

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -727,19 +727,23 @@ TRACE 2024-06-14 15:37:59,195 [shard  2:main] kafka_quotas - connection_context.
 ----
 endif::[]
 
-// DRAFT-VERIFY (DOC-226): Confirm whether Redpanda Cloud exposes the
-// kafka_per_entity_quota_metrics cluster property. Gated to Self-Managed until confirmed.
-ifndef::env-cloud[]
 ==== Track quota use per entity
 
 When a workload slows down because a client hits its throughput quota, the aggregate quota metrics can confirm that throttling is happening, but they cannot tell you which client is being throttled or how close each client is to its limit. Per-entity quota metrics answer these questions. Redpanda labels each throttle-time and throughput series with the identity of the throttled entity, so you can measure how much of an enforced quota each client actually uses. Use these metrics to identify throttled clients by name and right-size quota values based on observed usage.
 
-Per-entity quota metrics are disabled by default because each throttled entity adds metric series. To enable them:
+Per-entity quota metrics are disabled by default because each throttled entity adds metric series.
+
+ifndef::env-cloud[]
+To enable them:
 
 [,bash]
 ----
 rpk cluster config set kafka_per_entity_quota_metrics true
 ----
+endif::[]
+ifdef::env-cloud[]
+To enable them, set the `kafka_per_entity_quota_metrics` cluster property. See xref:manage:cluster-maintenance/config-cluster.adoc[].
+endif::[]
 
 The change takes effect without a broker restart.
 
@@ -747,10 +751,14 @@ When enabled, Redpanda exposes two additional counters:
 
 * Total per-entity quota throttling delay, in milliseconds:
 ** `/public_metrics` - `redpanda_kafka_quotas_client_quota_throttle_time_ms_by_entity`
+ifndef::env-cloud[]
 ** `/metrics` - `vectorized_kafka_quotas_client_quota_throttle_time_ms_by_entity`
+endif::[]
 * Per-entity quota throughput (bytes for produce and fetch quotas, partition mutations for partition mutation quotas):
 ** `/public_metrics` - `redpanda_kafka_quotas_client_quota_throughput_by_entity`
+ifndef::env-cloud[]
 ** `/metrics` - `vectorized_kafka_quotas_client_quota_throughput_by_entity`
+endif::[]
 
 
 Each series is labeled with the entity identity and the quota type:
@@ -764,7 +772,7 @@ Combined quotas, such as a user with a specific client ID, include each matching
 
 To keep metric cardinality bounded, Redpanda registers a per-entity series only while an entity is actively being throttled, and removes the series after the entity has been idle. An entity appears in these metrics only after it has been throttled at least once. From that point, Redpanda records the entity's throughput on every request, not only on throttled requests, so a Prometheus `rate()` query reflects the entity's actual throughput.
 
-To measure how much of its quota an entity is using, divide the entity's throughput rate by its configured limit. For example, the following query returns the produce throughput rate for each throttled client ID:
+To measure how much of its quota an entity is using, divide the entity's throughput rate by its configured limit. Quota limits apply per broker, so aggregate by broker as well as by entity to keep the results comparable with the configured limits. For example, the following query returns the produce throughput rate for each throttled client ID on each broker:
 
 [,promql]
 ----
@@ -774,7 +782,6 @@ sum by (redpanda_quota_client_id, pod) (
 ----
 
 Compare the result with the entity's configured limit from xref:reference:rpk/rpk-cluster/rpk-cluster-quotas-describe.adoc[`rpk cluster quotas describe`]. A ratio close to 1 means the client is saturating its quota and its requests are being delayed.
-endif::[]
 
 == See also
 

--- a/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
+++ b/modules/manage/pages/cluster-maintenance/manage-throughput.adoc
@@ -759,8 +759,6 @@ Each series is labeled with the entity identity and the quota type:
 * `redpanda_quota_user`: The user principal, for user-based quotas.
 * `redpanda_quota_client_id`: The client ID, for client ID-based quotas.
 * `redpanda_quota_group_name`: The client ID prefix, for quotas that apply to a <<group-of-clients-throughput-limit,group of clients>>.
-// DRAFT-VERIFY (DOC-226): Confirm the redpanda_quota_group_name label corresponds to
-// client-id-prefix quotas (not consumer groups) on a live build.
 
 Combined quotas, such as a user with a specific client ID, include each matching label on the same series.
 


### PR DESCRIPTION
## Description

Documents the new **per-entity client quota metrics** shipping in v26.2 ([ENG-37](https://redpandadata.atlassian.net/browse/ENG-37) "Metrics: Throughput Quota Utilization", implemented in redpanda#30832, merged to dev 2026-06-24). This answers the customer ask behind the epic: track how much of an enforced quota each client is actually using.

Resolves https://redpandadata.atlassian.net/browse/DOC-226
Review deadline:

### What's new

One subsection, `Track quota use per entity`, added to the existing "Monitor client throughput" section of manage-throughput.adoc:

- Intro contextualizing the change: aggregate metrics show *that* throttling happens per rule; per-entity metrics show *who* is being throttled and how close each client is to its limit (identify noisy clients by name, alert before quota saturation)
- `kafka_per_entity_quota_metrics` cluster property (opt-in, default false, no restart)
- The two new counters on `/public_metrics` and `/metrics`
- Label scheme (`redpanda_quota_type` + user/client-id/group labels) and the cardinality-bounding behavior (series exist only while an entity is throttled; cleaned up after idle)
- Utilization guidance: PromQL rate query + compare against `rpk cluster quotas describe`

### Deliberately NOT in this PR (anti-duplication)

The v24.2 client quota changes from the eng context doc (KIP-546/rpk cluster quotas, prefix quotas, per-broker semantics, deprecated cluster configs, the two aggregate histograms, and the `kafka_quotas` logger) are **already documented** — verified on beta in manage-throughput.adoc, about-throughput-quotas.adoc, both metrics references, and upgrade/deprecated. This PR only adds the 26.2 delta.

### Generated-content notes

- **Metrics references**: the new metrics will appear in public/internal metrics reference via `/gen-metrics` at 26.2 release — plain code spans used for now, with a DRAFT-VERIFY to convert to xrefs after regeneration (anchors don't exist yet)
- **Property reference**: `kafka_per_entity_quota_metrics` arrives via `/gen-props` at release — not hand-added
- API doc updates: none needed (feature is metrics-only; no admin API or rpk changes per source)

### ⚠️ Verify before merge (DRAFT-VERIFY comments in source)

- [x] Internal (`/metrics`) exposed names for the two counters against a 26.2 build
- [x] `redpanda_quota_group_name` = client-ID-prefix quotas (agent-inferred; confirm with @mnajda-redpanda)
- [x] Whether Redpanda Cloud exposes `kafka_per_entity_quota_metrics` — subsection is `ifndef::env-cloud` gated until confirmed
- [x] Combined-quota label behavior (multiple labels on one series)

## Page previews

- https://deploy-preview-1779--redpanda-docs-preview.netlify.app/streaming/26.2/manage/cluster-maintenance/manage-throughput/#track-quota-use-per-entity

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-37]: https://redpandadata.atlassian.net/browse/ENG-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

