### PR TITLE
docs: state minimum operator version for cross-namespace shadow links

### DIFF
--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -73,7 +73,7 @@ The operator automatically resolves cluster connection details from the referenc
 When using `clusterRef`, the operator handles authentication automatically using the cluster's internal credentials. For clusters that are not managed by the same operator, use `staticConfiguration` instead.
 ====
 +
-By default, a `clusterRef` resolves in the same namespace as the `ShadowLink` resource. If the source and shadow clusters are managed by the same operator but deployed in different namespaces on the same Kubernetes cluster, set the `namespace` field on the source cluster's `clusterRef`:
+By default, a `clusterRef` resolves in the same namespace as the `ShadowLink` resource. If the source and shadow clusters are managed by the same operator but deployed in different namespaces on the same Kubernetes cluster, set the `namespace` field on the source cluster's `clusterRef`. The `namespace` field requires Redpanda Operator 26.2.1-beta.3 or later; on earlier versions, the field is silently ignored and the reference resolves in the ShadowLink's namespace.
 +
 .`shadowlink.yaml`
 [,yaml]


### PR DESCRIPTION
One-sentence follow-up to #1793 (per the review comment there): the `namespace` field on `clusterRef` exists from **operator 26.2.1-beta.3**. On beta.1/beta.2, Kubernetes silently prunes the unknown CRD field and the ShadowLink resolves the source in its own namespace — a quiet misconfiguration, so the page should state the minimum version. The 26.1 page (#1794) already carries its equivalent (v26.1.9).

Related: DOC-2274

🤖 Generated with [Claude Code](https://claude.com/claude-code)