### PR TITLE
Fix fetch_partition_max_bytes default to 5MB in Shadowing setup

### DIFF
--- a/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
+++ b/modules/manage/pages/disaster-recovery/shadowing/setup.adoc
@@ -215,7 +215,7 @@ endif::[]
   fetch_wait_max_ms: 500              # Max time to wait for fetch requests (default: 500ms)
   fetch_min_bytes: 5242880            # Min bytes per fetch (default: 5MB)
   fetch_max_bytes: 20971520           # Max bytes per fetch (default: 20MB)
-  fetch_partition_max_bytes: 1048576  # Max bytes per partition fetch (default: 1MB)
+  fetch_partition_max_bytes: 5242880  # Max bytes per partition fetch (default: 5MB)
 
 topic_metadata_sync_options:
   interval: 30s                       # How often to sync topic metadata (examples: "30s", "1m", "5m")
@@ -731,7 +731,7 @@ client_options:
   fetch_wait_max_ms: 500              # Default 500ms, max time to wait for fetch requests
   fetch_min_bytes: 5242880            # Default 5MB, minimum bytes to fetch per request
   fetch_max_bytes: 20971520           # Default 20MB, maximum bytes to fetch per request
-  fetch_partition_max_bytes: 1048576  # Default 1MB, maximum bytes to fetch per partition
+  fetch_partition_max_bytes: 5242880  # Default 5MB, maximum bytes to fetch per partition
 ----
 
 


### PR DESCRIPTION
## Description

The Shadowing setup page's connection tuning examples listed `fetch_partition_max_bytes` as `1048576` with a "default: 1MB" comment. The actual Core default is **5 MiB (5242880 bytes)**.

Verified against Core v26.1.12:
- `proto/redpanda/core/admin/v2/shadow_link.proto`: `fetch_partition_max_bytes` — "If 0 is provided, defaults to 5 MiB"
- `src/v/cluster_link/model/types.h`: `static constexpr auto default_fetch_partition_max_bytes = 5_MiB;`

The other tuning defaults on the page (`fetch_min_bytes` 5MB, `fetch_max_bytes` 20MB, `fetch_wait_max_ms` 500ms, `connection_timeout_ms` 1000ms, `retry_backoff_ms` 100ms, `metadata_max_age_ms` 10000ms) all match the v26.1.12 protobufs.

## Page

https://docs.redpanda.com/current/manage/disaster-recovery/shadowing/setup/#connection-tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)