### PR TITLE
docs: per-broker restart probes for operator rolling restarts (26.2)

### DIFF
--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -24,7 +24,7 @@ For deployment steps, see xref:deploy:redpanda/kubernetes/k-stretch-clusters.ado
 
 === Safer rolling restarts with per-broker health probes
 
-The Redpanda Operator now gates each step of a rolling restart with Redpanda's per-broker restart probes instead of a single cluster-wide health check. Before restarting a broker, the operator confirms that the restart cannot lose `acks=1`-acknowledged data, make partitions unavailable, or block `acks=all` produce requests. After each restart, the operator waits until the broker reports that it has fully re-synced before restarting the next one, because a Pod can pass its readiness checks while the broker is still replaying partition state.
+Starting with Redpanda Operator v26.2.1, rolling restarts are safer by default: the operator gates each step of a rolling restart with Redpanda's per-broker restart probes instead of a single cluster-wide health check. Before restarting a broker, the operator confirms that the restart cannot lose `acks=1`-acknowledged data, make partitions unavailable, or block `acks=all` produce requests. After each restart, the operator waits until the broker reports that it has fully re-synced before restarting the next one, because a Pod can pass its readiness checks while the broker is still replaying partition state.
 
 The probes require Redpanda 25.1 or later. On earlier versions, the operator falls back to the cluster-wide health check.
 

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -22,6 +22,14 @@ The release also adds the xref:reference:rpk/rpk-k8s/rpk-k8s.adoc[`rpk k8s` plug
 
 For deployment steps, see xref:deploy:redpanda/kubernetes/k-stretch-clusters.adoc[].
 
+=== Safer rolling restarts with per-broker health probes
+
+The Redpanda Operator now gates each step of a rolling restart with Redpanda's per-broker restart probes instead of a single cluster-wide health check. Before restarting a broker, the operator confirms that the restart cannot lose `acks=1`-acknowledged data, make partitions unavailable, or block `acks=all` produce requests. After each restart, the operator waits until the broker reports that it has fully re-synced before restarting the next one, because a Pod can pass its readiness checks while the broker is still replaying partition state.
+
+The probes require Redpanda 25.1 or later. On earlier versions, the operator falls back to the cluster-wide health check.
+
+See xref:manage:kubernetes/k-rolling-restart.adoc#operator-restart-gates[How the Redpanda Operator gates each restart].
+
 === Broker pool resources by deployment type
 
 The new RedpandaBrokerPool custom resource manages broker pools for Stretch Clusters only. The RedpandaBrokerPool CRD is installed only in multicluster mode, and its controller does not reconcile pools for standalone Redpanda resources.

--- a/modules/get-started/pages/release-notes/operator.adoc
+++ b/modules/get-started/pages/release-notes/operator.adoc
@@ -24,7 +24,7 @@ For deployment steps, see xref:deploy:redpanda/kubernetes/k-stretch-clusters.ado
 
 === Safer rolling restarts with per-broker health probes
 
-Starting with Redpanda Operator v26.2.1, rolling restarts are safer by default: the operator gates each step of a rolling restart with Redpanda's per-broker restart probes instead of a single cluster-wide health check. Before restarting a broker, the operator confirms that the restart cannot lose `acks=1`-acknowledged data, make partitions unavailable, or block `acks=all` produce requests. After each restart, the operator waits until the broker reports that it has fully re-synced before restarting the next one, because a Pod can pass its readiness checks while the broker is still replaying partition state.
+In Redpanda Operator v26.2.1 or later, the operator gates each step of a rolling restart with Redpanda's per-broker restart probes instead of a single cluster-wide health check. Before restarting a broker, the operator confirms that the restart cannot lose data acknowledged with `acks=1`, make partitions unavailable, or block `acks=all` produce requests. After each restart, the operator waits until the broker reports that it has fully resynced before restarting the next one, because a Pod can pass its readiness probe while the broker is still replaying partition state.
 
 The probes require Redpanda 25.1 or later. On earlier versions, the operator falls back to the cluster-wide health check.
 

--- a/modules/manage/pages/kubernetes/k-rolling-restart.adoc
+++ b/modules/manage/pages/kubernetes/k-rolling-restart.adoc
@@ -45,7 +45,7 @@ The `postStart` hook takes the broker out of maintenance mode. This action re-in
 [[operator-restart-gates]]
 === How the Redpanda Operator gates each restart
 
-If the Redpanda Operator manages your cluster, the operator itself replaces the Pods during restarts that it performs, such as applying a configuration change that requires a restart or rolling out a version upgrade. In addition to the maintenance-mode hooks, the operator gates every restart with Redpanda's per-broker restart probes. It restarts at most one broker per pass and re-evaluates the cluster against a fresh view of the brokers before touching the next Pod:
+If the Redpanda Operator manages your cluster, the operator itself replaces the Pods during restarts that it performs, such as applying a configuration change that requires a restart or rolling out a version upgrade. Starting with Redpanda Operator v26.2.1, the operator gates every restart with Redpanda's per-broker restart probes, in addition to the maintenance-mode hooks. It restarts at most one broker per pass and re-evaluates the cluster against a fresh view of the brokers before touching the next Pod:
 
 . Before restarting a broker, the operator calls the broker's pre-restart probe (admin API `GET /v1/broker/pre_restart_probe`), which answers the question: if this broker restarts right now, which partitions are put at risk? The operator delays the restart, and retries on its next pass, while the probe reports any of the following risks:
 +

--- a/modules/manage/pages/kubernetes/k-rolling-restart.adoc
+++ b/modules/manage/pages/kubernetes/k-rolling-restart.adoc
@@ -45,19 +45,19 @@ The `postStart` hook takes the broker out of maintenance mode. This action re-in
 [[operator-restart-gates]]
 === How the Redpanda Operator gates each restart
 
-If the Redpanda Operator manages your cluster, the operator itself replaces the Pods during restarts that it performs, such as applying a configuration change that requires a restart or rolling out a version upgrade. Starting with Redpanda Operator v26.2.1, the operator gates every restart with Redpanda's per-broker restart probes, in addition to the maintenance-mode hooks. It restarts at most one broker per pass and re-evaluates the cluster against a fresh view of the brokers before touching the next Pod:
+If the Redpanda Operator manages your cluster, the operator itself replaces the Pods during restarts that it performs, such as applying a configuration change that requires a restart or rolling out a version upgrade. In Redpanda Operator v26.2.1 or later, the operator gates every restart with Redpanda's per-broker restart probes, in addition to the maintenance-mode hooks. It restarts at most one broker per pass and re-evaluates the cluster against a fresh view of the brokers before touching the next Pod:
 
-. Before restarting a broker, the operator calls the broker's pre-restart probe (admin API `GET /v1/broker/pre_restart_probe`), which answers the question: if this broker restarts right now, which partitions are put at risk? The operator delays the restart, and retries on its next pass, while the probe reports any of the following risks:
+. Before restarting a broker, the operator calls the broker's pre-restart probe (Admin API `GET /v1/broker/pre_restart_probe`) to determine which partitions the restart would put at risk. The operator delays the restart, and retries on its next pass, while the probe reports any of the following risks:
 +
 --
-* Partitions that would lose data acknowledged with `acks=1`.
-* Partitions that would become unavailable.
-* Partitions that could no longer complete `acks=all` produce requests.
+* Partitions that would lose data acknowledged with `acks=1`
+* Partitions that would become unavailable
+* Partitions that could no longer complete `acks=all` produce requests
 --
 +
 Partitions on topics with a replication factor of 1 do not block the restart, because they have no redundancy for the restart to preserve. To keep them available, temporarily increase their replication factor before you restart. See <<Perform a rolling restart>>.
 
-. After the restarted broker's Pod passes its Kubernetes readiness checks, the operator calls the broker's post-restart probe (admin API `GET /v1/broker/post_restart_probe`) and holds the next restart until the broker reports that it has reclaimed 100% of its in-sync-replica load. A Pod can become Ready while the broker inside it is still replaying partition state from its peers, so this gate prevents the operator from taking a second replica down before the first has caught up.
+. After the restarted broker's Pod passes its Kubernetes readiness probe, the operator calls the broker's post-restart probe (Admin API `GET /v1/broker/post_restart_probe`) and holds the next restart until the broker reports that it has reclaimed 100% of its in-sync replica load. A Pod can become Ready while the broker inside it is still replaying partition state from its peers, so this gate prevents the operator from taking a second replica down before the first has caught up.
 
 The restart probes require Redpanda 25.1 or later. On earlier Redpanda versions, the operator falls back to gating restarts on the cluster-wide health check. The probes run only while a restart is in progress, so they add no load during steady-state operation.
 

--- a/modules/manage/pages/kubernetes/k-rolling-restart.adoc
+++ b/modules/manage/pages/kubernetes/k-rolling-restart.adoc
@@ -42,6 +42,25 @@ use the `statefulset.podTemplate.spec.terminationGracePeriodSeconds` setting.
 . The `postStart` hook is executed immediately after a container is created.
 The `postStart` hook takes the broker out of maintenance mode. This action re-integrates the broker into the cluster, allowing it to start handling requests and participate in the cluster's operations again.
 
+[[operator-restart-gates]]
+=== How the Redpanda Operator gates each restart
+
+If the Redpanda Operator manages your cluster, the operator itself replaces the Pods during restarts that it performs, such as applying a configuration change that requires a restart or rolling out a version upgrade. In addition to the maintenance-mode hooks, the operator gates every restart with Redpanda's per-broker restart probes. It restarts at most one broker per pass and re-evaluates the cluster against a fresh view of the brokers before touching the next Pod:
+
+. Before restarting a broker, the operator calls the broker's pre-restart probe (admin API `GET /v1/broker/pre_restart_probe`), which answers the question: if this broker restarts right now, which partitions are put at risk? The operator delays the restart, and retries on its next pass, while the probe reports any of the following risks:
++
+--
+* Partitions that would lose data acknowledged with `acks=1`.
+* Partitions that would become unavailable.
+* Partitions that could no longer complete `acks=all` produce requests.
+--
++
+Partitions on topics with a replication factor of 1 do not block the restart, because they have no redundancy for the restart to preserve. To keep them available, temporarily increase their replication factor before you restart. See <<Perform a rolling restart>>.
+
+. After the restarted broker's Pod passes its Kubernetes readiness checks, the operator calls the broker's post-restart probe (admin API `GET /v1/broker/post_restart_probe`) and holds the next restart until the broker reports that it has reclaimed 100% of its in-sync-replica load. A Pod can become Ready while the broker inside it is still replaying partition state from its peers, so this gate prevents the operator from taking a second replica down before the first has caught up.
+
+The restart probes require Redpanda 25.1 or later. On earlier Redpanda versions, the operator falls back to gating restarts on the cluster-wide health check. The probes run only while a restart is in progress, so they add no load during steady-state operation.
+
 include::upgrade:partial$rolling-upgrades/restart-impact.adoc[leveloffset=+1]
 
 == Perform a rolling restart


### PR DESCRIPTION
Documents the per-broker pre/post-restart probes that gate operator-driven rolling restarts (redpanda-operator#1547, merged 2026-06-25, ships in operator v26.2.x).

## Changes

1. **New section** `How the Redpanda Operator gates each restart` under "What happens during a rolling restart" on `manage:kubernetes/k-rolling-restart.adoc`:
   - The operator replaces Pods itself, one broker per pass, re-evaluating against a fresh broker view each time
   - **Pre-restart probe** (`GET /v1/broker/pre_restart_probe`): the restart is delayed while it would lose `acks=1`-acknowledged data, make partitions unavailable, or block `acks=all` produce; replication-factor-1 partitions don't block (no redundancy to preserve — cross-linked to the existing RF-1 guidance in the procedure)
   - **Post-restart probe** (`GET /v1/broker/post_restart_probe`): the next restart is held until the recovering broker reports 100% of its in-sync-replica load reclaimed, because Pod readiness can pass while the broker is still replaying partition state
   - Version behavior: probes require Redpanda 25.1+; on older versions the operator falls back to the cluster-wide health check; probes run only while a restart is in progress
2. **What's new**: `Safer rolling restarts with per-broker health probes` entry under Redpanda Operator v26.2.x in `get-started:release-notes/operator.adoc`.

## Verification

Content follows the eng PR's probe contract and was cross-checked against operator `main`: `internal/probes/broker.go` (risk-category interpretation, `load_reclaimed_pc >= 100` threshold, 404 fallbacks) and `internal/lifecycle/client.go` (operator-managed StatefulSets use the `OnDelete` update strategy, so the operator's gated roll loop performs the restarts). The eng PR's EKS E2E (6 brokers, sustained rolls under load) recorded 88 post-restart deferrals and 32 pre-restart blocks with zero acks=1 loss.

Note: this PR inserts a section under the v26.2.x what's-new heading, as do open PRs #1808 and #1825 — whichever merges later needs a trivial conflict resolution (the entries just stack).

## Preview pages

- [Perform a Rolling Restart of Redpanda in Kubernetes](https://deploy-preview-1826--redpanda-docs-preview.netlify.app/streaming/current/manage/kubernetes/k-rolling-restart/) (updated)
- [What's New in the Redpanda Operator](https://deploy-preview-1826--redpanda-docs-preview.netlify.app/streaming/current/get-started/release-notes/operator/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
