### PR TITLE
Update quota labels for client throughput metric

### DIFF
--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -2045,7 +2045,7 @@ Histogram of client quota throttling delays (in seconds) per quota rule and type
 
 *Labels*:
 
-* `quota_rule=("not_applicable" | "kafka_client_default" | "cluster_client_default" | "kafka_client_prefix" | "cluster_client_prefix" | "kafka_client_id")`
+* `quota_rule=("not_applicable" | "kafka_client_default" | "kafka_client_prefix" | "kafka_client_id" | "kafka_user_default" | "kafka_user_default_client_default" | "kafka_user_default_client_prefix" | "kafka_user_default_client_id" | "kafka_user" | "kafka_user_client_default" | "kafka_user_client_prefix" | "kafka_user_client_id")`
 
 * `quota_type=("produce_quota" | "fetch_quota" | "partition_mutation_quota")`
 
@@ -2063,7 +2063,7 @@ Histogram of client quota throughput per quota rule and type.
 
 *Labels*:
 
-* `quota_rule=("not_applicable" | "kafka_client_default" | "cluster_client_default" | "kafka_client_prefix" | "cluster_client_prefix" | "kafka_client_id")`
+* `quota_rule=("not_applicable" | "kafka_client_default" | "kafka_client_prefix" | "kafka_client_id" | "kafka_user_default" | "kafka_user_default_client_default" | "kafka_user_default_client_prefix" | "kafka_user_default_client_id" | "kafka_user" | "kafka_user_client_default" | "kafka_user_client_prefix" | "kafka_user_client_id")`
 
 * `quota_type=("produce_quota" | "fetch_quota" | "partition_mutation_quota")`
 


### PR DESCRIPTION
## Description

This pull request updates the documentation for quota rule labels in two public metrics. The main change is the expansion of the possible values for the `quota_rule` label to include additional user-based quota rules, making the documentation more accurate and comprehensive.

**Documentation updates:**

* Expanded the list of possible values for the `quota_rule` label in the "Histogram of client quota throttling delays" section to include user-based quota rules such as `kafka_user_default`, `kafka_user`, and related combinations.
* Made the same expansion to the `quota_rule` label in the "Histogram of client quota throughput" section, ensuring consistency across both metrics.

Resolves https://redpandadata.atlassian.net/browse/2346
Review deadline: 13 Jul

## Page previews

- [Public Metrics](https://deploy-preview-1785--redpanda-docs-preview.netlify.app/streaming/current/reference/public-metrics-reference/) (updated)

## Checks

- [ ] New feature
- [x] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
