### PR TITLE
feat(crd-docs): mark beta CRDs with (beta) heading suffix and badge

### DIFF
--- a/.github/crd-config/templates/asciidoctor/operator/type.tpl
+++ b/.github/crd-config/templates/asciidoctor/operator/type.tpl
@@ -7,8 +7,10 @@ line at the start of the section body. The explicit [id=...] anchor above each
 heading is untouched, so existing xrefs keep working.
 Update this pattern when features graduate to GA or new beta CRDs are added.
 Pipeline* = Pipeline CRD, Stretch* = StretchCluster CRD, Shadow* = ShadowLink CRD.
+NamedValueSource (exact match) is a Pipeline-only supporting type that does not
+share the prefix. The shared ValueSource type predates Pipeline and stays GA.
 */ -}}
-{{- $betaTypePattern := "^(Pipeline|Stretch|Shadow)" -}}
+{{- $betaTypePattern := "^(Pipeline|Stretch|Shadow|NamedValueSource$)" -}}
 {{- $isBeta := regexMatch $betaTypePattern $type.Name -}}
 {{- if asciidocShouldRenderType $type -}}
 

--- a/.github/crd-config/templates/asciidoctor/operator/type.tpl
+++ b/.github/crd-config/templates/asciidoctor/operator/type.tpl
@@ -6,11 +6,12 @@ They get a plain (beta) suffix on the section heading and a badge::[label=beta]
 line at the start of the section body. The explicit [id=...] anchor above each
 heading is untouched, so existing xrefs keep working.
 Update this pattern when features graduate to GA or new beta CRDs are added.
-Pipeline* = Pipeline CRD, Stretch* = StretchCluster CRD, Shadow* = ShadowLink CRD.
-NamedValueSource (exact match) is a Pipeline-only supporting type that does not
-share the prefix. The shared ValueSource type predates Pipeline and stays GA.
+Pipeline* = Pipeline CRD (beta in 26.2). NamedValueSource (exact match) is a
+Pipeline-only supporting type that does not share the prefix. The shared
+ValueSource type predates Pipeline and stays GA. StretchCluster and ShadowLink
+are GA in 26.2 and deliberately not listed.
 */ -}}
-{{- $betaTypePattern := "^(Pipeline|Stretch|Shadow|NamedValueSource$)" -}}
+{{- $betaTypePattern := "^(Pipeline|NamedValueSource$)" -}}
 {{- $isBeta := regexMatch $betaTypePattern $type.Name -}}
 {{- if asciidocShouldRenderType $type -}}
 

--- a/.github/crd-config/templates/asciidoctor/operator/type.tpl
+++ b/.github/crd-config/templates/asciidoctor/operator/type.tpl
@@ -1,11 +1,23 @@
 {{- define "type" -}}
 {{- $type := . -}}
+{{- /*
+Beta CRD marking: types whose names match this pattern document beta features.
+They get a plain (beta) suffix on the section heading and a badge::[label=beta]
+line at the start of the section body. The explicit [id=...] anchor above each
+heading is untouched, so existing xrefs keep working.
+Update this pattern when features graduate to GA or new beta CRDs are added.
+Pipeline* = Pipeline CRD, Stretch* = StretchCluster CRD, Shadow* = ShadowLink CRD.
+*/ -}}
+{{- $betaTypePattern := "^(Pipeline|Stretch|Shadow)" -}}
+{{- $isBeta := regexMatch $betaTypePattern $type.Name -}}
 {{- if asciidocShouldRenderType $type -}}
 
 [id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
-== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}
+== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}{{ if $isBeta }}(beta){{ end }}
 
-{{ $type.Doc }}
+{{ if $isBeta }}badge::[label=beta]
+
+{{ end }}{{ $type.Doc }}
 
 {{ if eq $type.Name "RedpandaClusterSpec" }}
 For descriptions and default values, see xref:k-redpanda-helm-spec.adoc[].

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -39,6 +39,7 @@ asciidoc:
   - '@redpanda-data/docs-extensions-and-macros/macros/glossary'
   - '@redpanda-data/docs-extensions-and-macros/macros/config-ref'
   - '@redpanda-data/docs-extensions-and-macros/macros/helm-ref'
+  - '@redpanda-data/docs-extensions-and-macros/macros/badge'
   - '@redpanda-data/docs-extensions-and-macros/asciidoc-extensions/add-line-numbers-highlights'
 antora:
   extensions:


### PR DESCRIPTION
## The gap

The auto-generated `modules/reference/pages/k-crd.adoc` carries no beta indicators for beta CRDs. The Pipeline CRD is a beta feature in operator 26.2 (per the 26.2 release notes, which mark only Redpanda Connect pipelines and Gateway API Console support as beta), but its sections render unmarked in the otherwise-GA reference page. StretchCluster and ShadowLink are GA in 26.2. The NodePool CRD (beta since 26.1) is not part of this reference page, and its own page already carries `:page-beta: true`.

## The convention

Per the team convention for beta features inside an otherwise-GA page:

- A plain `(beta)` suffix on the section heading (no macros in headings, which leak markup into the TOC and anchors).
- A `badge::[label=beta]` badge at the start of the section body.
- `:page-beta:` is not used because the page as a whole is GA.

## Design choice: template-level marking, driven by one editable pattern

The marking is implemented in the docs-side crd-ref-docs template (`.github/crd-config/templates/asciidoctor/operator/type.tpl`), keyed on a single commented pattern at the top of the template:

```gotemplate
{{- $betaTypePattern := "^(Pipeline|NamedValueSource$)" -}}
```

Why the template rather than a post-processing step or a `betaKinds` entry in `.github/crd-config/config.yaml`:

- **Every regen path flows through these templates.** The `generate-crd.yml` workflow, the doc-tools `generate crd-spec` command (its default `--templates-dir` is this directory), and manual `crd-ref-docs` runs all consume `.github/crd-config/templates/asciidoctor/operator`. A post-processing step would have to be wired into each of those paths separately and would silently drop off any path that forgets it. The config paths do NOT converge the same way: the workflow and doc-tools both pull the crd-ref-docs config from the **operator** repo, so `.github/crd-config/config.yaml` here is not consumed by any regen path today, and a `betaKinds` list there would be dead config.
- **crd-ref-docs cannot pass custom config values into templates**, so the list lives as a clearly commented one-line pattern in the template itself. Writers edit that one line when a feature graduates to GA or a new beta CRD ships. crd-ref-docs v0.1.0 (the version pinned in the workflow) ships Sprig, so `regexMatch` is available (verified by running the real binary).
- **No operator repo changes** (no godoc edits, no operator-side markers).

The pattern uses a prefix rather than exact kind names because a beta CRD brings a family of generated type sections that are all beta: `Pipeline*` (6 sections: Pipeline, PipelineBudget, PipelinePhase, PipelineSpec, PipelineStatus, PipelineUserRef) plus `NamedValueSource` (exact match, a Pipeline-only supporting type that does not share the prefix; the shared `ValueSource` type predates Pipeline and stays GA). Verified against the full 221-section output that no GA type matches the pattern.

This PR also registers `@redpanda-data/docs-extensions-and-macros/macros/badge` in `local-antora-playbook.yml` so local previews render the badge. The production docs-site playbooks already register it.

## Anchor stability

The templates emit an explicit `[id="..."]` anchor line above every heading, so the heading text does not participate in ID generation:

```asciidoc
[id="{anchor_prefix}-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-pipeline"]
== Pipeline (beta)

badge::[label=beta]
```

Proof from a real render (not just the source): generated the page before and after the change, converted both with Asciidoctor (with the real `badge` macro from docs-extensions-and-macros registered), and diffed the 221 `<h2 id="...">` values. **Byte-identical.** Heading text differs only by the ` (beta)` suffix on the beta sections (7 with the final Pipeline-only pattern). Existing xrefs such as `xref:reference:k-crd.adoc#k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-pipeline` keep resolving unchanged.

## Validation

Ran the real generation locally with `crd-ref-docs` v0.1.0 (same version and flags as `generate-crd.yml`), against two operator sources, using the same GA ignore config as the #1817/#1830 regens:

- `operator/v26.2.1-beta.3` tag (204 sections, StretchCluster + ShadowLink, no Pipeline because that tag predates the Pipeline CRD merge)
- operator `main` (221 sections, includes Pipeline, same source #1830 regenerated from)

Old templates vs new templates, on the operator-main output:

| Check | Result |
| --- | --- |
| `[id=...]` anchor lines in the .adoc | byte-identical (diff clean) |
| `<h2 id>` values in rendered HTML | byte-identical, all 221 |
| Sections gaining `(beta)` heading suffix | 7, all matching `^(Pipeline\|NamedValueSource$)` |
| `badge::[label=beta]` lines added | 7, one per beta section, all converting to `<span class="badge badge--beta">` in the render |
| Beta-family sections missed | 0 |
| GA sections changed | 0 (every diff hunk is a beta heading suffix, a badge line, or surrounding blank line) |

Example rendered output for the Pipeline section:

```html
<h2 id="k8s-api-github-com-redpanda-data-redpanda-operator-operator-api-redpanda-v1alpha2-pipeline">Pipeline (beta)</h2>
...
<p><span class="badge badge--beta ">(beta)</span></p>
<p>Pipeline defines a Redpanda Connect pipeline managed by the operator.</p>
```

## What this PR does not do

`k-crd.adoc` itself is **not** regenerated here. #1830 (open, also based on `beta`) already regenerates it from operator main to add the Pipeline CRD. Regenerating in this PR too would duplicate and conflict with that work. After this merges, rerunning the #1830 regen with these templates (a single `crd-ref-docs` command) picks up the beta markers, and every future regen keeps them.

History note: an earlier revision of this PR also marked `Stretch*` and `Shadow*` types. That was wrong. Stretch Clusters and ShadowLink are GA in 26.2, and the pattern was corrected to Pipeline-only in commit 51a025f. The anchor-stability proof is pattern-independent (anchors come from explicit `[id=...]` lines, not heading text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

