### PR TITLE
Document cross-namespace clusterRef for shadow links in Kubernetes

### DIFF
--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -70,10 +70,39 @@ The operator automatically resolves cluster connection details from the referenc
 +
 [NOTE]
 ====
-When using `clusterRef`, the operator handles authentication automatically using the cluster's internal credentials. For cross-namespace or external clusters, use `staticConfiguration` instead.
+When using `clusterRef`, the operator handles authentication automatically using the cluster's internal credentials. For clusters that are not managed by the same operator, use `staticConfiguration` instead.
+====
++
+By default, a `clusterRef` resolves in the same namespace as the `ShadowLink` resource. If the source and shadow clusters are managed by the same operator but deployed in different namespaces on the same Kubernetes cluster, set the `namespace` field on the source cluster's `clusterRef`:
++
+.`shadowlink.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: ShadowLink
+metadata:
+  name: disaster-recovery-link
+spec:
+  shadowCluster:
+    clusterRef:
+      name: redpanda-shadow
+  sourceCluster:
+    clusterRef:
+      name: redpanda-source
+      namespace: <source-namespace>
+  topicMetadataSyncOptions:
+    autoCreateShadowTopicFilters:
+      - name: '*'
+        filterType: include
+        patternType: literal
+----
++
+[WARNING]
+====
+Use this same-cluster, cross-namespace topology only for development and testing, such as rehearsing replication and failover on a single Kubernetes cluster. A single Kubernetes cluster is a single failure domain, so it cannot provide disaster recovery. For production, deploy the source and shadow clusters in separate Kubernetes clusters, ideally in separate cloud regions, and connect them using `staticConfiguration`.
 ====
 
-- For external or cross-namespace clusters, use `staticConfiguration`:
+- For external clusters, or clusters that are not managed by the same operator, use `staticConfiguration`:
 +
 Create a shadow link with explicit connection details:
 +


### PR DESCRIPTION
## Description

The Redpanda Operator supports an optional `namespace` field on `clusterRef` (redpanda-data/redpanda-operator#1562, backported to 26.1.x in redpanda-data/redpanda-operator#1663), which allows a `ShadowLink` to reference a source cluster in a different namespace on the same Kubernetes cluster.

This updates the Configure Shadowing in Kubernetes page (26.2) to:

- Add an example of a shadow link across namespaces on the same Kubernetes cluster using `clusterRef.namespace`.
- Warn that this same-cluster, cross-namespace topology is for development and testing only — a single Kubernetes cluster is a single failure domain, so production disaster recovery should place source and shadow clusters in separate Kubernetes clusters, ideally in separate cloud regions.
- Fix the note that previously said cross-namespace clusters require `staticConfiguration`, which is no longer the case.

## Page previews

- [Configure Shadowing in Kubernetes](https://deploy-preview-1793--redpanda-docs-preview.netlify.app/streaming/26.2/manage/kubernetes/shadowing/k-shadow-linking/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
