### PR TITLE
Update antora attributes for 26.2 GA

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,6 @@
 name: streaming
 title: Streaming
 version: 26.2
-display_version: '26.2 Beta'
-prerelease: true
 start_page: home:index.adoc
 nav:
 - modules/ROOT/nav.adoc
@@ -19,7 +17,7 @@ asciidoc:
     page-whats-new-doc: get-started:release-notes/index.adoc
     page-upgrade-doc: upgrade:index.adoc
     # Date of release in the format YYYY-MM-DD
-    page-release-date: 2026-03-31
+    page-release-date: 2026-07-28
     # Only used in the main branch (latest version)
     component-metadata:
       title: "Streaming"
@@ -34,9 +32,9 @@ asciidoc:
     # We try to fetch the latest versions from GitHub at build time
     # --
     full-version: 26.2.1
-    latest-redpanda-tag: 'v26.1.13'
+    latest-redpanda-tag: 'v26.2.1'
     latest-console-tag: 'v3.3.1'
-    latest-release-commit: 'ebee215fdb2b8004735c6f800e532564cdcc05e1'
+    latest-release-commit: '8cd781be99c737c7d147d9dc239a0bbdd591a4d8'
     latest-operator-version: 'v2.3.8-24.3.6'
     operator-beta-tag: ''
     helm-beta-tag: ''

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Redpanda Docs
-  start_page: 26.2@streaming:get-started:intro-to-events.adoc
+  start_page: streaming:get-started:intro-to-events.adoc
   url: http://localhost:5002
   robots: disallow
   keys:
@@ -16,7 +16,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/docs
-    branches: [v/*, main, shared, site-search,'!v-end-of-life/*']
+    branches: [v/*, shared, site-search,'!v-end-of-life/*']
   - url: https://github.com/redpanda-data/cloud-docs
     branches: main
   - url: https://github.com/redpanda-data/redpanda-labs

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-config.adoc
@@ -44,23 +44,33 @@ rpk cluster config [flags]
 |===
 |Command |Description
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-edit.adoc[`rpk cluster config edit`]
 |Edit cluster-wide configuration properties. This command opens a text editor to modify the cluster's configuration.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-export.adoc[`rpk cluster config export`]
 |Export cluster configuration. Writes out a YAML representation of the cluster configuration to a file, suitable for editing and later applying with the corresponding `import` command.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-force-reset.adoc[`rpk cluster config force-reset`]
 |Forcibly clear a cluster configuration property on this node. This command is not for general changes to cluster configuration: use this only when Redpanda will not start due to a configuration issue.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-get.adoc[`rpk cluster config get`]
 |Get a cluster configuration property.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-import.adoc[`rpk cluster config import`]
 |Import cluster configuration from a file. Import configuration from a YAML file, usually generated with corresponding `export` command.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-lint.adoc[`rpk cluster config lint`]
 |Identify any Redpanda configuration properties that are not recognized. These may be properties that were valid in earlier versions of Redpanda but are now managed via the central configuration store.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config-list.adoc[`rpk cluster config list`]
 |List cluster configuration properties. This command lists all available cluster configuration properties.

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage.adoc
@@ -39,8 +39,10 @@ rpk cluster storage [flags]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-storage-mount.adoc[`rpk cluster storage mount`]
 |Mount a topic from Tiered Storage, making it available for reads.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-storage-restore.adoc[`rpk cluster storage restore`]
 |Interact with the topic restoration process. This command is used to restore topics from the archival bucket, which can be useful for disaster recovery or if a topic was accidentally deleted.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-storage-status-mount.adoc[`rpk cluster storage status-mount`]
 |Check the status of a mount or unmount operation for a topic in Tiered Storage.

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
@@ -24,8 +24,10 @@ rpk cluster [flags]
 |===
 |Command |Description
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-brokers.adoc[`rpk cluster brokers`]
 |Manage Redpanda cluster brokers.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-config.adoc[`rpk cluster config`]
 |View and modify cluster-wide configuration properties. Changes take effect across all brokers.
@@ -33,32 +35,44 @@ rpk cluster [flags]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-connections.adoc[`rpk cluster connections`]
 |Manage and monitor cluster connections.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`]
 |Query cluster health and display the overall health status of the cluster. Redpanda collects health reports periodically from all nodes and aggregates them into a health overview.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-info.adoc[`rpk cluster info`]
 |Request broker metadata information. The Kafka protocol's metadata contains information about brokers, topics, and the cluster as a whole.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-license.adoc[`rpk cluster license`]
 |Manage cluster license.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-logdirs.adoc[`rpk cluster logdirs`]
 |Describe log directories on Redpanda brokers.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-loggers.adoc[`rpk cluster loggers`]
 |List and configure Redpanda broker loggers.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-maintenance.adoc[`rpk cluster maintenance`]
 |Manage cluster maintenance mode for performing rolling upgrades and other maintenance operations.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-partitions.adoc[`rpk cluster partitions`]
 |Manage cluster partitions.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-quotas.adoc[`rpk cluster quotas`]
 |Manage Redpanda client quotas.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-self-test.adoc[`rpk cluster self-test`]
 |Start, stop and query runs of Redpanda self-test through the Admin API listener.
+endif::[]
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster-storage.adoc[`rpk cluster storage`]
 |Manage cluster storage, including mounting and unmounting topics from Tiered Storage.
@@ -66,8 +80,10 @@ rpk cluster [flags]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-txn.adoc[`rpk cluster txn`]
 |Information about transactions and transactional producers. Transactions allow producing, or consume-modifying-producing, to Redpanda.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-cluster/rpk-cluster-upgrade.adoc[`rpk cluster upgrade`]
 |Check and finalize major-version upgrades. When the cluster configuration `features_auto_finalization` is disabled, an upgrade stays pending after all brokers are on the new version, so you can downgrade while soak-testing.
+endif::[]
 
 |===
 

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
@@ -30,11 +30,15 @@ rpk generate [template] [flags]
 |xref:reference:rpk/rpk-generate/rpk-generate-grafana-dashboard.adoc[`rpk generate grafana-dashboard`]
 |Generate Grafana dashboards for Redpanda metrics. Use this command to generate sample Grafana dashboards that can be imported into a Grafana or Grafana Cloud instance.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-generate/rpk-generate-license.adoc[`rpk generate license`]
 |Generate a trial license for a 30-day Redpanda Enterprise Edition trial. The license is saved in your working directory or the specified path.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-generate/rpk-generate-prometheus-config.adoc[`rpk generate prometheus-config`]
 |Generate the Prometheus configuration to scrape Redpanda nodes. The output of this command should be included in the `scrape_configs` array within the YAML configuration file of your Prometheus instance.
+endif::[]
 
 |xref:reference:rpk/rpk-generate/rpk-generate-shell-completion.adoc[`rpk generate shell-completion`]
 |Shell completion can help autocomplete `rpk` commands when you press tab. BASH Bash autocompletion relies on the `bash-completion` package.

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile.adoc
@@ -66,8 +66,10 @@ rpk profile [flags]
 |xref:reference:rpk/rpk-profile/rpk-profile-use.adoc[`rpk profile use`]
 |Switch to a different `rpk profile`, making it the active profile for subsequent `rpk` commands.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-profile/rpk-profile-validate.adoc[`rpk profile validate`]
 |Validate profile configuration and detect common issues.
+endif::[]
 
 |===
 

--- a/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
@@ -35,7 +35,7 @@ rpk sec
 |xref:reference:rpk/rpk-security/rpk-security-role.adoc[`rpk security role`]
 |Manage Redpanda roles.
 
-|xref:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]
+|xref:cloud-data-platform:reference:rpk/rpk-security/rpk-security-secret.adoc[`rpk security secret`]
 |Manage secrets for Redpanda Cloud clusters. This command allows you to manage secrets for your cloud clusters.
 
 |xref:reference:rpk/rpk-security/rpk-security-user.adoc[`rpk security user`]

--- a/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
+++ b/modules/reference/pages/rpk/rpk-shadow/rpk-shadow.adoc
@@ -29,8 +29,10 @@ rpk shadow [flags]
 |===
 |Command |Description
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-shadow/rpk-shadow-config.adoc[`rpk shadow config`]
 |Generate a Redpanda Shadow Link configuration file.
+endif::[]
 
 |xref:reference:rpk/rpk-shadow/rpk-shadow-create.adoc[`rpk shadow create`]
 |Create a Redpanda Shadow Link. This command creates a Shadow Link using a configuration file that defines the connection details and synchronization settings.

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
@@ -30,8 +30,10 @@ rpk topic [flags]
 |xref:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[`rpk topic alter-config`]
 |Set, delete, add, and remove key/value configs for a topic. This command allows you to incrementally alter the configuration for multiple topics at a time.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-topic/rpk-topic-analyze.adoc[`rpk topic analyze`]
 |Analyze topics. This command consumes records from the specified topics to determine topic characteristics such as batch rate and batch size.
+endif::[]
 
 |xref:reference:rpk/rpk-topic/rpk-topic-consume.adoc[`rpk topic consume`]
 |Consume records from topics. Consuming records reads from any amount of input topics, formats each record according to `--format`, and prints them to `STDOUT`.
@@ -45,8 +47,10 @@ rpk topic [flags]
 |xref:reference:rpk/rpk-topic/rpk-topic-describe.adoc[`rpk topic describe`]
 |Print detailed information about topics. There are three potential views: a summary of the topic, the topic configurations, and a detailed partitions section.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-topic/rpk-topic-describe-storage.adoc[`rpk topic describe-storage`]
 |Describe the cloud storage status of a topic, including storage mode, offset availability, segment sizes, and synchronization state.
+endif::[]
 
 |xref:reference:rpk/rpk-topic/rpk-topic-list.adoc[`rpk topic list`]
 |List topics, optionally listing specific topics. This command lists all topics that you have access to by default.

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform.adoc
@@ -49,11 +49,15 @@ rpk transfrom
 |xref:reference:rpk/rpk-transform/rpk-transform-logs.adoc[`rpk transform logs`]
 |View logs for a data transform. Streams STDOUT and STDERR output captured during runtime to your terminal.
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-transform/rpk-transform-pause.adoc[`rpk transform pause`]
 |Pause a data transform. This command suspends execution of the specified transform without removing it from the system.
+endif::[]
 
+ifndef::env-cloud[]
 |xref:reference:rpk/rpk-transform/rpk-transform-resume.adoc[`rpk transform resume`]
 |Resume a data transform. This command resumes execution of the specified data transform, if it was previously paused.
+endif::[]
 
 |===
 

--- a/modules/reference/pages/rpk/rpk.adoc
+++ b/modules/reference/pages/rpk/rpk.adoc
@@ -23,7 +23,7 @@ rpk [flags]
 |===
 |Command |Description
 
-|xref:reference:rpk/rpk-cloud/rpk-cloud.adoc[`rpk cloud`]
+|xref:cloud-data-platform:reference:rpk/rpk-cloud/rpk-cloud.adoc[`rpk cloud`]
 |Interact with Redpanda Cloud.
 
 |xref:reference:rpk/rpk-cluster/rpk-cluster.adoc[`rpk cluster`]

--- a/modules/reference/partials/rpk-cloud/rpk-cloud-mcp.adoc
+++ b/modules/reference/partials/rpk-cloud/rpk-cloud-mcp.adoc
@@ -26,9 +26,6 @@ rpk cloud mcp [flags]
 |xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-install.adoc[`rpk cloud mcp install`]
 |Install the MCP client configuration to connect your AI assistant to the local MCP server for Redpanda Cloud. This command generates and installs the necessary configuration files for your MCP client (like Claude Code) to automatically connect to the local MCP server for Redpanda Cloud.
 
-|xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-proxy.adoc[`rpk cloud mcp proxy`]
-|Proxy MCP requests to a remote Redpanda Cloud MCP server. This command connects to a specific cluster and MCP server running in that cluster, then proxies MCP requests from stdio to the remote MCP server over HTTP.
-
 |xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-stdio.adoc[`rpk cloud mcp stdio`]
 |Communicate with the local MCP server for Redpanda Cloud using the stdio protocol. This command provides a direct stdio interface for communicating with the local MCP server for Redpanda Cloud.
 

--- a/modules/reference/partials/rpk-cloud/rpk-cloud-mcp.adoc
+++ b/modules/reference/partials/rpk-cloud/rpk-cloud-mcp.adoc
@@ -26,6 +26,9 @@ rpk cloud mcp [flags]
 |xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-install.adoc[`rpk cloud mcp install`]
 |Install the MCP client configuration to connect your AI assistant to the local MCP server for Redpanda Cloud. This command generates and installs the necessary configuration files for your MCP client (like Claude Code) to automatically connect to the local MCP server for Redpanda Cloud.
 
+|xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-proxy.adoc[`rpk cloud mcp proxy`]
+|Proxy MCP requests to a remote Redpanda Cloud MCP server. This command connects to a specific cluster and MCP server running in that cluster, then proxies MCP requests from stdio to the remote MCP server over HTTP.
+
 |xref:reference:rpk/rpk-cloud/rpk-cloud-mcp-stdio.adoc[`rpk cloud mcp stdio`]
 |Communicate with the local MCP server for Redpanda Cloud using the stdio protocol. This command provides a direct stdio interface for communicating with the local MCP server for Redpanda Cloud.
 


### PR DESCRIPTION
Prepares the `beta` branch for the 26.2 GA release, following the beta-to-GA runbook.

## Changes

### `antora.yml`
- Remove the `prerelease: true` and `display_version: '26.2 Beta'` attributes.
- Update `latest-redpanda-tag` to `v26.2.1` and `latest-release-commit` to `8cd781be99c737c7d147d9dc239a0bbdd591a4d8` (the commit the `v26.2.1` tag points to). `full-version` was already `26.2.1`.
- Set `page-release-date` to `2026-07-28`. This drives the EoL calculation and notification banners.

### `local-antora-playbook.yml`
- Remove the version ID from `start_page` (`26.2@streaming:...` → `streaming:...`).
- Remove `main` from the docs content branches. After GA, this branch's content becomes `main`, so keeping it would duplicate the component version.

## Out of scope (remaining GA steps, handled separately)

Disabling build workflows, creating `v/26.1` off `main`, build previews, the beta→main merge (true merge commit, not squash), beta branch deletion, docs-site playbook/redirect updates, and EoL renames.