### PR TITLE
docs: fix misleading shadow linking troubleshooting check (DOC-2231, beta)

### DIFF
--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -800,16 +800,15 @@ kubectl describe shadowlink --namespace <shadow-namespace> <shadowlink-name>
 Helm::
 +
 --
-Verify shadow linking is enabled on both clusters:
+Verify shadow linking is enabled on the shadow cluster:
 
 [,bash]
 ----
-kubectl exec --namespace <source-namespace> <source-pod-name> --container redpanda -- \
-  rpk cluster config get enable_shadow_linking
-
 kubectl exec --namespace <shadow-namespace> <shadow-pod-name> --container redpanda -- \
   rpk cluster config get enable_shadow_linking
 ----
+
+Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bi-directional topologies.
 
 Check shadow link status for errors:
 

--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -808,7 +808,7 @@ kubectl exec --namespace <shadow-namespace> <shadow-pod-name> --container redpan
   rpk cluster config get enable_shadow_linking
 ----
 
-Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bi-directional topologies.
+Only the shadow (target) cluster requires the `enable_shadow_linking` property. The source cluster does not require it, unless that cluster also acts as the shadow cluster of another shadow link, such as in bidirectional topologies.
 
 Check shadow link status for errors:
 


### PR DESCRIPTION
Beta counterpart of #1802: the troubleshooting check for `enable_shadow_linking` now targets only the shadow cluster, matching the prerequisites. See #1802 for details. Fixes DOC-2231.