### PR TITLE
docs: ShadowLink schema replication and role sync on Kubernetes (DOC-2333)

### DIFF
--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -100,6 +100,8 @@ spec:
 [WARNING]
 ====
 Use this same-cluster, cross-namespace topology only for development and testing, such as rehearsing replication and failover on a single Kubernetes cluster. A single Kubernetes cluster is a single failure domain, so it cannot provide disaster recovery. For production, deploy the source and shadow clusters in separate Kubernetes clusters, ideally in separate cloud regions, and connect them using `staticConfiguration`.
+
+When two Redpanda clusters run on the same Kubernetes cluster with default values, their external listeners collide on the same node ports and the second cluster fails to deploy with `provided port is already allocated`. Disable external access on at least one of the clusters with `external.enabled: false`, or assign non-overlapping node ports.
 ====
 
 - For external clusters, or clusters that are not managed by the same operator, use `staticConfiguration`:
@@ -485,6 +487,106 @@ security_sync_options:
 --
 ======
 
+== Configure schema replication
+
+A shadow link replicates Schema Registry data from the source cluster by default. Choose one of three modes with `schema_registry_shadowing_mode`:
+
+* `topic` (default): Shadow the source Redpanda cluster's internal `_schemas` topic byte for byte. Use this mode when the source is another Redpanda cluster.
+* `api`: Replicate schemas from the source Schema Registry over its REST API. Use this mode when the source is a Confluent Schema Registry, or when you need to filter contexts or subjects, remap contexts, or control how unsupported schema features are handled. For concepts, the migration workflow, and validation policies, see xref:manage:disaster-recovery/shadowing/migrate-schemas-confluent.adoc[].
+* `disabled`: Turn schema replication off.
+
+This example replicates schemas from a Confluent Schema Registry, with the API key and secret stored in a Kubernetes Secret named `sr-credentials`:
+
+[tabs]
+======
+Operator::
++
+--
+[,yaml]
+----
+spec:
+  schemaRegistrySyncOptions:
+    schema_registry_shadowing_mode: api
+    shadowSchemaRegistryAPI:
+      sourceURL: https://psrc-xxxxx.us-east-1.aws.confluent.cloud
+      authentication:
+        basic:
+          username:
+            secretKeyRef:
+              name: sr-credentials
+              key: api-key
+          password:
+            secretKeyRef:
+              name: sr-credentials
+              key: api-secret
+----
+
+For source filters, destination context mappings, sync intervals, and the unsupported-schema policy, see the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[ShadowLinkSchemaRegistryAPIOptions] reference.
+--
+
+Helm::
++
+--
+[,yaml]
+----
+# shadow-config.yaml
+schema_registry_sync_options:
+  shadow_schema_registry_api:
+    source_url: https://psrc-xxxxx.us-east-1.aws.confluent.cloud
+    auth_options:
+      basic:
+        username: <sr-api-key>
+        password: <sr-api-secret>
+    tls_settings:
+      enabled: true
+----
+--
+======
+
+NOTE: While the link is active, the destination contexts that the link replicates into are read-only on the shadow cluster. Schema replication in `api` mode requires Redpanda 26.2 or later, and the feature activates only after all brokers complete the upgrade.
+
+== Configure role synchronization
+
+A shadow link replicates RBAC role definitions and role memberships from the source cluster by default, so that role-based permissions keep working after failover. Use role synchronization together with <<Configure ACL synchronization,ACL synchronization>> when your authorization model uses roles.
+
+[tabs]
+======
+Operator::
++
+--
+[,yaml]
+----
+spec:
+  roleSyncOptions:
+    enabled: true
+    interval: 30s
+    roleNameFilters:
+      - name: "*"
+        filterType: include
+        patternType: literal
+----
+
+Set `enabled: false` to turn role replication off. Role name filters use the same pattern and filter types as topic filters.
+--
+
+Helm::
++
+--
+[,yaml]
+----
+# shadow-config.yaml
+role_sync_options:
+  interval: 30s
+  role_name_filters:
+    - pattern_type: LITERAL
+      filter_type: INCLUDE
+      name: '*'
+----
+--
+======
+
+Within the configured filters, the shadow cluster's roles are kept as a full mirror of the source: roles are created, updated, and deleted to match. Role synchronization requires Redpanda 26.2 or later on both clusters, and the feature activates only after all brokers complete the upgrade.
+
 == Verify shadow link
 
 [tabs]
@@ -504,13 +606,15 @@ The status section shows replication details:
 [,yaml]
 ----
 status:
+  state: active
   conditions:
-    - type: Ready
+    - type: Synced
       status: "True"
-      lastTransitionTime: "2024-12-10T10:00:00Z"
-      reason: ReconciliationSucceeded
-      message: Shadow link is active and replicating
-  observedGeneration: 1
+      reason: Synced
+      message: Successfully synced "disaster-recovery-link" to cluster.
+  shadowTopicStatuses:
+    - name: orders
+      state: active
 ----
 
 Verify replication:

--- a/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
+++ b/modules/manage/pages/kubernetes/shadowing/k-shadow-linking.adoc
@@ -519,6 +519,10 @@ spec:
             secretKeyRef:
               name: sr-credentials
               key: api-secret
+      tls:
+        enabled: true  # Confluent Cloud serves publicly issued certificates, so no CA is needed.
+  roleSyncOptions:
+    enabled: false     # Role synchronization requires a Redpanda source. See the next section.
 ----
 
 For source filters, destination context mappings, sync intervals, and the unsupported-schema policy, see the xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[ShadowLinkSchemaRegistryAPIOptions] reference.
@@ -543,11 +547,13 @@ schema_registry_sync_options:
 --
 ======
 
-NOTE: While the link is active, the destination contexts that the link replicates into are read-only on the shadow cluster. Schema replication in `api` mode requires Redpanda 26.2 or later, and the feature activates only after all brokers complete the upgrade.
+NOTE: While the link is active, the destination contexts that the link replicates into are read-only on the shadow cluster. Pausing the schema sync task (`paused: true` on `shadowSchemaRegistryAPI`) stops replication and lifts this write protection. Schema replication in `api` mode requires Redpanda 26.2 or later, and the feature activates only after all brokers complete the upgrade.
 
 == Configure role synchronization
 
 A shadow link replicates RBAC role definitions and role memberships from the source cluster by default, so that role-based permissions keep working after failover. Use role synchronization together with <<Configure ACL synchronization,ACL synchronization>> when your authorization model uses roles.
+
+Role synchronization requires a Redpanda source cluster. When the source is not a Redpanda cluster, such as a Confluent cluster, set `enabled: false`: against a non-Redpanda source, the role sync task cannot query roles and reports `LINK_UNAVAILABLE`, even though the rest of the shadow link keeps operating.
 
 [tabs]
 ======
@@ -566,7 +572,7 @@ spec:
         patternType: literal
 ----
 
-Set `enabled: false` to turn role replication off. Role name filters use the same pattern and filter types as topic filters.
+This block is optional and shows the defaults: role synchronization is on even when you omit `roleSyncOptions` entirely. Set `enabled: false` to turn role replication off. Role name filters use the same pattern and filter types as topic filters.
 --
 
 Helm::

--- a/modules/reference/pages/k-crd.adoc
+++ b/modules/reference/pages/k-crd.adoc
@@ -10,9 +10,11 @@
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-console[$$Console$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-group[$$Group$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpanda[$$Redpanda$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandabrokerpool[$$RedpandaBrokerPool$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandarole[$$RedpandaRole$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-schema[$$Schema$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlink[$$ShadowLink$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchcluster[$$StretchCluster$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-topic[$$Topic$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-user[$$User$$]
 
@@ -280,6 +282,7 @@ Auth configures authentication in the Helm values. See xref:manage:kubernetes/se
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -389,6 +392,7 @@ CPU configures CPU resources for containers. See xref:manage:kubernetes/manage-r
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-resources[$$Resources$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchresources[$$StretchResources$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -586,6 +590,7 @@ Config configures Redpanda config properties supported by Redpanda that may not 
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -962,6 +967,7 @@ CredentialSecretRef can be used to set cloud_storage_secret_key from referenced 
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtiered[$$StretchTiered$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-tiered[$$Tiered$$]
 
 [cols="25a,75a", options="header"]
@@ -1004,6 +1010,10 @@ on remote Kubernetes clusters.
 |===
 
 
+
+
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-enterprise"]
 == Enterprise 
 
@@ -1013,6 +1023,7 @@ Enterprise configures an Enterprise license key to enable Redpanda Enterprise fe
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -1050,6 +1061,7 @@ External defines external connectivity settings in the Helm values.
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -1477,6 +1489,7 @@ InitContainerImage configures the init container image used to perform initial s
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-statefulset[$$Statefulset$$]
 
 [cols="25a,75a", options="header"]
@@ -1853,6 +1866,7 @@ Memory configures memory resources.
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-resources[$$Resources$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchresources[$$StretchResources$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -1889,6 +1903,7 @@ Monitoring configures monitoring resources for Redpanda. See xref:manage:kuberne
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -1950,6 +1965,22 @@ and `patternType` must be `literal` +
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-networking"]
+== Networking 
+
+Networking configures cross-cluster networking for stretch clusters.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`crossClusterMode`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-crossclustermode[$$CrossClusterMode$$]__ | CrossClusterMode controls how per-pod Services route traffic to pods +
+on remote Kubernetes clusters. Defaults to "mesh". +
+|===
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-oidcloginsecrets"]
@@ -2060,6 +2091,8 @@ PersistentVolume configures configurations for a PersistentVolumeClaim to use to
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-storage[$$Storage$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchstorage[$$StretchStorage$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtiered[$$StretchTiered$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-tiered[$$Tiered$$]
 
 [cols="25a,75a", options="header"]
@@ -2102,6 +2135,7 @@ PodTemplate will pass label and annotation to Statefulset Pod template.
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-postinstalljob[$$PostInstallJob$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-postupgradejob[$$PostUpgradeJob$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-statefulset[$$Statefulset$$]
@@ -2150,6 +2184,23 @@ PodTemplate will pass label and annotation to Statefulset Pod template.
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-poolinitcontainers"]
+== PoolInitContainers 
+
+
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`fsValidator`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-poolfsvalidator[$$PoolFSValidator$$]__ | 
+| *`setDataDirOwnership`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-poolsetdatadirownership[$$PoolSetDataDirOwnership$$]__ | 
+| *`configurator`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-poolconfigurator[$$PoolConfigurator$$]__ | 
+|===
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-poolsetdatadirownership"]
@@ -2246,6 +2297,7 @@ RBAC configures role-based access control (RBAC).
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -2310,6 +2362,7 @@ RackAwareness configures rack awareness in the Helm values. See xref:manage:kube
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -2389,6 +2442,34 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 | *`tlsCa`* __string__ | 
 | *`tlsCert`* __string__ | 
 | *`tlsKey`* __string__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandabrokerpool"]
+== RedpandaBrokerPool 
+
+
+
+
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `cluster.redpanda.com/v1alpha2`
+| *`kind`* __string__ | `RedpandaBrokerPool`
+| *`kind`* __string__ | Kind is a string value representing the REST resource this object represents. +
+Servers may infer this from the endpoint the client submits requests to. +
+Cannot be updated. +
+In CamelCase. +
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds +
+| *`apiVersion`* __string__ | APIVersion defines the versioned schema of this representation of an object. +
+Servers should convert recognized schemas to the latest internal value, and +
+may reject unrecognized values. +
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources +
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to the Kubernetes API documentation for fields of `metadata`.
+
 |===
 
 
@@ -2558,10 +2639,12 @@ RedpandaImage configures the Redpanda container image settings in the Helm value
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-rpcontrollers[$$RPControllers$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaconnectors[$$RedpandaConnectors$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-sidecars[$$SideCars$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -2581,6 +2664,7 @@ RedpandaImage configures the Redpanda container image settings in the Helm value
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandastatus[$$RedpandaStatus$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterstatus[$$StretchClusterStatus$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -3256,6 +3340,7 @@ ServiceAccount configures Service Accounts.
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -4044,6 +4129,489 @@ Storage configures storage-related settings in the Helm values. See xref:manage:
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener"]
+== StretchAPIListener 
+
+StretchAPIListener configures an API listener (Admin, HTTP, Kafka, SchemaRegistry)
+for stretch clusters.
+
+
+Collapsed from Admin, HTTP, Kafka, SchemaRegistry — all identical after removing
+deprecated KafkaEndpoint field from HTTP and SchemaRegistry (was not respected)
+and deprecated SecretRef from ListenerTLS (had no effect).
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlisteners[$$StretchListeners$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Specifies whether this Listener is enabled. +
+| *`authenticationMethod`* __string__ | Specifies the authentication method for this listener. +
+| *`appProtocol`* __string__ | 
+| *`port`* __integer__ | Specifies the container port number for this listener. +
+| *`tls`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls[$$StretchListenerTLS$$]__ | Configures TLS settings for the internal listener. +
+| *`prefixTemplate`* __string__ | Specifies the template used for generating the advertised addresses of Services. +
+| *`external`* __object (keys:string, values:xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchexternallistener[$$StretchExternalListener$$])__ | Defines settings for the external listeners. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchauditlogging"]
+== StretchAuditLogging 
+
+StretchAuditLogging configures how to perform audit logging for a redpanda cluster
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Specifies whether to enable audit logging or not +
+| *`partitions`* __integer__ | Integer value defining the number of partitions used by a newly created audit topic +
+| *`enabledEventTypes`* __string array__ | Event types that should be captured by audit logs +
+| *`excludedTopics`* __string array__ | List of topics to exclude from auditing +
+| *`excludedPrincipals`* __string array__ | List of principals to exclude from auditing +
+| *`clientMaxBufferSize`* __integer__ | Defines the number of bytes (in bytes) allocated by the internal audit client for audit messages. +
+| *`queueDrainIntervalMs`* __integer__ | In ms, frequency in which per shard audit logs are batched to client for write to audit log. +
+| *`queueMaxBufferSizePerShard`* __integer__ | Defines the maximum amount of memory used (in bytes) by the audit buffer in each shard +
+| *`replicationFactor`* __integer__ | Defines the replication factor for a newly created audit log topic. This configuration applies +
+only to the audit log topic and may be different from the cluster or other topic configurations. +
+This cannot be altered for existing audit log topics. Setting this value is optional. If a value is not provided, +
+Redpanda will use the `internal_topic_replication_factor` cluster config value. Default is `null` +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchcluster"]
+== StretchCluster 
+
+StretchCluster defines the CRD for StretchCluster configuration.
+
+
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `cluster.redpanda.com/v1alpha2`
+| *`kind`* __string__ | `StretchCluster`
+| *`kind`* __string__ | Kind is a string value representing the REST resource this object represents. +
+Servers may infer this from the endpoint the client submits requests to. +
+Cannot be updated. +
+In CamelCase. +
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds +
+| *`apiVersion`* __string__ | APIVersion defines the versioned schema of this representation of an object. +
+Servers should convert recognized schemas to the latest internal value, and +
+may reject unrecognized values. +
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources +
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to the Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterstatus[$$StretchClusterStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec"]
+== StretchClusterSpec 
+
+
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchcluster[$$StretchCluster$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`commonLabels`* __object (keys:string, values:string)__ | Assigns custom labels to all resources generated by the operator. Specify labels as key/value pairs. +
+| *`image`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaimage[$$RedpandaImage$$]__ | Defines the container image settings to use for the Redpanda cluster. +
+| *`imagePullSecrets`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ | Specifies credentials for a private image repository. For details, see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/. +
+| *`enterprise`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-enterprise[$$Enterprise$$]__ | Defines an Enterprise license. +
+| *`auth`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-auth[$$Auth$$]__ | Defines authentication settings for listeners. +
+| *`logging`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlogging[$$StretchLogging$$]__ | Defines the log level settings. +
+| *`auditLogging`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchauditlogging[$$StretchAuditLogging$$]__ | Defines audit logging settings. +
+| *`resources`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchresources[$$StretchResources$$]__ | Defines container resource settings. +
+| *`storage`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchstorage[$$StretchStorage$$]__ | Defines storage settings for the Redpanda data directory and the Tiered Storage cache. +
+| *`tuning`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtuning[$$StretchTuning$$]__ | Defines settings for the autotuner tool in Redpanda. +
+| *`config`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-config[$$Config$$]__ | Defines configuration properties supported by Redpanda. +
+| *`networking`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-networking[$$Networking$$]__ | Defines cross-cluster networking settings. +
+| *`internalServiceAnnotations`* __object (keys:string, values:string)__ | InternalServiceAnnotations is applied to the headless ClusterIP +
+Service rendered for each member K8s cluster. The headless Service is +
+cluster-wide (one per K8s cluster, not per NodePool), so its +
+annotations live on StretchCluster.spec rather than on individual +
+pools. Typical use: annotations consumed by other operators or +
+controllers in the same cluster (DNS controllers, service-mesh +
+sidecars, etc.) that need to attach to the headless Service. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterstatus"]
+== StretchClusterStatus 
+
+
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchcluster[$$StretchCluster$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`conditions`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta[$$Condition$$] array__ | Conditions holds the conditions for the StretchCluster. +
+| *`configVersion`* __string__ | ConfigVersion contains the configuration version written in +
+Redpanda used for restarting broker nodes as necessary. +
+| *`license`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandalicensestatus[$$RedpandaLicenseStatus$$]__ | LicenseStatus contains information about the current state of any +
+installed license in the Redpanda cluster. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchexternallistener"]
+== StretchExternalListener 
+
+StretchExternalListener configures an external listener in stretch clusters.
+
+
+Forked from ExternalListener: embeds StretchListener instead of Listener.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Specifies whether this Listener is enabled. +
+| *`authenticationMethod`* __string__ | Specifies the authentication method for this listener. +
+| *`appProtocol`* __string__ | 
+| *`port`* __integer__ | Specifies the container port number for this listener. +
+| *`tls`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls[$$StretchListenerTLS$$]__ | Configures TLS settings for the internal listener. +
+| *`prefixTemplate`* __string__ | Specifies the template used for generating the advertised addresses of Services. +
+| *`advertisedPorts`* __integer array__ | Specifies the network port that the external Service listens on. +
+| *`nodePort`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistener"]
+== StretchListener 
+
+StretchListener configures a single listener in stretch clusters.
+
+
+Forked from Listener: references StretchListenerTLS instead of ListenerTLS.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchexternallistener[$$StretchExternalListener$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Specifies whether this Listener is enabled. +
+| *`authenticationMethod`* __string__ | Specifies the authentication method for this listener. +
+| *`appProtocol`* __string__ | 
+| *`port`* __integer__ | Specifies the container port number for this listener. +
+| *`tls`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls[$$StretchListenerTLS$$]__ | Configures TLS settings for the internal listener. +
+| *`prefixTemplate`* __string__ | Specifies the template used for generating the advertised addresses of Services. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls"]
+== StretchListenerTLS 
+
+StretchListenerTLS configures TLS for a listener in stretch clusters.
+
+
+Forked from ListenerTLS: removed deprecated SecretRef field (had no effect).
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchexternallistener[$$StretchExternalListener$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistener[$$StretchListener$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchrpc[$$StretchRPC$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`cert`* __string__ | References a specific certificate for the listener. +
+| *`enabled`* __boolean__ | Specifies whether TLS is enabled for the listener. +
+| *`requireClientAuth`* __boolean__ | Indicates whether client authentication (mTLS) is required. +
+| *`trustStore`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-truststore[$$TrustStore$$]__ | TrustStore allows setting the `truststore_path` on this listener. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlisteners"]
+== StretchListeners 
+
+StretchListeners configures listener settings for stretch clusters.
+
+
+Forked from Listeners: uses StretchAPIListener (collapsed from Admin, HTTP,
+Kafka, SchemaRegistry — all identical after removing deprecated KafkaEndpoint
+from HTTP and SchemaRegistry) and StretchRPC.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`admin`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]__ | Configures settings for the Admin API listeners. +
+| *`http`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]__ | Configures settings for the HTTP Proxy listeners. +
+| *`kafka`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]__ | Configures settings for the Kafka API listeners. +
+| *`rpc`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchrpc[$$StretchRPC$$]__ | Configures settings for the RPC API listener. +
+| *`schemaRegistry`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchapilistener[$$StretchAPIListener$$]__ | Configures settings for the Schema Registry listeners. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlogging"]
+== StretchLogging 
+
+StretchLogging defines log level settings for stretch clusters.
+
+
+Forked from Logging: uses StretchUsageStats instead of UsageStats.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`logLevel`* __string__ | Specifies the log level. +
+| *`usageStats`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchusagestats[$$StretchUsageStats$$]__ | Defines settings for usage statistics reporting. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchrpc"]
+== StretchRPC 
+
+StretchRPC configures the RPC API listener for stretch clusters.
+
+
+Forked from RPC: references StretchListenerTLS instead of ListenerTLS.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlisteners[$$StretchListeners$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`port`* __integer__ | Specifies the container port number for the internal listener. +
+| *`tls`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls[$$StretchListenerTLS$$]__ | Configures TLS settings for the internal listener. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchresources"]
+== StretchResources 
+
+StretchResources defines container resource settings for stretch clusters.
+
+
+Forked from Resources: changed Limits/Requests from *map[corev1.ResourceName]resource.Quantity
+(pointer-to-map) to corev1.ResourceList (standard K8s type alias) for idiomatic usage.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`cpu`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-cpu[$$CPU$$]__ | Specifies the number of CPU cores. +
+| *`memory`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-memory[$$Memory$$]__ | Specifies the amount of memory. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchstorage"]
+== StretchStorage 
+
+StretchStorage configures storage for stretch clusters.
+
+
+Forked from Storage: uses StretchTiered instead of Tiered to pick up
+the cleaned-up StretchTieredConfig.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`hostPath`* __string__ | Specifies the absolute path on the worker node to store the Redpanda data directory. +
+| *`persistentVolume`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-persistentvolume[$$PersistentVolume$$]__ | Configures a PersistentVolumeClaim (PVC) template to create for each Pod. +
+| *`tiered`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtiered[$$StretchTiered$$]__ | Configures storage for the Tiered Storage cache. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtiered"]
+== StretchTiered 
+
+StretchTiered configures tiered storage for stretch clusters.
+
+
+Forked from Tiered: uses StretchTieredConfig instead of TieredConfig.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchstorage[$$StretchStorage$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`mountType`* __string__ | mountType: "none", "hostPath", "emptyDir", or "persistentVolume". +
+| *`hostPath`* __string__ | Specifies the absolute path on the worker node to store the Tiered Storage cache. +
+| *`persistentVolume`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-persistentvolume[$$PersistentVolume$$]__ | Configures a PersistentVolumeClaim (PVC) template for the Tiered Storage cache. +
+| *`config`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtieredconfig[$$StretchTieredConfig$$]__ | Configures Tiered Storage properties. +
+| *`credentialsSecretRef`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-credentialsecretref[$$CredentialSecretRef$$]__ | CredentialsSecretRef sets cloud_storage_secret_key and/or cloud_storage_access_key from a referenced Secret. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtieredconfig"]
+== StretchTieredConfig 
+
+StretchTieredConfig configures Tiered Storage properties for stretch clusters.
+
+
+Forked from TieredConfig: removed deprecated CloudStorageReconciliationIntervalMs
+(see xref:reference:tunable-properties.adoc[]);
+replaced *apiutil.JSONBoolean with *bool for CloudStorageEnabled (JSONBoolean was a
+Helm-era hack to handle "true" vs true in values files).
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtiered[$$StretchTiered$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`cloud_storage_enabled`* __boolean__ | 
+| *`cloud_storage_api_endpoint`* __string__ | 
+| *`cloud_storage_api_endpoint_port`* __integer__ | 
+| *`cloud_storage_bucket`* __string__ | 
+| *`cloud_storage_azure_container`* __string__ | 
+| *`cloud_storage_azure_managed_identity_id`* __string__ | 
+| *`cloud_storage_azure_storage_account`* __string__ | 
+| *`cloud_storage_azure_shared_key`* __string__ | 
+| *`cloud_storage_azure_adls_endpoint`* __string__ | 
+| *`cloud_storage_azure_adls_port`* __integer__ | 
+| *`cloud_storage_cache_check_interval`* __integer__ | 
+| *`cloud_storage_cache_directory`* __string__ | 
+| *`cloud_storage_cache_size`* __string__ | 
+| *`cloud_storage_credentials_source`* __string__ | 
+| *`cloud_storage_disable_tls`* __boolean__ | 
+| *`cloud_storage_enable_remote_read`* __boolean__ | 
+| *`cloud_storage_enable_remote_write`* __boolean__ | 
+| *`cloud_storage_initial_backoff_ms`* __integer__ | 
+| *`cloud_storage_manifest_upload_timeout_ms`* __integer__ | 
+| *`cloud_storage_max_connection_idle_time_ms`* __integer__ | 
+| *`cloud_storage_max_connections`* __integer__ | 
+| *`cloud_storage_region`* __string__ | 
+| *`cloud_storage_segment_max_upload_interval_sec`* __integer__ | 
+| *`cloud_storage_segment_upload_timeout_ms`* __integer__ | 
+| *`cloud_storage_trust_file`* __string__ | 
+| *`cloud_storage_upload_ctrl_d_coeff`* __integer__ | 
+| *`cloud_storage_upload_ctrl_max_shares`* __integer__ | 
+| *`cloud_storage_upload_ctrl_min_shares`* __integer__ | 
+| *`cloud_storage_upload_ctrl_p_coeff`* __integer__ | 
+| *`cloud_storage_upload_ctrl_update_interval_ms`* __integer__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchtuning"]
+== StretchTuning 
+
+StretchTuning defines autotuner settings for stretch clusters.
+
+
+Forked from Tuning: removed ExtraVolumeMounts and Resources fields which are
+init-container concerns (used by Statefulset.InitContainers.Tuning in the Helm chart)
+and have no meaning as cluster-level tuning configuration.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchclusterspec[$$StretchClusterSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`ballast_file_path`* __string__ | Specifies the file path for ballast file. +
+| *`ballast_file_size`* __string__ | Defines the size of the ballast file. +
+| *`tune_aio_events`* __boolean__ | Specifies whether to increase the number of allowed asynchronous IO events. +
+| *`tune_ballast_file`* __boolean__ | Specifies whether to create the ballast file. +
+| *`tune_clocksource`* __boolean__ | Specifies whether to synchronize NTP. +
+| *`well_known_io`* __string__ | Specifies the vendor, VM type, and storage device type that Redpanda runs on, in the format <vendor>:<vm>:<storage>. +
+| *`apply_host_tuners`* __boolean__ | ApplyHostTuners enables a chroot-based tuning init container that +
+gives `rpk redpanda tune all` access to the host's /sys, /proc, +
+NICs and block devices, so tuners like disk_irq, disk_scheduler, +
+disk_nomerges and net actually apply. Enabling it default-enables +
+those tuners plus fstrim, disk_write_cache (GCP-only) and cpu; an +
+explicit `config.rpk.tune_*: false` overrides any of the defaults. +
+Requires `tune_aio_events: true` (rendering fails otherwise). +
+Defaults to false. +
+
+
+Security: the tuning init container runs privileged and the pod +
+mounts twelve hostPath volumes (/bin, /sbin, /usr, /lib, /lib64 +
+read-only; /sys, /proc, /etc, /dev, /var, /run writable; plus the +
+tuner state file). The namespace needs the PSA `privileged` level, +
+or on OpenShift an SCC allowing hostPath and privileged containers. +
+
+
+Constraints: run at most one Redpanda pod per node (the default +
+anti-affinity) — concurrent tuners race on kernel parameters. +
+Disabling the flag does not revert tuning already applied to a +
+node: sysctl/IRQ/block-device settings persist until reboot and +
+the fstrim systemd timer rpk installs keeps firing until removed. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchusagestats"]
+== StretchUsageStats 
+
+StretchUsageStats defines usage statistics settings for stretch clusters.
+
+
+Forked from UsageStats: removed deprecated Organization field and unused ClusterID field.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlogging[$$StretchLogging$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Specifies whether usage statistics are enabled. +
+|===
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-tls"]
 == TLS 
 
@@ -4052,6 +4620,7 @@ TLS configures TLS in the Helm values. See xref:manage:kubernetes/security/tls.a
 
 
 .Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-embeddedbrokerpoolspec[$$EmbeddedBrokerPoolSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec[$$RedpandaClusterSpec$$]
 
 [cols="25a,75a", options="header"]
@@ -4308,6 +4877,7 @@ TrustStore is a mapping from a value on either a Secret or ConfigMap to the
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-listenertls[$$ListenerTLS$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-stretchlistenertls[$$StretchListenerTLS$$]
 
 [cols="25a,75a", options="header"]
 |===

--- a/modules/reference/pages/k-crd.adoc
+++ b/modules/reference/pages/k-crd.adoc
@@ -274,7 +274,7 @@ Redpanda will use the `internal_topic_replication_factor` cluster config value. 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-auth"]
 == Auth 
 
-Auth configures authentication in the Helm values. See https://docs.redpanda.com/current/manage/kubernetes/security/authentication/sasl-kubernetes/.
+Auth configures authentication in the Helm values. See xref:manage:kubernetes/security/authentication/sasl-kubernetes.adoc[]
 
 
 
@@ -383,7 +383,7 @@ Budget configures the management of disruptions affecting the Pods in the Statef
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-cpu"]
 == CPU 
 
-CPU configures CPU resources for containers. See https://docs.redpanda.com/current/manage/kubernetes/manage-resources/.
+CPU configures CPU resources for containers. See xref:manage:kubernetes/manage-resources.adoc[]
 
 
 
@@ -393,7 +393,7 @@ CPU configures CPU resources for containers. See https://docs.redpanda.com/curre
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`cores`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api[$$Quantity$$]__ | Specifies the number of CPU cores available to the application. Redpanda makes use of a thread per core model. For details, see https://docs.redpanda.com/current/get-started/architecture/#thread-per-core-model. For this reason, Redpanda should only be given full cores. Note: You can increase cores, but decreasing cores is not currently supported. See the GitHub issue:https://github.com/redpanda-data/redpanda/issues/350. This setting is equivalent to `--smp`, `resources.requests.cpu`, and `resources.limits.cpu`. For production, use `4` or greater. +
+| *`cores`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api[$$Quantity$$]__ | Specifies the number of CPU cores available to the application. Redpanda makes use of a thread per core model. For details, see xref:get-started:architecture.adoc[] For this reason, Redpanda should only be given full cores. Note: You can increase cores, but decreasing cores is not currently supported. See the GitHub issue:https://github.com/redpanda-data/redpanda/issues/350. This setting is equivalent to `--smp`, `resources.requests.cpu`, and `resources.limits.cpu`. For production, use `4` or greater. +
 | *`overprovisioned`* __boolean__ | Specifies whether Redpanda assumes it has all of the provisioned CPU. This should be `true` unless the container has CPU affinity. Equivalent to: `--idle-poll-time-us 0`, `--thread-affinity 0`, and `--poll-aio 0`. If the value of full cores in `resources.cpu.cores` is less than `1`, this setting is set to `true`. +
 |===
 
@@ -490,9 +490,17 @@ ClusterRef represents a reference to a cluster that is being targeted.
 | Field | Description
 | *`group`* __string__ | Group is used to override the object group that this reference points to. +
 If unspecified, defaults to "cluster.redpanda.com". +
+A bare API group only — controllers match it by string comparison, so a +
+"group/version" value (e.g. "cluster.redpanda.com/v1alpha2") would +
+silently match nothing and the referencing object would never bind. +
 | *`kind`* __string__ | Kind is used to override the object kind that this reference points to. +
 If unspecified, defaults to "Redpanda". +
 | *`name`* __string__ | Name specifies the name of the cluster being referenced. +
+| *`namespace`* __string__ | Namespace specifies the namespace of the cluster being referenced. +
+If unspecified, defaults to the namespace of the referencing object. +
+Setting this allows referencing a cluster that resides in a different +
+namespace, e.g. a ShadowLink whose source and shadow Redpanda clusters +
+live in separate namespaces on the same Kubernetes cluster. +
 |===
 
 
@@ -535,6 +543,7 @@ CommonTLS specifies TLS configuration settings for Redpanda clusters that have a
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-adminapispec[$$AdminAPISpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-kafkaapispec[$$KafkaAPISpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-schemaregistryspec[$$SchemaRegistrySpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]
 
 [cols="25a,75a", options="header"]
 |===
@@ -581,15 +590,15 @@ Config configures Redpanda config properties supported by Redpanda that may not 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`rpk`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies cluster configuration properties. See https://docs.redpanda.com/current/reference/cluster-properties/. +
-| *`cluster`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies cluster configuration properties. See https://docs.redpanda.com/current/reference/cluster-properties/. +
+| *`rpk`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies cluster configuration properties. See xref:reference:cluster-properties.adoc[] +
+| *`cluster`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies cluster configuration properties. See xref:reference:cluster-properties.adoc[] +
 | *`extraClusterConfiguration`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-clusterconfiguration[$$ClusterConfiguration$$]__ | Holds values (or references to values) that should be used to configure the cluster; these +
 are resolved late in order to avoid embedding secrets directly into bootstrap configurations +
 exposed as Kubernetes configmaps. +
-| *`node`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies broker configuration properties. See https://docs.redpanda.com/current/reference/node-properties/. +
-| *`tunable`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See https://docs.redpanda.com/current/reference/tunable-properties/. +
-| *`schema_registry_client`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See https://docs.redpanda.com/current/reference/tunable-properties/. +
-| *`pandaproxy_client`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See https://docs.redpanda.com/current/reference/tunable-properties/. +
+| *`node`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies broker configuration properties. See xref:reference:node-properties.adoc[] +
+| *`tunable`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See xref:reference:tunable-properties.adoc[] +
+| *`schema_registry_client`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See xref:reference:tunable-properties.adoc[] +
+| *`pandaproxy_client`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies tunable configuration properties. See xref:reference:tunable-properties.adoc[] +
 |===
 
 
@@ -697,7 +706,7 @@ the dynamic configuration, while its "synonym" will be the default. +
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-connectormonitoring"]
 == ConnectorMonitoring 
 
-ConnectorMonitoring configures monitoring resources for Connectors. See https://docs.redpanda.com/current/manage/kubernetes/monitoring/monitor-redpanda/.
+ConnectorMonitoring configures monitoring resources for Connectors. See xref:manage:kubernetes/monitoring/monitor-redpanda.adoc[]
 
 
 
@@ -807,6 +816,7 @@ ConsoleCreateObj represents configuration options for creating Kubernetes object
 | *`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core[$$SecurityContext$$]__ | 
 | *`service`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-serviceconfig[$$ServiceConfig$$]__ | 
 | *`ingress`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-ingressconfig[$$IngressConfig$$]__ | 
+| *`gateway`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayconfig[$$GatewayConfig$$]__ | 
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | 
 | *`autoscaling`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-autoscaling[$$AutoScaling$$]__ | 
 | *`nodeSelector`* __object (keys:string, values:string)__ | 
@@ -893,6 +903,7 @@ constraints without accidentally polluting the defaults of the chart.
 | *`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core[$$SecurityContext$$]__ | 
 | *`service`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-serviceconfig[$$ServiceConfig$$]__ | 
 | *`ingress`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-ingressconfig[$$IngressConfig$$]__ | 
+| *`gateway`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayconfig[$$GatewayConfig$$]__ | 
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | 
 | *`autoscaling`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-autoscaling[$$AutoScaling$$]__ | 
 | *`nodeSelector`* __object (keys:string, values:string)__ | 
@@ -961,6 +972,19 @@ CredentialSecretRef can be used to set cloud_storage_secret_key from referenced 
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-crossclustermode"]
+== CrossClusterMode (string) 
+
+CrossClusterMode defines how per-pod Services route traffic to pods
+on remote Kubernetes clusters.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-networking[$$Networking$$]
+
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-deploymentconfig"]
 == DeploymentConfig 
 
@@ -983,7 +1007,7 @@ CredentialSecretRef can be used to set cloud_storage_secret_key from referenced 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-enterprise"]
 == Enterprise 
 
-Enterprise configures an Enterprise license key to enable Redpanda Enterprise features. Requires the post-install job to be enabled (default). See https://docs.redpanda.com/current/get-started/licenses/.
+Enterprise configures an Enterprise license key to enable Redpanda Enterprise features. Requires the post-install job to be enabled (default). See xref:get-started:licenses.adoc[]
 
 
 
@@ -1016,6 +1040,8 @@ EnterpriseLicenseSecretRef configures a reference to a Secret resource that cont
 |===
 
 
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-external"]
 == External 
 
@@ -1038,6 +1064,7 @@ External defines external connectivity settings in the Helm values.
 | *`type`* __string__ | Specifies the external Service type. Only NodePort and LoadBalancer are supported. If undefined, then advertised listeners will be configured in Redpanda, but the Helm chart will not create a Service. NodePort is recommended in cases where latency is a priority. +
 | *`externalDns`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-externaldns[$$ExternalDNS$$]__ | Defines externalDNS configurations. +
 | *`prefixTemplate`* __string__ | Specifies a naming prefix template for external Services. +
+| *`gateway`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayexternalconfig[$$GatewayExternalConfig$$]__ | Configures Gateway API TLSRoute-based external access. When enabled, ClusterIP services and TLSRoute resources are created instead of NodePort/LoadBalancer services. The Gateway itself must be managed externally. +
 |===
 
 
@@ -1088,6 +1115,9 @@ internal and external listeners. However, it is ignored when specified +
 on internal listeners. +
 | *`advertisedPorts`* __integer array__ | Specifies the network port that the external Service listens on. +
 | *`nodePort`* __integer__ | 
+| *`type`* __string__ | Selects how this listener is exposed externally. Unset inherits the cluster-wide external.type (NodePort/LoadBalancer). Set to "tlsroute" to route this listener via Gateway API: a TLSRoute is created for it (requires external.gateway with parentRefs) and it is excluded from the NodePort/LoadBalancer Service. +
+| *`host`* __string__ | Host is the SNI hostname for the bootstrap TLSRoute when using Gateway API external access. +
+| *`hostTemplate`* __string__ | HostTemplate is a Go template for per-broker TLSRoute SNI hostnames. Supports $POD_ORDINAL and $POD_NAME variables. +
 |===
 
 
@@ -1154,6 +1184,88 @@ FilterType specifies the type, either include or exclude of a consumer group fil
 | *`expectedFS`* __string__ | 
 | *`extraVolumeMounts`* __string__ | Adds extra volume mounts. +
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | Specifies the resource requirements. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayconfig"]
+== GatewayConfig 
+
+GatewayConfig configures a Gateway API HTTPRoute for Console.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-consolespec[$$ConsoleSpec$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-consolevalues[$$ConsoleValues$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | 
+| *`annotations`* __object (keys:string, values:string)__ | 
+| *`parentRefs`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayparentreference[$$GatewayParentReference$$] array__ | 
+| *`hostnames`* __string array__ | 
+| *`path`* __string__ | 
+| *`pathType`* __xref:{anchor_prefix}-sigs-k8s-io-gateway-api-apis-v1-pathmatchtype[$$PathMatchType$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayexternalconfig"]
+== GatewayExternalConfig 
+
+GatewayExternalConfig holds configuration for Gateway API-based external access using TLSRoute resources with SNI-based routing.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-external[$$External$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Enables Gateway API TLSRoute-based external access. +
+| *`parentRefs`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayparentrefconfig[$$GatewayParentRefConfig$$] array__ | Defines which Gateway(s) handle the TLSRoutes. At least one parent reference must be provided. +
+| *`advertisedPort`* __integer__ | The port advertised to clients. Defaults to 443. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayparentrefconfig"]
+== GatewayParentRefConfig 
+
+GatewayParentRefConfig identifies a Gateway (or ListenerSet) that should handle the TLSRoute traffic. Schema mirrors the upstream Gateway API ParentReference.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayexternalconfig[$$GatewayExternalConfig$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`group`* __string__ | API group of the referent. Defaults to "gateway.networking.k8s.io". +
+| *`kind`* __string__ | Kind of the referent. Defaults to "Gateway". +
+| *`name`* __string__ | Name of the referent. +
+| *`namespace`* __string__ | Namespace of the referent. +
+| *`sectionName`* __string__ | Name of a section within the target resource. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayparentreference"]
+== GatewayParentReference 
+
+GatewayParentReference identifies a parent Gateway for the HTTPRoute.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-gatewayconfig[$$GatewayConfig$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`name`* __string__ | 
+| *`namespace`* __string__ | 
+| *`sectionName`* __xref:{anchor_prefix}-sigs-k8s-io-gateway-api-apis-v1-sectionname[$$SectionName$$]__ | 
 |===
 
 
@@ -1674,7 +1786,7 @@ specified, this field takes precedence over [Certificate.CAEnabled]. +
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-listeners"]
 == Listeners 
 
-Listeners configures settings for listeners, including HTTP Proxy, Schema Registry, the Admin API and the Kafka API. See https://docs.redpanda.com/current/manage/kubernetes/networking/configure-listeners/.
+Listeners configures settings for listeners, including HTTP Proxy, Schema Registry, the Admin API and the Kafka API. See xref:manage:kubernetes/networking/configure-listeners.adoc[]
 
 
 
@@ -1717,7 +1829,7 @@ LivenessProbe configures liveness probes to monitor the health of the Pods and r
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-logging"]
 == Logging 
 
-Logging configures logging settings in the Helm values. See https://docs.redpanda.com/current/manage/kubernetes/troubleshooting/troubleshoot/.
+Logging configures logging settings in the Helm values. See xref:manage:kubernetes/troubleshooting/troubleshoot.adoc[]
 
 
 
@@ -1772,7 +1884,7 @@ MetadataTemplate defines additional metadata to associate with a resource.
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-monitoring"]
 == Monitoring 
 
-Monitoring configures monitoring resources for Redpanda. See https://docs.redpanda.com/current/manage/kubernetes/monitoring/monitor-redpanda/.
+Monitoring configures monitoring resources for Redpanda. See xref:manage:kubernetes/monitoring/monitor-redpanda.adoc[]
 
 
 
@@ -1820,6 +1932,7 @@ A filter based on the name of a resource
 
 .Appears in:
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkconsumeroffsetsyncoptions[$$ShadowLinkConsumerOffsetSyncOptions$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkrolesyncoptions[$$ShadowLinkRoleSyncOptions$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinktopicmetadatasyncoptions[$$ShadowLinkTopicMetadataSyncOptions$$]
 
 [cols="25a,75a", options="header"]
@@ -1835,6 +1948,8 @@ and `patternType` must be `literal` +
 - literal +
 - prefixed +
 |===
+
+
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-oidcloginsecrets"]
@@ -1870,6 +1985,10 @@ Password specifies a password for the user.
 | *`value`* __string__ | Value is a hardcoded value to use for the given password. It should only be used for testing purposes. +
 In production, use ValueFrom. +
 | *`valueFrom`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-passwordsource[$$PasswordSource$$]__ | ValueFrom specifies a source for a password to be fetched from when specifying or generating user credentials. +
+Optional when value is set: the type-level validation rule enforces +
+that at least one of the two is present. (This field being marked +
+required in the schema used to make the documented value-only form +
+impossible to apply — https://github.com/redpanda-data/redpanda-operator/issues/1290.) +
 | *`noGenerate`* __boolean__ | NoGenerate when set to true does not create kubernetes secret when ValueFrom points to none-existent secret. +
 |===
 
@@ -1905,6 +2024,30 @@ PatternType specifies the type of pattern applied for ACL resource matching.
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-aclresourcefilter[$$ACLResourceFilter$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-aclresourcespec[$$ACLResourceSpec$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-namefilter[$$NameFilter$$]
+
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-perpodserviceoverride"]
+== PerPodServiceOverride 
+
+PerPodServiceOverride defines overrides for a per-pod Service using
+apply-configuration types. Only fields that are set will be merged
+into the generated Service.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-perpodservices[$$PerPodServices$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Enabled controls whether this per-pod Service is created. Defaults to true. +
+| *`labels`* __object (keys:string, values:string)__ | 
+| *`annotations`* __object (keys:string, values:string)__ | 
+| *`spec`* __xref:{anchor_prefix}-k8s-io-client-go-applyconfigurations-core-v1-servicespecapplyconfiguration[$$ServiceSpecApplyConfiguration$$]__ | 
+|===
+
 
 
 
@@ -2162,7 +2305,7 @@ DEPRECATED: Use sideCars.securityContext +
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-rackawareness"]
 == RackAwareness 
 
-RackAwareness configures rack awareness in the Helm values. See https://docs.redpanda.com/current/manage/kubernetes/kubernetes-rack-awareness/.
+RackAwareness configures rack awareness in the Helm values. See xref:manage:kubernetes/kubernetes-rack-awareness.adoc[]
 
 
 
@@ -2252,7 +2395,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaclusterspec"]
 == RedpandaClusterSpec 
 
-RedpandaClusterSpec defines the desired state of a Redpanda cluster. These settings are the same as those defined in the Redpanda Helm chart. The values in these settings are passed to the Redpanda Helm chart through Flux. For all default values and links to more documentation, see https://docs.redpanda.com/current/reference/redpanda-helm-spec/.
+RedpandaClusterSpec defines the desired state of a Redpanda cluster. These settings are the same as those defined in the Redpanda Helm chart. The values in these settings are passed to the Redpanda Helm chart through Flux. For all default values and links to more documentation, see xref:reference:redpanda-helm-spec.adoc[]
 
 
 For descriptions and default values, see xref:k-redpanda-helm-spec.adoc[].
@@ -2309,7 +2452,7 @@ documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-po
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-redpandaconnectors"]
 == RedpandaConnectors 
 
-RedpandaConnectors configures Redpanda Connectors. Redpanda Connectors is a package that includes Kafka Connect and built-in connectors, sometimes known as plugins. See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/kubernetes/k-deploy-connectors/.
+RedpandaConnectors configures Redpanda Connectors. Redpanda Connectors is a package that includes Kafka Connect and built-in connectors, sometimes known as plugins. See xref:deploy:deployment-option/self-hosted/kubernetes/k-deploy-connectors.adoc[]
 
 
 
@@ -2371,6 +2514,7 @@ see the Helm values for the Redpanda Console chart: https://artifacthub.io/packa
 | *`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Sets the security context for the Pods that run Redpanda Console. +
 | *`service`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Configures the Kubernetes Service for Redpanda Console. +
 | *`ingress`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Configures the Kubernetes Ingress resource for Redpanda Console. +
+| *`gateway`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Configures a Gateway API HTTPRoute for Redpanda Console. +
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Configures resource requests and limits for the Pods that run Redpanda Console. +
 | *`autoscaling`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Configures Horizontal Pod Autoscaling (HPA) for Redpanda Console. +
 | *`nodeSelector`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#rawextension-runtime-pkg[$$RawExtension$$]__ | Specifies Node labels for Pod assignment. +
@@ -3250,6 +3394,38 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkclientoptions"]
+== ShadowLinkClientOptions 
+
+ShadowLinkClientOptions configures the source-cluster Kafka fetch/connection
+behavior of a shadow link. These knobs primarily control replication latency
+vs. batching efficiency. Every field defaults server-side when left at 0, so
+omitting a field (or setting it to 0) preserves the Redpanda default noted in
+its documentation.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkspec[$$ShadowLinkSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`fetchMinBytes`* __integer__ | Minimum bytes the source broker accumulates before answering a fetch +
+request. Lowering this reduces replication latency at low throughput, at +
+the cost of more, smaller fetches. If 0, defaults to 5 MiB (5242880). +
+| *`fetchWaitMaxMs`* __integer__ | Maximum time in milliseconds the source broker waits to satisfy +
+fetchMinBytes before answering a fetch request. Lowering this caps the +
+worst-case replication latency when fetchMinBytes is not met. If 0, +
+defaults to 500ms. +
+| *`fetchMaxBytes`* __integer__ | Maximum bytes returned by a single fetch request. If 0, defaults to 20 MiB (20971520). +
+| *`fetchPartitionMaxBytes`* __integer__ | Maximum bytes returned per partition in a fetch request. If 0, defaults to 5 MiB (5242880). +
+| *`metadataMaxAgeMs`* __integer__ | How often in milliseconds the client refreshes source cluster metadata. If 0, defaults to 10000ms. +
+| *`connectionTimeoutMs`* __integer__ | Connection timeout to the source cluster in milliseconds. If 0, defaults to 1000ms. +
+| *`retryBackoffMs`* __integer__ | Base backoff between connection retries in milliseconds. If 0, defaults to 100ms. +
+|===
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkconsumeroffsetsyncoptions"]
 == ShadowLinkConsumerOffsetSyncOptions 
 
@@ -3272,6 +3448,188 @@ the source cluster +
 |===
 
 
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkrolesyncoptions"]
+== ShadowLinkRoleSyncOptions 
+
+Options for syncing RBAC roles
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkspec[$$ShadowLinkSpec$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`enabled`* __boolean__ | Enabled controls whether RBAC role definitions and role memberships +
+are replicated from the source cluster. Defaults to true, which +
+replicates every role (subject to roleNameFilters). Set to false to +
+turn role replication off. +
+| *`interval`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | How often to sync roles +
+If 0 provided, defaults to 30 seconds +
+| *`paused`* __boolean__ | Allows user to pause the role sync task. If paused, then the task +
+will enter the 'paused' state and not sync roles from the source +
+cluster +
+| *`roleNameFilters`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-namefilter[$$NameFilter$$] array__ | List of filters that select which roles are replicated. Defaults to +
+a single include-all filter so that every role is replicated. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions"]
+== ShadowLinkSchemaRegistryAPIOptions 
+
+Options for replicating schemas from a source schema registry over its
+REST API.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptions[$$ShadowLinkSchemaRegistrySyncOptions$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`sourceURL`* __string__ | URL of the source schema registry, for example +
+https://psrc-xxxxx.us-east-1.aws.confluent.cloud +
+| *`authentication`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryauthentication[$$ShadowLinkSchemaRegistryAuthentication$$]__ | Authentication options used to connect to the source schema +
+registry. +
+| *`tls`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-commontls[$$CommonTLS$$]__ | TLS settings used to connect to the source schema registry. Unlike +
+Kafka API connections, schema registry connection material is passed +
+to the cluster as PEM data, so insecureSkipTlsVerify and the +
+deprecated secret-reference fields are not supported here. +
+| *`tailInterval`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | How often to poll the source registry for incremental changes. +
+If not provided, the cluster default (10s) is used. +
+| *`fullSyncInterval`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | How often to run a full scan of the source registry. +
+If not provided, the cluster default (5m) is used. +
+| *`maxSourceRequestsPerSecond`* __integer__ | Rate limit for requests against the source registry. +
+If not provided, the cluster default (30) is used. +
+| *`sourceFilter`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysourcefilter[$$ShadowLinkSchemaRegistrySourceFilter$$]__ | Selects which schema registry contexts and subjects are replicated. +
+If not provided, the entire source registry is replicated. +
+| *`destination`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextdestination[$$ShadowLinkSchemaRegistryContextDestination$$]__ | Destination context mapping for source schema registry data. If not +
+provided, source context names are preserved on the shadow cluster. +
+| *`unsupportedSchemaFeaturePolicy`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-unsupportedschemafeaturepolicy[$$UnsupportedSchemaFeaturePolicy$$]__ | Policy applied when a source schema uses features that the Redpanda +
+schema registry does not support. Defaults to fail. +
+| *`paused`* __boolean__ | Allows the user to pause the schema registry sync task. If paused, +
+the task enters the 'paused' state, stops replicating schemas from +
+the source, and the per-context client write protection on the +
+contexts this link owns is lifted. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryauthentication"]
+== ShadowLinkSchemaRegistryAuthentication 
+
+Authentication options for a source schema registry.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`basic`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrybasicauthentication[$$ShadowLinkSchemaRegistryBasicAuthentication$$]__ | HTTP basic authentication credentials. For a Confluent Schema +
+Registry these are the schema registry API key (username) and API +
+secret (password). +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrybasicauthentication"]
+== ShadowLinkSchemaRegistryBasicAuthentication 
+
+HTTP basic authentication credentials for a source schema registry.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryauthentication[$$ShadowLinkSchemaRegistryAuthentication$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`username`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-valuesource[$$ValueSource$$]__ | Username used for basic authentication, for example a Confluent +
+Schema Registry API key. May reference a Kubernetes Secret. +
+| *`password`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-valuesource[$$ValueSource$$]__ | Password used for basic authentication, for example a Confluent +
+Schema Registry API secret. May reference a Kubernetes Secret. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextdestination"]
+== ShadowLinkSchemaRegistryContextDestination 
+
+Destination context mapping for source schema registry data. It mirrors
+the SchemaRegistryContextDestination oneof in shadow_link.proto: exactly
+one of identity or exact must be set.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`identity`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryidentitycontextmapping[$$ShadowLinkSchemaRegistryIdentityContextMapping$$]__ | Preserve source context names in the destination schema registry. +
+Mutually exclusive with exact. +
+| *`exact`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextmapping[$$ShadowLinkSchemaRegistryContextMapping$$] array__ | Map selected source contexts to explicit destination contexts. Every +
+source context in the effective source scope must have exactly one +
+mapping. Mutually exclusive with identity. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextmapping"]
+== ShadowLinkSchemaRegistryContextMapping 
+
+Maps a source schema registry context to a destination context on the
+shadow cluster.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextdestination[$$ShadowLinkSchemaRegistryContextDestination$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`source`* __string__ | The source context name. +
+| *`destination`* __string__ | The destination context name on the shadow cluster. +
+|===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryidentitycontextmapping"]
+== ShadowLinkSchemaRegistryIdentityContextMapping 
+
+Preserve source context names in the destination schema registry.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrycontextdestination[$$ShadowLinkSchemaRegistryContextDestination$$]
+
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysourcefilter"]
+== ShadowLinkSchemaRegistrySourceFilter 
+
+Selects which contexts and subjects are replicated from a source schema
+registry.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`contexts`* __string array__ | Schema registry contexts to replicate, for example ".". If empty, +
+all contexts are replicated. +
+| *`subjects`* __string array__ | Subjects to replicate within the selected contexts. If empty, all +
+subjects are replicated. +
+|===
+
+
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptions"]
 == ShadowLinkSchemaRegistrySyncOptions 
 
@@ -3285,14 +3643,32 @@ Options for syncing schema registry settings
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`schema_registry_shadowing_mode`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptionsmode[$$ShadowLinkSchemaRegistrySyncOptionsMode$$]__ | 
+| *`enabled`* __boolean__ | Deprecated: use schema_registry_shadowing_mode instead. Enabled is +
+retained for compatibility with objects created by an earlier build +
+of this CRD, where a boolean toggled schema replication. It is +
+honored only when schema_registry_shadowing_mode is unset: false maps +
+to disabled, and true maps to api when shadowSchemaRegistryAPI is +
+configured or topic otherwise. When both are set, +
+schema_registry_shadowing_mode takes precedence. +
+| *`schema_registry_shadowing_mode`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptionsmode[$$ShadowLinkSchemaRegistrySyncOptionsMode$$]__ | Mode selects how schemas are replicated from the source cluster. +
+Defaults to topic (shadow the source Redpanda cluster's internal +
+schemas topic) when neither this nor the legacy enabled field is set. +
+Set to api to replicate from the source schema registry over its REST +
+API (configured via shadowSchemaRegistryAPI), or disabled to turn schema +
+replication off. +
+| *`shadowSchemaRegistryAPI`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]__ | Configuration for replicating schemas from the source cluster's +
+schema registry REST API (for example a Confluent Schema Registry) +
+instead of shadowing a source Redpanda cluster's internal schemas +
+topic. Required when mode is api and forbidden otherwise. +
 |===
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptionsmode"]
 == ShadowLinkSchemaRegistrySyncOptionsMode (string) 
 
-
+ShadowLinkSchemaRegistrySyncOptionsMode selects how schemas are replicated
+from the source cluster. It mirrors the schema_registry_shadowing_mode
+oneof in shadow_link.proto so that additional modes can be introduced.
 
 
 
@@ -3341,7 +3717,17 @@ settings from the source cluster +
 | *`topicMetadataSyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinktopicmetadatasyncoptions[$$ShadowLinkTopicMetadataSyncOptions$$]__ | Topic metadata sync options +
 | *`consumerOffsetSyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkconsumeroffsetsyncoptions[$$ShadowLinkConsumerOffsetSyncOptions$$]__ | Consumer offset sync options +
 | *`securitySyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinksecuritysettingssyncoptions[$$ShadowLinkSecuritySettingsSyncOptions$$]__ | Security settings sync options +
-| *`schemaRegistrySyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptions[$$ShadowLinkSchemaRegistrySyncOptions$$]__ | options for schema registry +
+| *`schemaRegistrySyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrysyncoptions[$$ShadowLinkSchemaRegistrySyncOptions$$]__ | Schema registry sync options. Schemas are replicated from the source +
+cluster by default; set +
+schemaRegistrySyncOptions.schema_registry_shadowing_mode to disabled +
+to turn schema replication off. +
+| *`roleSyncOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkrolesyncoptions[$$ShadowLinkRoleSyncOptions$$]__ | RBAC role sync options. Roles are replicated from the source cluster +
+by default; set roleSyncOptions.enabled to false to turn role +
+replication off. +
+| *`clientOptions`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkclientoptions[$$ShadowLinkClientOptions$$]__ | Tuning knobs for the Kafka client the shadow cluster uses to fetch data +
+from the source cluster. Connection details (bootstrap servers, TLS) are +
+derived from sourceCluster and are not configurable here; only the mutable +
+performance/latency knobs are exposed. +
 |===
 
 
@@ -3606,6 +3992,13 @@ into this StatefulSet's PodTemplate. +
 | *`topologySpreadConstraints`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-topologyspreadconstraints[$$TopologySpreadConstraints$$] array__ | Defines topology spread constraints to control how Pods are spread across different topology domains. +
 | *`updateStrategy`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-updatestrategy[$$UpdateStrategy$$]__ | Defines the update strategy for the StatefulSet to manage how updates are rolled out to the Pods. +
 | *`terminationGracePeriodSeconds`* __integer__ | Specifies the termination grace period in seconds to control the time delay before forcefully terminating a Pod. +
+| *`persistentVolumeClaimRetentionPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps[$$StatefulSetPersistentVolumeClaimRetentionPolicy$$]__ | PersistentVolumeClaimRetentionPolicy controls the lifecycle of PersistentVolumeClaims +
+created from the StatefulSet's volume claim templates. Setting `whenScaled: Delete` +
+causes a broker's PVC to be deleted by the StatefulSet controller when the broker is +
+decommissioned via scale-down; `whenDeleted: Delete` causes all PVCs to be deleted +
+when the StatefulSet is deleted. When unset, the Kubernetes default (`Retain` for +
+both fields) applies. This value is the cluster-level default for all NodePools; +
+individual NodePools may override it via their own `persistentVolumeClaimRetentionPolicy`. +
 |===
 
 
@@ -3635,7 +4028,7 @@ API of a Redpanda cluster where the object should be created. +
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-storage"]
 == Storage 
 
-Storage configures storage-related settings in the Helm values. See https://docs.redpanda.com/current/manage/kubernetes/storage/.
+Storage configures storage-related settings in the Helm values. See xref:manage:kubernetes/storage.adoc[]
 
 
 
@@ -3654,7 +4047,7 @@ Storage configures storage-related settings in the Helm values. See https://docs
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-tls"]
 == TLS 
 
-TLS configures TLS in the Helm values. See https://docs.redpanda.com/current/manage/kubernetes/security/tls/.
+TLS configures TLS in the Helm values. See xref:manage:kubernetes/security/tls.adoc[]
 
 
 
@@ -3684,7 +4077,7 @@ Task states
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-tiered"]
 == Tiered 
 
-Tiered configures storage for the Tiered Storage cache. See https://docs.redpanda.com/current/manage/kubernetes/tiered-storage-kubernetes/.
+Tiered configures storage for the Tiered Storage cache. See xref:manage:kubernetes/tiered-storage-kubernetes.adoc[]
 
 
 
@@ -3721,44 +4114,44 @@ TieredConfig configures Tiered Storage, which requires an Enterprise license con
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`cloud_storage_enabled`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-apiutil-jsonboolean[$$JSONBoolean$$]__ | Enables Tiered Storage, if a license key is provided. See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_enabled. +
-| *`cloud_storage_api_endpoint`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_api_endpoint. +
-| *`cloud_storage_api_endpoint_port`* __integer__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_api_endpoint_port. +
-| *`cloud_storage_bucket`* __string__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_bucket. +
-| *`cloud_storage_azure_container`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_container. +
-| *`cloud_storage_azure_managed_identity_id`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_managed_identity_id. +
-| *`cloud_storage_azure_storage_account`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_storage_account. +
-| *`cloud_storage_azure_shared_key`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_shared_key. +
-| *`cloud_storage_azure_adls_endpoint`* __string__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_adls_endpoint. +
-| *`cloud_storage_azure_adls_port`* __integer__ | See https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_adls_port. +
-| *`cloud_storage_cache_check_interval`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_cache_check_interval. +
-| *`cloud_storage_cache_directory`* __string__ | See https://docs.redpanda.com/current/reference/node-properties/#cloud_storage_cache_directory. +
-| *`cloud_storage_cache_size`* __string__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_cache_size. +
-| *`cloud_storage_credentials_source`* __string__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_credentials_source. +
-| *`cloud_storage_disable_tls`* __boolean__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_disable_tls. +
-| *`cloud_storage_enable_remote_read`* __boolean__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_enable_remote_read. +
-| *`cloud_storage_enable_remote_write`* __boolean__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_enable_remote_write. +
-| *`cloud_storage_initial_backoff_ms`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_initial_backoff_ms. +
-| *`cloud_storage_manifest_upload_timeout_ms`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_manifest_upload_timeout_ms. +
-| *`cloud_storage_max_connection_idle_time_ms`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_max_connection_idle_time_ms. +
-| *`cloud_storage_max_connections`* __integer__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_max_connections. +
-| *`cloud_storage_reconciliation_interval_ms`* __integer__ | Deprecated: See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_reconciliation_interval_ms. +
-| *`cloud_storage_region`* __string__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_region. +
-| *`cloud_storage_segment_max_upload_interval_sec`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_segment_max_upload_interval_sec. +
-| *`cloud_storage_segment_upload_timeout_ms`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_segment_upload_timeout_ms. +
-| *`cloud_storage_trust_file`* __string__ | See https://docs.redpanda.com/current/reference/cluster-properties/#cloud_storage_trust_file. +
-| *`cloud_storage_upload_ctrl_d_coeff`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_upload_ctrl_d_coeff. +
-| *`cloud_storage_upload_ctrl_max_shares`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_upload_ctrl_max_shares. +
-| *`cloud_storage_upload_ctrl_min_shares`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_upload_ctrl_min_shares. +
-| *`cloud_storage_upload_ctrl_p_coeff`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_upload_ctrl_p_coeff. +
-| *`cloud_storage_upload_ctrl_update_interval_ms`* __integer__ | See https://docs.redpanda.com/current/reference/tunable-properties/#cloud_storage_upload_ctrl_update_interval_ms. +
+| *`cloud_storage_enabled`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-apiutil-jsonboolean[$$JSONBoolean$$]__ | Enables Tiered Storage, if a license key is provided. See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_api_endpoint`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_api_endpoint_port`* __integer__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_bucket`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_container`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_managed_identity_id`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_storage_account`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_shared_key`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_adls_endpoint`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_azure_adls_port`* __integer__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_cache_check_interval`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_cache_directory`* __string__ | See xref:reference:node-properties.adoc[] +
+| *`cloud_storage_cache_size`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_credentials_source`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_disable_tls`* __boolean__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_enable_remote_read`* __boolean__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_enable_remote_write`* __boolean__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_initial_backoff_ms`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_manifest_upload_timeout_ms`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_max_connection_idle_time_ms`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_max_connections`* __integer__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_reconciliation_interval_ms`* __integer__ | Deprecated: See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_region`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_segment_max_upload_interval_sec`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_segment_upload_timeout_ms`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_trust_file`* __string__ | See xref:reference:cluster-properties.adoc[] +
+| *`cloud_storage_upload_ctrl_d_coeff`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_upload_ctrl_max_shares`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_upload_ctrl_min_shares`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_upload_ctrl_p_coeff`* __integer__ | See xref:reference:tunable-properties.adoc[] +
+| *`cloud_storage_upload_ctrl_update_interval_ms`* __integer__ | See xref:reference:tunable-properties.adoc[] +
 |===
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-topic"]
 == Topic 
 
-Topic defines the CRD for Topic resources. See https://docs.redpanda.com/current/manage/kubernetes/manage-topics/.
+Topic defines the CRD for Topic resources. See xref:manage:kubernetes/manage-topics.adoc[]
 
 
 
@@ -3800,7 +4193,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-topicspec"]
 == TopicSpec 
 
-TopicSpec defines the desired state of the topic. See https://docs.redpanda.com/current/manage/kubernetes/manage-topics/.
+TopicSpec defines the desired state of the topic. See xref:manage:kubernetes/manage-topics.adoc[]
 
 
 
@@ -3816,11 +4209,11 @@ It can be increased after topic creation, but it is +
 important to understand the consequences that has, especially for +
 topics with semantic partitioning. When absent this will default to +
 the Redpanda cluster configuration `default_topic_partitions`. +
-See https://docs.redpanda.com/docs/reference/cluster-properties/#default_topic_partitions and +
-https://docs.redpanda.com/docs/get-started/architecture/#partitions +
+See xref:reference:cluster-properties.adoc[] and +
+xref:get-started:architecture.adoc[] +
 | *`replicationFactor`* __integer__ | Specifies the number of replicas the topic should have. Must be odd value. +
 When absent this will default to the Redpanda cluster configuration `default_topic_replications`. +
-See https://docs.redpanda.com/docs/reference/cluster-properties/#default_topic_replications. +
+See xref:reference:cluster-properties.adoc[] +
 | *`overwriteTopicName`* __string__ | Changes the topic name from the value of `metadata.name`. +
 | *`additionalConfig`* __object (keys:string, values:string)__ | Adds extra topic configurations. This is a free-form map of any configuration options that topics can have. +
 Examples: +
@@ -3829,6 +4222,21 @@ Examples: +
 `redpanda.remote.read=true` +
 `redpanda.remote.recovery=true` +
 `redpanda.remote.delete=true` +
+
+
+The map is reconciled declaratively against the live topic configuration: +
+
+
+- A key with a string value is kept in sync on the topic: whenever the +
+live value differs from the desired one, the operator sets it back. +
+- A key absent from the map is not managed; if the topic carries a +
+non-default value for it, the operator resets it to the cluster +
+default. (Exceptions: `cleanup.policy` and `redpanda.storage.mode` +
+are never reset.) +
+- A key with a null value is exempt from both: the operator neither +
+updates it nor resets it to the cluster default. Use this for a +
+configuration that is managed outside the operator (e.g. set via +
+`rpk` or another client) and should be left untouched. +
 | *`cluster`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-clustersource[$$ClusterSource$$]__ | ClusterSource is a reference to the cluster where the user should be created. +
 It is used in constructing the client created to configure a cluster. +
 | *`kafkaApiSpec`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-kafkaapispec[$$KafkaAPISpec$$]__ | Defines client configuration for connecting to Redpanda brokers. +
@@ -3839,7 +4247,16 @@ name of the metric. This should be easier to identify if +
 multiple operator instances runs inside the same Kubernetes cluster. +
 By default, it is set to `redpanda-operator`. +
 | *`interval`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta[$$Duration$$]__ | Defines when the topic controller will schedule the next reconciliation. +
-Default is 3 seconds. +
+If unset, the operator-wide default is used (the operator's +
+--topic-sync-interval flag, 30s by default). A per-CR value here always +
+takes precedence over the operator default. +
+
+
+NB: the CRD no longer carries a baked-in default (previously "3s"). Pinning +
+the default in the operator instead of the CRD lets cluster operators tune +
+reconcile pressure without editing every Topic. This is introduced in the +
+v26.2 operator; on that upgrade, Topics that never set this field move from +
+the old 3s cadence to the operator default. +
 |===
 
 
@@ -3922,7 +4339,33 @@ Tuning configures settings for the autotuner tool in Redpanda. The autotuner ide
 | *`tune_ballast_file`* __boolean__ | Specifies whether to create the ballast file. +
 | *`tune_clocksource`* __boolean__ | Specifies whether to synchronize NTP. +
 | *`well_known_io`* __string__ | Specifies the vendor, VM type, and storage device type that Redpanda runs on, in the format <vendor>:<vm>:<storage>. This hints to Redpanda which configuration values it should use for the Redpanda IO scheduler. +
+| *`apply_host_tuners`* __boolean__ | ApplyHostTuners enables a chroot-based tuning init container that +
+gives `rpk redpanda tune all` access to the host's /sys, /proc, +
+NICs and block devices so tuners like disk_irq, disk_scheduler, +
+disk_nomerges and net actually apply. Enabling it default-enables +
+those tuners plus fstrim, disk_write_cache (GCP-only) and cpu; an +
+explicit `config.rpk.tune_*: false` overrides any of the defaults. +
+Requires `tune_aio_events: true` (rendering fails otherwise). +
+Opt-in: defaults to false. Enabling requires a privileged SCC/PSA +
+on the namespace (the pod adds twelve hostPath mounts) and MUST be +
+combined with one-pod-per-node anti-affinity to avoid +
+kernel-parameter races. Disabling does not revert tuning already +
+applied: settings persist until node reboot and the fstrim systemd +
+timer keeps firing until removed. +
 |===
+
+
+[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-unsupportedschemafeaturepolicy"]
+== UnsupportedSchemaFeaturePolicy (string) 
+
+UnsupportedSchemaFeaturePolicy controls what happens when a source schema
+uses features that the Redpanda schema registry does not support.
+
+
+
+.Appears in:
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistryapioptions[$$ShadowLinkSchemaRegistryAPIOptions$$]
+
 
 
 [id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-updatestrategy"]
@@ -4010,6 +4453,11 @@ UserAuthenticationSpec defines the authentication mechanism enabled for this Red
 - scram-sha-512 +
 - scram-sha-256 +
 | *`password`* __xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-password[$$Password$$]__ | Password specifies where a password is read from. +
+| *`syncCredentials`* __boolean__ | SyncCredentials when set to true causes the operator to re-read the +
+password from the referenced Secret on every reconciliation cycle +
+(default: every 5 minutes) and upsert the credentials to Redpanda. +
+This enables password rotation via external systems like the External +
+Secrets Operator (ESO) without requiring user recreation. +
 |===
 
 
@@ -4129,6 +4577,7 @@ ValueSource represents where a value can be pulled from
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-kafkasaslgssapi[$$KafkaSASLGSSAPI$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-kafkasasloauthbearer[$$KafkaSASLOAuthBearer$$]
 - xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-schemaregistrysasl[$$SchemaRegistrySASL$$]
+- xref:{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-shadowlinkschemaregistrybasicauthentication[$$ShadowLinkSchemaRegistryBasicAuthentication$$]
 
 [cols="25a,75a", options="header"]
 |===


### PR DESCRIPTION
Documents the new ShadowLink CRD surfaces for 26.2 (DOC-2333, eng epic ENG-1232, confirmed ready for docs by David):

## Changes

- **Configure schema replication** section in `k-shadow-linking.adoc`: the three `schema_registry_shadowing_mode` values (`topic` default, `api` for Confluent/external registries, `disabled`), a Confluent example with the API key/secret in a Kubernetes Secret, Operator + Helm tabs, and a pointer to the core migration guide for concepts and validation policies.
- **Configure role synchronization** section: on by default, interval, name filters, and the guidance to pair with ACL sync (mirrors the merged core docs).
- **CRD reference regenerated** from operator main using the `crd-spec` automation (ran its underlying `crd-ref-docs` invocation with main's config plus `Broker.*` added to the ignore list, since the dark-launched Broker CR postdates the config's exclusions). Adds the ShadowLink SR/role types and the Gateway API types.
- **Verify example corrected**: the ShadowLink CRD reports `Synced` + `state: active` (+ `shadowTopicStatuses`), not a `Ready` condition; the example now shows the real observed status.
- **New gotcha** in the cross-namespace WARNING: two Redpanda clusters on one Kubernetes cluster collide on the default external node ports (`provided port is already allocated`); disable external access on one or assign non-overlapping ports. Hit live during validation of the documented dev/test topology.

## Validation (kind v1.34.0, operator built from main @ 550bab24b)

Cross-namespace ShadowLink (src/dst namespaces, one cluster-scoped operator): `schema_registry_shadowing_mode: api` pointed at the source's SR REST endpoint, `roleSyncOptions` enabled. Verified on the shadow: the `orders` topic (shadowTopicStatuses active), the `orders-value` subject replicated over the SR REST API, and `shadow-test-role` replicated. CEL admission verified (api mode requires `shadowSchemaRegistryAPI`).

## Notes for eng (also raised on the operator side)

The `crd-ref-docs-config.yaml` in the operator repo needs `Broker.*` added to `ignoreTypes` before the next automated CRD regen, and the `Stretch.*` ignore needs REMOVING at GA so StretchCluster/RedpandaBrokerPool get reference docs.

Coordination: the Confluent-source specifics defer to Joyce's merged core page (docs#1776); role-sync core docs are #1780.