### PR TITLE
Update wording in partial that describes requirements.adoc

### DIFF
--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -88,7 +88,7 @@ endif::[]
 
 *Requirements*:
 
-- Each node must have at least two physical CPU cores.
+- Each production node must have at least four physical CPU cores.
 - x86_64 (Westmere or newer) and AWS Graviton processors are supported.
 ifdef::env-kubernetes[]
 - Each Redpanda Pod requires at least 2 GiB of memory per core.

--- a/modules/deploy/partials/requirements.adoc
+++ b/modules/deploy/partials/requirements.adoc
@@ -88,7 +88,7 @@ endif::[]
 
 *Requirements*:
 
-- Each production node must have at least four physical CPU cores.
+- Each production node must have at least two physical CPU cores.
 - x86_64 (Westmere or newer) and AWS Graviton processors are supported.
 ifdef::env-kubernetes[]
 - Each Redpanda Pod requires at least 2 GiB of memory per core.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

This PR changes the shared `deploy/partials/requirements.adoc` partial, which renders on two pages:

- [Requirements and Recommendations](https://deploy-preview-1791--redpanda-docs-preview.netlify.app/streaming/current/deploy/redpanda/manual/production/requirements/#cpu-and-memory) (updated via shared partial)
- [Kubernetes Cluster Requirements and Recommendations](https://deploy-preview-1791--redpanda-docs-preview.netlify.app/streaming/current/deploy/redpanda/kubernetes/k-requirements/#cpu-and-memory) (updated via shared partial)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ x] Small fix (typos, links, copyedits, etc)

