### PR TITLE
docs: add 26.2 to the Kubernetes compatibility matrix

### DIFF
--- a/modules/upgrade/pages/k-compatibility.adoc
+++ b/modules/upgrade/pages/k-compatibility.adoc
@@ -37,15 +37,35 @@ Redpanda Core has no direct dependency on Kubernetes. Compatibility is influence
 |===
 |Redpanda Core / `rpk` |Helm Chart |Operator Helm Chart |Operator |Helm CLI |Kubernetes
 
-.2+|26.1.x
+.2+|26.2.x
+
+|26.2.x
+|26.2.x
+|26.2.x
+|3.12+
+// d (default) on Kubernetes cells is required to render footnotes at the
+// bottom of the page rather than inside the table cell.
+// See https://github.com/asciidoctor/asciidoctor/issues/2350#issuecomment-546841684
+d|1.33.x - 1.36.x{fn-k8s-compatibility}
 
 |26.1.x
 |26.1.x
 |26.1.x
 |3.12+
-// d (default) on Kubernetes cells is required to render footnotes at the
-// bottom of the page rather than inside the table cell.
-// See https://github.com/asciidoctor/asciidoctor/issues/2350#issuecomment-546841684
+d|1.32.x - 1.35.x{fn-k8s-compatibility}
+
+.3+|26.1.x
+
+|26.2.x
+|26.2.x
+|26.2.x
+|3.12+
+d|1.32.x - 1.35.x{fn-k8s-compatibility}
+
+|26.1.x
+|26.1.x
+|26.1.x
+|3.12+
 d|1.32.x - 1.35.x{fn-k8s-compatibility}
 
 |25.3.x


### PR DESCRIPTION
Adds the 26.2 rows to the compatibility matrix ahead of GA (July 28):

- New `26.2.x` core block: 26.2.x chart/operator supports **Kubernetes 1.33.x - 1.36.x** (per engineering; see the discussion on the Pipeline CRD PR where testing on 1.28 produced a false blocker), plus a 26.1.x chart row.
- The `26.1.x` core block gains a 26.2.x chart row, following the plus-or-minus-one-minor support policy and the pattern used when 26.1 was added (the 25.3 block lists the 26.1 chart).

The Kubernetes ranges on cross-version rows follow the existing convention in the table (the row keeps the older component's tested range).

**Reviewer check requested**: please confirm the 1.33.x - 1.36.x range with the K8s team (David/Rafal) before merge; the source is David's statement that operator 26.2.x will support 1.33-1.36.

Related: #1681 and #1787 now reference this matrix instead of hardcoding technical-floor versions (1.28/1.31).

## Preview pages

- [Kubernetes Compatibility](https://deploy-preview-1811--redpanda-docs-preview.netlify.app/streaming/26.2/upgrade/k-compatibility/) (updated)
