### PR TITLE
DOC-2407: add selfHostedOnly overrides for cloud-unavailable rpk commands

### DIFF
--- a/docs-data/RPK_OVERRIDES_GUIDE.adoc
+++ b/docs-data/RPK_OVERRIDES_GUIDE.adoc
@@ -331,6 +331,26 @@ Mark commands as platform-specific:
 
 Valid platforms: `linux`, `darwin`, `windows`
 
+== Cloud availability
+
+Mark a whole command as available in only one environment:
+
+[,json]
+----
+"rpk cluster health": {
+  "selfHostedOnly": true
+}
+----
+
+Use `selfHostedOnly` for commands that do not apply to Redpanda Cloud clusters, and `cloudOnly` for commands that apply only to them.
+
+Setting either key does two things:
+
+* Wraps the command's own page in an `ifndef::env-cloud[]` (or `ifdef::env-cloud[]`) conditional.
+* Wraps the command's row in the parent command's Subcommands table in the same conditional, so cloud-docs pages that single-source the table do not link to pages that only exist in the self-managed docs.
+
+NOTE: The `rpk cloud` and `rpk security secret` command families need no override. Their pages are generated into the cloud partials directory and published by cloud-docs, and their rows in regular pages automatically link across to the `cloud-data-platform` component.
+
 == Deprecation
 
 Mark commands as deprecated:
@@ -342,7 +362,7 @@ Mark commands as deprecated:
   "deprecatedMessage": "Use 'rpk new-command' instead.",
   "deprecatedInVersion": "v24.1.0",
   "removedInVersion": "v25.1.0",
-  "replacement": "xref:rpk-new-command.adoc[rpk new-command]"
+  "replacement": "xref:reference:rpk/rpk-new-command.adoc[rpk new-command]"
 }
 ----
 

--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -1510,13 +1510,15 @@
           "position": "after_description",
           "content": "A cluster is considered healthy when the following conditions are met:\n\n* All cluster nodes are responding\n* All partitions have leaders\n* The cluster controller is present"
         }
-      ]
+      ],
+      "selfHostedOnly": true
     },
     "rpk cluster maintenance": {
       "description": "Manage cluster maintenance mode for performing rolling upgrades and other maintenance operations.",
       "$refs": [
         "#/definitions/common-admin-flags"
-      ]
+      ],
+      "selfHostedOnly": true
     },
     "rpk cluster maintenance enable": {
       "description": "Enable maintenance mode on a broker. While in maintenance mode, the broker drains partition leadership to other brokers. Use this command before performing broker upgrades or hardware maintenance. After maintenance is complete, run `rpk cluster maintenance disable <broker-id>` to restore normal operation.",
@@ -1644,7 +1646,8 @@
         "cache-file": {
           "description": "Location of the configuration cache file. Defaults to the Redpanda data directory."
         }
-      }
+      },
+      "selfHostedOnly": true
     },
     "rpk cluster config get": {
       "description": "Get a cluster configuration property.",
@@ -2066,7 +2069,8 @@
         "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-start.adoc[rpk cluster self-test start]",
         "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-status.adoc[rpk cluster self-test status]",
         "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-stop.adoc[rpk cluster self-test stop]"
-      ]
+      ],
+      "selfHostedOnly": true
     },
     "rpk cluster storage restore start": {
       "description": "Start the cluster restoration process. This command starts the process of restoring data from a failed cluster with Tiered Storage enabled, including its metadata, onto a new cluster. If the wait flag (`--wait`/`-w`) is set, the command will poll the status of the recovery process until it's finished. Use `--cluster-uuid-override` if you want to specify an explicit cluster UUID to restore from.",
@@ -2085,7 +2089,8 @@
       "seeAlso": [
         "xref:manage:whole-cluster-restore.adoc[Whole-Cluster Restore]"
       ],
-      "pageAliases": "reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc"
+      "pageAliases": "reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc",
+      "selfHostedOnly": true
     },
     "rpk connect dry-run": {
       "description": "Test pipeline configurations by performing a dry run. Exits with a status code 1 if any connection errors are detected in a directory.",
@@ -2257,7 +2262,9 @@
         }
       }
     },
-    "rpk generate prometheus-config": {},
+    "rpk generate prometheus-config": {
+      "selfHostedOnly": true
+    },
     "rpk group delete": {
       "content": [
         {
@@ -2476,7 +2483,8 @@
         "human-readable": {
           "description": "Print times (in milliseconds) and byte values in human-readable units (for example, 1.2 GiB, 3m 20s)."
         }
-      }
+      },
+      "selfHostedOnly": true
     },
     "rpk transform deploy": {
       "content": [
@@ -3127,17 +3135,20 @@
         "timeout": {
           "description": "Maximum duration for the command to run before timing out."
         }
-      }
+      },
+      "selfHostedOnly": true
     },
     "rpk cluster config import": {
       "flags": {
         "filename": {
           "description": "Full path to the configuration file to import, for example, `/tmp/config.yml`."
         }
-      }
+      },
+      "selfHostedOnly": true
     },
     "rpk cluster config lint": {
-      "description": "Identify any Redpanda configuration properties that are not recognized. These may be properties that were valid in earlier versions of Redpanda but are now managed via the central configuration store."
+      "description": "Identify any Redpanda configuration properties that are not recognized. These may be properties that were valid in earlier versions of Redpanda but are now managed via the central configuration store.",
+      "selfHostedOnly": true
     },
     "rpk cluster logdirs describe": {
       "flags": {
@@ -3228,7 +3239,8 @@
       "description": "View logs for a data transform. Streams STDOUT and STDERR output captured during runtime to your terminal."
     },
     "rpk generate license": {
-      "description": "Generate a trial license for a 30-day Redpanda Enterprise Edition trial. The license is saved in your working directory or the specified path."
+      "description": "Generate a trial license for a 30-day Redpanda Enterprise Edition trial. The license is saved in your working directory or the specified path.",
+      "selfHostedOnly": true
     },
     "rpk ai auth login": {
       "description": "Run the OAuth 2.0 device authorization grant against Redpanda Cloud, persist the resulting credentials, and prompt to select an environment whose AI Gateway URL becomes the active profile's dataplane URL."
@@ -3468,11 +3480,16 @@
       }
     },
     "rpk cluster partitions": {
-      "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-partitions.adoc"
+      "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-partitions.adoc",
+      "selfHostedOnly": true
     },
     "rpk cluster brokers": {
       "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers.adoc",
+<<<<<<< HEAD
       "introducedInVersion": "v26.2.1"
+=======
+      "selfHostedOnly": true
+>>>>>>> a8cf35b4 (Add selfHostedOnly overrides for cloud-unavailable rpk commands)
     },
     "rpk cluster brokers decommission": {
       "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission.adoc",
@@ -3488,7 +3505,11 @@
     },
     "rpk cluster loggers": {
       "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level.adoc",
+<<<<<<< HEAD
       "introducedInVersion": "v26.2.1"
+=======
+      "selfHostedOnly": true
+>>>>>>> a8cf35b4 (Add selfHostedOnly overrides for cloud-unavailable rpk commands)
     },
     "rpk cluster loggers set": {
       "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level-set.adoc",
@@ -3549,6 +3570,7 @@
     },
     "rpk check install": {
       "description": "Install Redpanda Check.\n\nThis command installs the latest version by default.\n\nAlternatively, you may specify a version using the `--check-version` flag.\n\nYou may force the installation using the `--force` flag.",
+<<<<<<< HEAD
       "_note": "The source help text is missing a period after the summary sentence, which breaks the generated meta description.",
       "introducedInVersion": "v26.2.1"
     },
@@ -3728,6 +3750,33 @@
           "introducedInVersion": "v26.2.1"
         }
       }
+=======
+      "_note": "The source help text is missing a period after the summary sentence, which breaks the generated meta description."
+    },
+    "rpk cluster license": {
+      "selfHostedOnly": true
+    },
+    "rpk cluster upgrade": {
+      "selfHostedOnly": true
+    },
+    "rpk cluster config edit": {
+      "selfHostedOnly": true
+    },
+    "rpk cluster config export": {
+      "selfHostedOnly": true
+    },
+    "rpk transform pause": {
+      "selfHostedOnly": true
+    },
+    "rpk transform resume": {
+      "selfHostedOnly": true
+    },
+    "rpk shadow config": {
+      "selfHostedOnly": true
+    },
+    "rpk profile validate": {
+      "selfHostedOnly": true
+>>>>>>> a8cf35b4 (Add selfHostedOnly overrides for cloud-unavailable rpk commands)
     }
   }
 }


### PR DESCRIPTION
Follow-up to #1837, which fixed 25 broken-xref build errors by hand-editing autogenerated rpk pages. Those edits would be reverted by the next rpk regeneration because the generator had no way to express them.

This PR encodes the intent in `rpk-overrides.json` so regeneration reproduces the fixes:

- Adds `selfHostedOnly: true` to the 22 commands whose reference pages exist only in the self-managed docs (cluster brokers/health/license/loggers/maintenance/partitions/self-test/upgrade, cluster config edit/export/force-reset/import/lint, cluster storage restore, transform pause/resume, topic analyze/describe-storage, shadow config, profile validate, generate license/prometheus-config).
- Documents the command-level `cloudOnly`/`selfHostedOnly` keys in a new "Cloud availability" section of the overrides guide, and fixes a module-prefix lint warning in an existing guide example.

Requires the generator support in redpanda-data/docs-extensions-and-macros PR "feat(rpk-docs): gate subcommand table rows by cloud availability". Verified by running that generator build against `rpk-v26.2.1-rc2.json` with these overrides: the regenerated pages are byte-identical to the pages fixed in #1837. The overrides are inert until a regeneration runs with the new generator, so merge order does not matter.

## Jira

Fixes [DOC-2407](https://redpandadata.atlassian.net/browse/DOC-2407): the 22 `selfHostedOnly` entries here match the ticket's 22 broken cloud-docs xref targets exactly (verified 2026-08-02). Once this merges and the rpk pages regenerate, the parent pages' rows for these commands render inside `ifndef::env-cloud[]` and the cloud-docs builds stop emitting the broken links.

[DOC-2407]: https://redpandadata.atlassian.net/browse/DOC-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ