### PR TITLE
DOC-2347: give Cloud readers log-free troubleshooting steps for shadow links

### DIFF
--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -486,11 +486,29 @@ Document the time of failover initiation and completion, applications affected a
 
 == Troubleshoot common issues
 
+ifdef::env-cloud[]
+[NOTE]
+====
+Direct access to shadow cluster logs isn't available in Redpanda Cloud. To troubleshoot, use:
+
+* Run xref:reference:rpk/rpk-shadow/rpk-shadow-status.adoc[`rpk shadow status`] to check task states, topic status, and lag.
+* Use the link:/api/doc/cloud-dataplane/operation/operation-shadowlinkservice_listshadowlinktopics[Data Plane API] for programmatic monitoring.
+* Monitor xref:manage:disaster-recovery/shadowing/monitor.adoc#shadow-link-metrics[Prometheus metrics] such as `redpanda_shadow_link_shadow_lag` and `redpanda_shadow_link_client_errors`.
+
+If these don't reveal the root cause, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your cluster ID, shadow link name, and the timestamp of the issue.
+====
+endif::[]
+
 === Topics stuck in FAILING_OVER state
 
 **Problem**: Topics remain in `FAILING_OVER` state for extended periods
 
+ifndef::env-cloud[]
 **Solution**: Check shadow cluster logs for specific error messages and ensure sufficient cluster resources (CPU, memory, disk space) are available on the shadow cluster. Verify network connectivity between shadow cluster nodes and confirm that all shadow topic partitions have elected leaders and the controller partition is properly replicated with an active leader.
+endif::[]
+ifdef::env-cloud[]
+**Solution**: Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check for specific error messages, and ensure sufficient cluster resources (CPU, memory, disk space) are available on the shadow cluster. Verify network connectivity between shadow cluster nodes and confirm that all shadow topic partitions have elected leaders and the controller partition is properly replicated with an active leader.
+endif::[]
 
 If topics remain stuck after addressing these cluster health issues and you need immediate failover, you can force delete the shadow link to failover all topics:
 
@@ -551,7 +569,12 @@ Force deleting a shadow link immediately fails over all topics in the link. This
 
 **Problem**: Topics show `FAULTED` state and are not replicating
 
+ifndef::env-cloud[]
 **Solution**: Check for authentication issues, network connectivity problems, or source cluster unavailability. Verify that the shadow link service account still has the required permissions on the source cluster. Review shadow cluster logs for specific error messages about the faulted topics.
+endif::[]
+ifdef::env-cloud[]
+**Solution**: Check for authentication issues, network connectivity problems, or source cluster unavailability. Verify that the shadow link service account still has the required permissions on the source cluster. Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check for specific error messages about the faulted topics.
+endif::[]
 
 === Application connection failures
 

--- a/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/failover-runbook.adoc
@@ -507,7 +507,7 @@ ifndef::env-cloud[]
 **Solution**: Check shadow cluster logs for specific error messages and ensure sufficient cluster resources (CPU, memory, disk space) are available on the shadow cluster. Verify network connectivity between shadow cluster nodes and confirm that all shadow topic partitions have elected leaders and the controller partition is properly replicated with an active leader.
 endif::[]
 ifdef::env-cloud[]
-**Solution**: Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check for specific error messages, and ensure sufficient cluster resources (CPU, memory, disk space) are available on the shadow cluster. Verify network connectivity between shadow cluster nodes and confirm that all shadow topic partitions have elected leaders and the controller partition is properly replicated with an active leader.
+**Solution**: Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check task and topic states, replication lag, and client-error counts, and ensure sufficient cluster resources (CPU, memory, disk space) are available on the shadow cluster. Verify network connectivity between shadow cluster nodes and confirm that all shadow topic partitions have elected leaders and the controller partition is properly replicated with an active leader.
 endif::[]
 
 If topics remain stuck after addressing these cluster health issues and you need immediate failover, you can force delete the shadow link to failover all topics:
@@ -573,7 +573,7 @@ ifndef::env-cloud[]
 **Solution**: Check for authentication issues, network connectivity problems, or source cluster unavailability. Verify that the shadow link service account still has the required permissions on the source cluster. Review shadow cluster logs for specific error messages about the faulted topics.
 endif::[]
 ifdef::env-cloud[]
-**Solution**: Check for authentication issues, network connectivity problems, or source cluster unavailability. Verify that the shadow link service account still has the required permissions on the source cluster. Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check for specific error messages about the faulted topics.
+**Solution**: Check for authentication issues, network connectivity problems, or source cluster unavailability. Verify that the shadow link service account still has the required permissions on the source cluster. Use `rpk shadow status`, the Data Plane API, or Prometheus metrics to check task and topic states, replication lag, and client-error counts for the faulted topics.
 endif::[]
 
 === Application connection failures


### PR DESCRIPTION
## Summary
- Cloud customers (BYOC, Dedicated, Serverless) don't have direct access to shadow cluster logs, but the shadow link failover runbook told them to check/review logs anyway, causing avoidable support tickets (see #7043).
- Adds a Cloud-only note (`ifdef::env-cloud[]`) at the top of "Troubleshoot common issues" pointing to `rpk shadow status`, the Data Plane API, and Prometheus metrics as alternatives.
- Adjusts the two affected "Solution" steps (`Topics stuck in FAILING_OVER state`, `Topics in FAULTED state`) so the Cloud version doesn't contradict the note by still saying "check/review shadow cluster logs."
- Self-Managed content is unchanged — this file single-sources into both Self-Managed and Cloud via the `env-cloud` attribute.

Jira: DOC-2347

## Preview pages

- [Failover Runbook (Cloud)](https://deploy-preview-1782--redpanda-docs-preview.netlify.app/cloud-data-platform/manage/disaster-recovery/shadowing/failover-runbook/) (updated)
- [Failover Runbook (Self-Managed)](https://deploy-preview-1782--redpanda-docs-preview.netlify.app/streaming/current/manage/disaster-recovery/shadowing/failover-runbook/) (updated)

## Test plan
- [x] `npm run build` completes with no errors related to this file
- [x] Verified locally that the Cloud page shows the new note and adjusted Solution wording
- [x] Verified locally that the Self-Managed page is unchanged (no note, original wording)
- [x] Verified all links in the new note resolve (rpk shadow status xref, Data Plane API link, Prometheus metrics anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
