### PR TITLE
[26.2] Improved cluster health summary

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -7,6 +7,11 @@ This topic includes new content added in version {page-component-version}. For a
 * xref:cloud-data-platform:get-started:whats-new-cloud.adoc[]
 * xref:cloud-data-platform:get-started:cloud-overview.adoc#redpanda-cloud-vs-self-managed-feature-compatibility[Redpanda Cloud vs Self-Managed feature compatibility]
 
+== Cluster health metrics
+
+Redpanda can now export a cluster health summary as Prometheus metrics, so you can alert on overall cluster health, such as brokers down, leaderless partitions, or a missing controller, directly from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`]. The metrics mirror the output of `rpk cluster health` and are disabled by default.
+
+To enable them, set xref:reference:properties/cluster-properties.adoc#health_monitor_metrics_enabled[`health_monitor_metrics_enabled`] to `true` and restart your brokers. See xref:manage:monitoring.adoc#cluster-health[Cluster health] for the available metrics and query patterns.
 
 == Kafka 4.x client compatibility
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -10,7 +10,7 @@ endif::[]
 
 This section provides guidelines and example queries using Redpanda's public metrics to optimize your system's performance and monitor its health.
 
-To help detect and mitigate anomalous system behaviors, capture baseline metrics of your healthy system at different stages (at start-up, under high load, in steady state) so you can set thresholds and alerts according to those baselines.
+To help detect and mitigate anomalous system behaviors, capture baseline metrics of your healthy system at different stages (at startup, under high load, in steady state) so you can set thresholds and alerts according to those baselines.
 
 [TIP]
 ====
@@ -432,7 +432,7 @@ ifndef::env-cloud[]
 [[cluster-health]]
 === Cluster health
 
-A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda can export this cluster health summary as a set of Prometheus metrics, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
+A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda continuously assembles these signals into a cluster health summary. Redpanda can export this summary as a set of Prometheus metrics, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
 
 These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
 
@@ -510,11 +510,11 @@ helm upgrade --install redpanda redpanda/redpanda \
 ======
 endif::[]
 
-Each broker refreshes the metrics on an interval of 10 times xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`] (100 seconds by default). Enabling the metrics increases CPU usage and network traffic, so capture a baseline before and after you turn them on.
+Each broker refreshes the metrics on an interval of 10 times xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`] (100 seconds by default). Enabling the metrics causes a modest increase in CPU usage and network traffic.
 
 ==== Available metrics
 
-Redpanda emits two groups of metrics on the public metrics endpoint, both prefixed `redpanda_cluster_health_` and reported once per broker. The freshness metrics (`redpanda_cluster_health_metadata_age_seconds` and `redpanda_cluster_health_refreshes_total`) appear as soon as you enable the feature, so you can confirm that refreshes are running. The overview metrics, which are all the others, appear on a broker once it assembles a usable view of the cluster, typically a few seconds after start-up.
+Redpanda emits two groups of metrics on the public metrics endpoint, both prefixed `redpanda_cluster_health_` and reported once per broker. The freshness metrics (`redpanda_cluster_health_metadata_age_seconds` and `redpanda_cluster_health_refreshes_total`) appear as soon as you enable the feature, so you can confirm that refreshes are running. The overview metrics, which are all the others, appear on a broker after it assembles a usable view of the cluster, typically a few seconds after startup.
 
 [cols="2a,1,3"]
 |===
@@ -565,7 +565,7 @@ This join returns a value only while some broker is the controller leader. If no
 sum(redpanda_raft_leader_for{namespace="redpanda",topic="controller",partition="0"}) == 0
 ----
 
-A controller election creates a brief window where no broker is the leader, and the joined series drops out. Use a `for` duration of at least one minute on these alerts to ride through normal elections.
+A controller election creates a brief window where no broker is the leader, and the joined series drops out. To avoid spurious alerts during these normal elections, configure the alerts to fire only after the metric has been non-zero for at least one minute (for example, with a Prometheus `for` duration of `1m`).
 endif::[]
 
 [[consumers]]

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -436,7 +436,7 @@ A healthy cluster has all brokers responding, a leader for every partition, and 
 
 These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
 
-NOTE: Cluster health metrics require Redpanda version 26.2.1 and later.
+NOTE: Cluster health metrics require Redpanda version 26.2 and later.
 
 ==== Cluster health metrics setup
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -436,9 +436,9 @@ A healthy cluster has all brokers responding, a leader for every partition, and 
 
 These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
 
-NOTE: Cluster health metrics require Redpanda version 26.2 and later.
+NOTE: Cluster health metrics require Redpanda version 26.2 or later.
 
-==== Cluster health metrics setup
+==== Enable cluster health metrics
 
 Set xref:reference:properties/cluster-properties.adoc#health_monitor_metrics_enabled[`health_monitor_metrics_enabled`] to `true`. This property requires a broker restart to take effect.
 
@@ -514,19 +514,19 @@ Each broker refreshes the metrics on an interval of 10 times xref:reference:prop
 
 ==== Available metrics
 
-Redpanda emits two groups of metrics, both prefixed `redpanda_cluster_health_` on the public metrics endpoint and reported once per broker. The overview metrics appear on a broker as soon as it assembles a usable view of the cluster, typically a few seconds after start-up.
+Redpanda emits two groups of metrics on the public metrics endpoint, both prefixed `redpanda_cluster_health_` and reported once per broker. The freshness metrics (`redpanda_cluster_health_metadata_age_seconds` and `redpanda_cluster_health_refreshes_total`) appear as soon as you enable the feature, so you can confirm that refreshes are running. The overview metrics, which are all the others, appear on a broker once it assembles a usable view of the cluster, typically a few seconds after start-up.
 
 [cols="2a,1,3"]
 |===
 |Metric |Type |Description
 
-|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_unhealthy_reasons[`redpanda_cluster_health_unhealthy_reasons`] |gauge |Number of reasons the cluster is currently unhealthy. `0` means healthy.
-|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_elected_controller[`redpanda_cluster_health_no_elected_controller`] |gauge |`1` if no controller is elected, otherwise `0`.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_unhealthy_reasons[`redpanda_cluster_health_unhealthy_reasons`] |gauge |Number of reasons the cluster is currently unhealthy. A value of `0` means healthy.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_elected_controller[`redpanda_cluster_health_no_elected_controller`] |gauge |Reports `1` if no controller is elected, otherwise `0`.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_down[`redpanda_cluster_health_nodes_down`] |gauge |Number of brokers not responding to liveness checks.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_leaderless_partitions[`redpanda_cluster_health_leaderless_partitions`] |gauge |Number of partitions without a leader.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_under_replicated_partitions[`redpanda_cluster_health_under_replicated_partitions`] |gauge |Number of partitions that are not fully replicated.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_high_disk_usage_nodes[`redpanda_cluster_health_high_disk_usage_nodes`] |gauge |Number of brokers past the storage-space alert threshold.
-|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_health_report[`redpanda_cluster_health_no_health_report`] |gauge |`1` if the most recent refresh attempt failed, otherwise `0`.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_health_report[`redpanda_cluster_health_no_health_report`] |gauge |Reports `1` if the most recent refresh attempt failed, otherwise `0`.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_cluster_size[`redpanda_cluster_health_cluster_size`] |gauge |Number of known cluster members. Informational.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_in_recovery_mode[`redpanda_cluster_health_nodes_in_recovery_mode`] |gauge |Number of brokers in recovery mode. Informational; does not affect the health verdict.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_bytes_in_cloud_storage[`redpanda_cluster_health_bytes_in_cloud_storage`] |gauge |Bytes stored in object storage. Informational; `0` if Tiered Storage isn't enabled.
@@ -565,7 +565,7 @@ This join returns a value only while some broker is the controller leader. If no
 sum(redpanda_raft_leader_for{namespace="redpanda",topic="controller",partition="0"}) == 0
 ----
 
-During a controller election there is a brief window where no broker is the leader and the joined series drops out. Use a `for` duration of at least one minute on these alerts to ride through normal elections.
+A controller election creates a brief window where no broker is the leader, and the joined series drops out. Use a `for` duration of at least one minute on these alerts to ride through normal elections.
 endif::[]
 
 [[consumers]]

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -428,6 +428,146 @@ Leaderless partitions can be caused by unresponsive brokers. When an alert on `r
 
 Redpanda's Raft implementation exchanges periodic status RPCs between a broker and its peers. The xref:reference:public-metrics-reference.adoc#redpanda_node_status_rpcs_timed_out[`redpanda_node_status_rpcs_timed_out`] gauge increases when a status RPC times out for a peer, which indicates that a peer may be unresponsive and may lead to problems with partition replication that Raft manages. Monitor for non-zero values of this gauge, and correlate it with any logged errors or changes in partition replication.
 
+ifndef::env-cloud[]
+[[cluster-health]]
+=== Cluster health
+
+A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda can export this cluster health summary as a set of Prometheus metrics, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
+
+These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
+
+NOTE: Cluster health metrics require Redpanda version 26.2.1 and later.
+
+==== Cluster health metrics setup
+
+Set xref:reference:properties/cluster-properties.adoc#health_monitor_metrics_enabled[`health_monitor_metrics_enabled`] to `true`. This property requires a broker restart to take effect.
+
+ifndef::env-kubernetes[]
+[,bash]
+----
+rpk cluster config set health_monitor_metrics_enabled true
+----
+endif::[]
+
+ifdef::env-kubernetes[]
+[tabs]
+======
+Helm + Operator::
++
+--
+.`redpanda-cluster.yaml`
+[,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha2
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    config:
+      cluster:
+        health_monitor_metrics_enabled: true
+----
+
+```bash
+kubectl apply -f redpanda-cluster.yaml --namespace <namespace>
+```
+
+--
+Helm::
++
+--
+[tabs]
+====
+--values::
++
+.`health-metrics.yaml`
+[,yaml]
+----
+config:
+  cluster:
+    health_monitor_metrics_enabled: true
+----
++
+```bash
+helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --create-namespace \
+--values health-metrics.yaml --reuse-values
+```
+
+--set::
++
+[,bash]
+----
+helm upgrade --install redpanda redpanda/redpanda \
+  --namespace <namespace> \
+  --create-namespace \
+  --set config.cluster.health_monitor_metrics_enabled=true
+----
+
+====
+--
+======
+endif::[]
+
+Each broker refreshes the metrics on an interval of 10 times xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`] (100 seconds by default). Enabling the metrics increases CPU usage and network traffic, so capture a baseline before and after you turn them on.
+
+==== Available metrics
+
+Redpanda emits two groups of metrics, both prefixed `redpanda_cluster_health_` on the public metrics endpoint and reported once per broker. The overview metrics appear on a broker as soon as it assembles a usable view of the cluster, typically a few seconds after start-up.
+
+[cols="2a,1,3"]
+|===
+|Metric |Type |Description
+
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_unhealthy_reasons[`redpanda_cluster_health_unhealthy_reasons`] |gauge |Number of reasons the cluster is currently unhealthy. `0` means healthy.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_elected_controller[`redpanda_cluster_health_no_elected_controller`] |gauge |`1` if no controller is elected, otherwise `0`.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_down[`redpanda_cluster_health_nodes_down`] |gauge |Number of brokers not responding to liveness checks.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_leaderless_partitions[`redpanda_cluster_health_leaderless_partitions`] |gauge |Number of partitions without a leader.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_under_replicated_partitions[`redpanda_cluster_health_under_replicated_partitions`] |gauge |Number of partitions that are not fully replicated.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_high_disk_usage_nodes[`redpanda_cluster_health_high_disk_usage_nodes`] |gauge |Number of brokers past the storage-space alert threshold.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_health_report[`redpanda_cluster_health_no_health_report`] |gauge |`1` if the most recent refresh attempt failed, otherwise `0`.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_cluster_size[`redpanda_cluster_health_cluster_size`] |gauge |Number of known cluster members. Informational.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_in_recovery_mode[`redpanda_cluster_health_nodes_in_recovery_mode`] |gauge |Number of brokers in recovery mode. Informational; does not affect the health verdict.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_bytes_in_cloud_storage[`redpanda_cluster_health_bytes_in_cloud_storage`] |gauge |Bytes stored in object storage. Informational; `0` if Tiered Storage isn't enabled.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_metadata_age_seconds[`redpanda_cluster_health_metadata_age_seconds`] |gauge |Seconds since the last successful refresh on the broker. Reports a very large value before the first refresh so that staleness alerts fire.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_refreshes_total[`redpanda_cluster_health_refreshes_total`] |counter |Number of successful refreshes on the broker.
+|===
+
+NOTE: The informational metrics (`cluster_size`, `nodes_in_recovery_mode`, and `bytes_in_cloud_storage`) don't affect whether the cluster is considered healthy.
+
+==== Metric aggregation across brokers
+
+Every broker exposes its own copy of these metrics, so decide how to combine them.
+
+Aggregate across all brokers, for example with `max()`:
+
+[,promql]
+----
+max(redpanda_cluster_health_nodes_down)
+----
+
+Use `max()`, not `sum()`. Every broker reports its own copy, so `sum()` returns roughly the broker count times the real value. Aggregation is fine for coarse cluster-health alerting, but it's noisier during controller elections and broker restarts, and a stale or partitioned broker still contributes its last cached view.
+
+For a lower-noise signal, read the metric only from the current controller leader by joining against the Raft `leader_for` gauge for the controller partition:
+
+[,promql]
+----
+redpanda_cluster_health_unhealthy_reasons
+  and on(instance)
+    redpanda_raft_leader_for{namespace="redpanda",topic="controller",partition="0"} == 1
+----
+
+This join returns a value only while some broker is the controller leader. If no broker is the leader, for example when the cluster has no controller at all, the query returns an empty result, which an alert configured to fire above zero would not catch. Pair the join with a separate alert that fires when no broker reports itself as the controller leader:
+
+[,promql]
+----
+sum(redpanda_raft_leader_for{namespace="redpanda",topic="controller",partition="0"}) == 0
+----
+
+During a controller election there is a brief window where no broker is the leader and the joined series drops out. Use a `for` duration of at least one minute on these alerts to ride through normal elections.
+endif::[]
+
 [[consumers]]
 === Consumer group lag
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -432,7 +432,7 @@ ifndef::env-cloud[]
 [[cluster-health]]
 === Cluster health
 
-A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda continuously assembles these signals into a cluster health summary. Redpanda can export this summary as a set of Prometheus metrics, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
+A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda continuously assembles these signals into a cluster health summary. Redpanda can export this summary as a set of <<available-metrics,Prometheus metrics>>, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
 
 These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -510,7 +510,7 @@ helm upgrade --install redpanda redpanda/redpanda \
 ======
 endif::[]
 
-Each broker refreshes the metrics on an interval of 10 times xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`] (100 seconds by default). Enabling the metrics causes a modest increase in CPU usage and network traffic.
+By default, each broker refreshes the metrics every 100 seconds. This interval is 10 times the value of xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`]. Enabling the metrics causes a modest increase in CPU usage and network traffic.
 
 ==== Available metrics
 

--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -510,7 +510,7 @@ helm upgrade --install redpanda redpanda/redpanda \
 ======
 endif::[]
 
-By default, each broker refreshes the metrics every 100 seconds. This interval is 10 times the value of xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`]. Enabling the metrics causes a modest increase in CPU usage and network traffic.
+By default, each broker refreshes the metrics every 100 seconds (10 times the value of xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`]). Enabling the metrics causes a modest increase in CPU usage and network traffic.
 
 ==== Available metrics
 
@@ -520,6 +520,8 @@ Redpanda emits two groups of metrics on the public metrics endpoint, both prefix
 |===
 |Metric |Type |Description
 
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_metadata_age_seconds[`redpanda_cluster_health_metadata_age_seconds`] |gauge |Seconds since the last successful refresh on the broker. Reports a very large value before the first refresh so that staleness alerts fire.
+|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_refreshes_total[`redpanda_cluster_health_refreshes_total`] |counter |Number of successful refreshes on the broker.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_unhealthy_reasons[`redpanda_cluster_health_unhealthy_reasons`] |gauge |Number of reasons the cluster is currently unhealthy. A value of `0` means healthy.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_no_elected_controller[`redpanda_cluster_health_no_elected_controller`] |gauge |Reports `1` if no controller is elected, otherwise `0`.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_down[`redpanda_cluster_health_nodes_down`] |gauge |Number of brokers not responding to liveness checks.
@@ -530,8 +532,6 @@ Redpanda emits two groups of metrics on the public metrics endpoint, both prefix
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_cluster_size[`redpanda_cluster_health_cluster_size`] |gauge |Number of known cluster members. Informational.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_nodes_in_recovery_mode[`redpanda_cluster_health_nodes_in_recovery_mode`] |gauge |Number of brokers in recovery mode. Informational; does not affect the health verdict.
 |xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_bytes_in_cloud_storage[`redpanda_cluster_health_bytes_in_cloud_storage`] |gauge |Bytes stored in object storage. Informational; `0` if Tiered Storage isn't enabled.
-|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_metadata_age_seconds[`redpanda_cluster_health_metadata_age_seconds`] |gauge |Seconds since the last successful refresh on the broker. Reports a very large value before the first refresh so that staleness alerts fire.
-|xref:reference:public-metrics-reference.adoc#redpanda_cluster_health_refreshes_total[`redpanda_cluster_health_refreshes_total`] |counter |Number of successful refreshes on the broker.
 |===
 
 NOTE: The informational metrics (`cluster_size`, `nodes_in_recovery_mode`, and `bytes_in_cloud_storage`) don't affect whether the cluster is considered healthy.

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -92,6 +92,104 @@ endif::[]
 
 ---
 
+ifndef::env-cloud[]
+=== redpanda_cluster_health_bytes_in_cloud_storage
+
+Bytes stored in object storage. Informational; `0` if Tiered Storage isn't enabled.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_cluster_size
+
+Number of known cluster members. Informational.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_high_disk_usage_nodes
+
+Number of brokers past the storage-space alert threshold.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_leaderless_partitions
+
+Number of partitions without a leader.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_metadata_age_seconds
+
+Seconds since the last successful refresh on the broker. Reports a very large value before the first refresh so that staleness alerts fire.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_no_elected_controller
+
+`1` if no controller is elected, otherwise `0`.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_no_health_report
+
+`1` if the most recent refresh attempt failed, otherwise `0`.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_nodes_down
+
+Number of brokers not responding to liveness checks.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_nodes_in_recovery_mode
+
+Number of brokers in recovery mode. Informational; does not affect the health verdict.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_refreshes_total
+
+Number of successful refreshes on the broker.
+
+*Type*: counter
+
+---
+
+=== redpanda_cluster_health_under_replicated_partitions
+
+Number of partitions that are not fully replicated.
+
+*Type*: gauge
+
+---
+
+=== redpanda_cluster_health_unhealthy_reasons
+
+Number of reasons the cluster is currently unhealthy. `0` means healthy.
+
+*Type*: gauge
+
+---
+endif::[]
+
 === redpanda_cluster_latest_cluster_metadata_manifest_age
 
 The amount of time in seconds since the last time Redpanda uploaded metadata files to Tiered Storage for your cluster. A value of `0` indicates metadata has not yet been uploaded.

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -135,7 +135,7 @@ Seconds since the last successful refresh on the broker. Reports a very large va
 
 === redpanda_cluster_health_no_elected_controller
 
-`1` if no controller is elected, otherwise `0`.
+Reports `1` if no controller is elected, otherwise `0`.
 
 *Type*: gauge
 
@@ -143,7 +143,7 @@ Seconds since the last successful refresh on the broker. Reports a very large va
 
 === redpanda_cluster_health_no_health_report
 
-`1` if the most recent refresh attempt failed, otherwise `0`.
+Reports `1` if the most recent refresh attempt failed, otherwise `0`.
 
 *Type*: gauge
 
@@ -183,7 +183,7 @@ Number of partitions that are not fully replicated.
 
 === redpanda_cluster_health_unhealthy_reasons
 
-Number of reasons the cluster is currently unhealthy. `0` means healthy.
+Number of reasons the cluster is currently unhealthy. A value of `0` means healthy.
 
 *Type*: gauge
 

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-health.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-health.adoc
@@ -13,6 +13,13 @@ A cluster is considered healthy when the following conditions are met:
 * All partitions have leaders
 * The cluster controller is present
 
+ifndef::env-cloud[]
+[NOTE]
+====
+The same health fields are also available as Prometheus metrics. See xref:manage:monitoring.adoc#cluster-health[Cluster health] for how to enable and query them.
+====
+endif::[]
+
 == Usage
 
 [,bash]


### PR DESCRIPTION
## Description

This pull request updates the Redpanda release notes to document new features and configuration options, most notably the addition of cluster health metrics export as Prometheus metrics. It also removes several older release note sections and details on new configuration properties, streamlining the release notes and focusing on the most impactful changes.

**New Feature Documentation:**

* Added a section on cluster health metrics, describing how Redpanda can now export a cluster health summary as Prometheus metrics for alerting on cluster health issues (e.g., brokers down, leaderless partitions, missing controller) without polling `rpk cluster health`. The metrics mirror `rpk cluster health` output and are disabled by default.
* Provided instructions for enabling cluster health metrics by setting the `health_monitor_metrics_enabled` property and restarting brokers, with a reference to the documentation for available metrics and query examples.

**Release Notes Streamlining:**

* Removed detailed sections and descriptions for multiple features, configuration properties, and changes to default values, focusing the release notes on the most significant new feature (cluster health metrics).

Resolves https://redpandadata.atlassian.net/browse/DOC-2016
Review deadline: 23 July

## Page previews

- [What's New in Redpanda](https://deploy-preview-1805--redpanda-docs-preview.netlify.app/streaming/26.2/get-started/release-notes/redpanda/) (updated)
- [Public Metrics](https://deploy-preview-1805--redpanda-docs-preview.netlify.app/streaming/26.2/reference/public-metrics-reference/) (updated)
- [rpk cluster health](https://deploy-preview-1805--redpanda-docs-preview.netlify.app/streaming/26.2/reference/rpk/rpk-cluster/rpk-cluster-health/) (updated)
- [Monitor Redpanda: Cluster health](https://deploy-preview-1805--redpanda-docs-preview.netlify.app/streaming/26.2/manage/monitoring/#cluster-health) (updated) — where the new Cluster health section renders

_Preview links resolve once the Netlify build for this PR completes._

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

