### PR TITLE
docs: fix misleading shadow linking troubleshooting check (DOC-2231)

### DIFF
--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -800,16 +800,15 @@ kubectl describe shadowlink --namespace <shadow-namespace> <shadowlink-name>
 Helm::
 +
 --
-Verify shadow linking is enabled on both clusters:
+Verify shadow linking is enabled on the shadow cluster:
 
 [,bash]
 ----
-kubectl exec --namespace <source-namespace> <source-pod-name> --container redpanda -- \
-  rpk cluster config get enable_shadow_linking
-
 kubectl exec --namespace <shadow-namespace> <shadow-pod-name> --container redpanda -- \
   rpk cluster config get enable_shadow_linking
 ----
+
+Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bi-directional topologies.
 
 Check shadow link status for errors:
 

--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -808,7 +808,7 @@ kubectl exec --namespace <shadow-namespace> <shadow-pod-name> --container redpan
   rpk cluster config get enable_shadow_linking
 ----
 
-Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bi-directional topologies.
+Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bidirectional topologies.
 
 Check shadow link status for errors:
 


### PR DESCRIPTION
The troubleshooting section on k-shadow-linking told users to verify `enable_shadow_linking` on **both** clusters, but only the shadow (target) cluster requires it — the prerequisites partial on the same page already says so. The mismatch misleads readers and LLM assistants using the Docs MCP treat it as a debugging gotcha even when irrelevant (DOC-2231).

Now the check targets the shadow cluster only, with a sentence explaining that the source cluster needs the property only when it also acts as the shadow cluster of another link (bi-directional topologies).

Beta counterpart PR follows. Fixes DOC-2231.