### PR TITLE
[v/25.2] Raise production CPU requirement to 4 cores; state Guaranteed QoS support policy

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -90,7 +90,7 @@ endif::[]
 
 *Requirements*:
 
-- Each node must have at least two physical CPU cores.
+- Each node must have at least four physical CPU cores.
 - x86_64 (Westmere or newer) and AWS Graviton processors are supported.
 ifdef::env-kubernetes[]
 - Each Redpanda Pod requires at least 2 GiB of memory per core.
@@ -105,10 +105,6 @@ endif::[]
 - Each Redpanda broker must have at least 2 MB of memory for each topic partition replica.
 +
 The total memory available for partition replicas is determined as a percentage of the cluster's total memory, which is controlled by the xref:reference:tunable-properties.adoc#topic_partitions_memory_allocation_percent[`topic_partitions_memory_allocation_percent`] setting. Each partition replica consumes xref:reference:tunable-properties.adoc#topic_memory_per_partition[`topic_memory_per_partition`] bytes from this pool. If insufficient memory is available, topic operations will fail. You can adjust the allocation ratio using `topic_partitions_memory_allocation_percent`, but doing so is not recommended, as lowering it may lead to instability or degraded performance.
-
-*Recommendations*:
-
-- Four physical cores for each node are strongly recommended.
 
 ifdef::env-kubernetes[]
 == Pod resource configuration

--- a/modules/manage/pages/kubernetes/k-manage-resources.adoc
+++ b/modules/manage/pages/kubernetes/k-manage-resources.adoc
@@ -262,7 +262,9 @@ kubectl --namespace <namespace> get pod <pod-name> -o jsonpath='{.spec.container
 [[qos]]
 == Quality of service and resource guarantees
 
-To ensure that Redpanda receives stable and consistent resources, set the https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[quality of service (QoS) class] to `Guaranteed` by matching resource requests and limits on all containers in the Pods that run Redpanda.
+IMPORTANT: Redpanda supports only clusters that run in the `Guaranteed` https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/[quality of service (QoS) class]. Clusters whose Redpanda Pods run in the `Burstable` or `BestEffort` QoS classes are not supported.
+
+To run Redpanda in the `Guaranteed` https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[QoS class], match resource requests and limits on all containers in the Pods that run Redpanda.
 
 Kubernetes uses QoS to decide which Pods to evict from a worker node that runs out of resources. When a worker node runs out of resources, Kubernetes evicts Pods with a `Guaranteed` QoS last. This stability is crucial for Redpanda because it requires consistent computational and memory resources to maintain high performance.
 


### PR DESCRIPTION
## Description

Two updates to the 25.2 docs:

1. **Production CPU requirement: 2 → 4 cores.** The requirement in the shared `deploy/partials/requirements.adoc` now reads "at least four physical CPU cores." The separate *Recommendations* block ("Four physical cores… strongly recommended") became redundant once the requirement itself is four, so it's removed. Because this is a shared partial, the change appears on **both** consumer pages: the bare-metal production requirements page and the Kubernetes `k-requirements` page. This also aligns with `k-manage-resources`, which already tells users to give each broker at least 4 CPU cores.
2. **Guaranteed QoS is the only supported mode.** The QoS section of `k-manage-resources.adoc` now leads with an IMPORTANT admonition: only clusters running in the `Guaranteed` QoS class are supported; `Burstable` and `BestEffort` are not. The how-to sentence follows unchanged in substance.

**Follow-up (not in this PR):** `main` and `beta` carry the same "two physical CPU cores" text in the same partial. If the 4-core requirement applies to 25.3/26.x as well, equivalent PRs are needed there.

## Page previews

- [Requirements and Recommendations (bare metal)](https://deploy-preview-1788--redpanda-docs-preview.netlify.app/streaming/25.2/deploy/redpanda/manual/production/requirements/#cpu-and-memory) (updated)
- [Kubernetes Cluster Requirements](https://deploy-preview-1788--redpanda-docs-preview.netlify.app/streaming/25.2/deploy/redpanda/kubernetes/k-requirements/#cpu-and-memory) (updated via shared partial)
- [Manage Pod Resources — QoS](https://deploy-preview-1788--redpanda-docs-preview.netlify.app/streaming/25.2/manage/kubernetes/k-manage-resources/#qos) (updated)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
