### PR TITLE
ci: fix What's-new diff base and accept pre-GA plugin pins

### DIFF
--- a/.github/workflows/update-rpk-docs.yml
+++ b/.github/workflows/update-rpk-docs.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: 'true'
         type: boolean
+      plugin_pins:
+        description: 'Comma-separated plugin version pins for pre-GA plugins (e.g. k8s=26.3.1-beta.1). Without a pin, a plugin with no promoted latest version installs nothing and its commands are absent from the docs.'
+        required: false
   repository_dispatch:
     types: [update-rpk-docs]
 
@@ -55,24 +58,29 @@ jobs:
           DISPATCH_VERSION: ${{ github.event.client_payload.version }}
           DISPATCH_DIFF_VERSION: ${{ github.event.client_payload.diff_version }}
           DISPATCH_DRAFT_MISSING: ${{ github.event.client_payload.draft_missing }}
+          DISPATCH_PLUGIN_PINS: ${{ github.event.client_payload.plugin_pins }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
           INPUT_DIFF_VERSION: ${{ github.event.inputs.diff_version }}
           INPUT_DRAFT_MISSING: ${{ github.event.inputs.draft_missing }}
+          INPUT_PLUGIN_PINS: ${{ github.event.inputs.plugin_pins }}
         run: |
           # Handle workflow_dispatch vs repository_dispatch
           if [ "$EVENT_NAME" = "repository_dispatch" ]; then
             VERSION="${DISPATCH_VERSION:-dev}"
             DIFF_VERSION="${DISPATCH_DIFF_VERSION}"
             DRAFT_MISSING="${DISPATCH_DRAFT_MISSING:-false}"
+            PLUGIN_PINS="${DISPATCH_PLUGIN_PINS}"
           else
             VERSION="${INPUT_VERSION}"
             DIFF_VERSION="${INPUT_DIFF_VERSION}"
             DRAFT_MISSING="${INPUT_DRAFT_MISSING}"
+            PLUGIN_PINS="${INPUT_PLUGIN_PINS}"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "diff_version=$DIFF_VERSION" >> $GITHUB_OUTPUT
           echo "draft_missing=$DRAFT_MISSING" >> $GITHUB_OUTPUT
+          echo "plugin_pins=$PLUGIN_PINS" >> $GITHUB_OUTPUT
 
           # Detect RC versions (e.g., v26.2.0-rc1, 26.2.0-rc2)
           if [[ "$VERSION" =~ -rc[0-9]+$ ]]; then
@@ -200,6 +208,22 @@ jobs:
           DRAFT_MISSING="${{ steps.params.outputs.draft_missing }}"
           if [ "$DRAFT_MISSING" = "true" ]; then
             CMD="$CMD --draft-missing"
+          fi
+
+          # Pin individual plugin installs (pre-GA plugins have no promoted
+          # latest version, so unpinned installs resolve nothing and their
+          # commands drop out of the docs).
+          PLUGIN_PINS="${{ steps.params.outputs.plugin_pins }}"
+          if [ -n "$PLUGIN_PINS" ]; then
+            IFS=',' read -ra PINS <<< "$PLUGIN_PINS"
+            for PIN in "${PINS[@]}"; do
+              PIN="$(echo "$PIN" | tr -d '[:space:]')"
+              if [[ ! "$PIN" =~ ^[a-z0-9]+=[A-Za-z0-9._-]+$ ]]; then
+                echo "::error::Invalid plugin pin '$PIN'. Expected <name>=<version>, e.g. k8s=26.3.1-beta.1"
+                exit 1
+              fi
+              CMD="$CMD --plugin-pin $PIN"
+            done
           fi
 
           CMD="$CMD --output-dir modules/reference/pages/rpk"

--- a/.github/workflows/update-rpk-docs.yml
+++ b/.github/workflows/update-rpk-docs.yml
@@ -142,18 +142,21 @@ jobs:
           VERSION="${{ steps.params.outputs.version }}"
 
           # When no diff version is supplied (the usual case for the rpk-release
-          # repository_dispatch trigger), fall back to the currently-published
-          # version recorded in antora.yml (full-version). That is the version the
-          # docs currently target, so it is the correct baseline for "what's new".
+          # repository_dispatch trigger), diff against the newest committed rpk
+          # snapshot on this branch: that is the version the docs currently
+          # document, so it is the correct baseline for "what's new". Resolving
+          # from antora.yml full-version broke whenever full-version advanced
+          # past the newest snapshot (RC suffixes on beta, or patch releases
+          # documented by other automations on main) — the named snapshot did
+          # not exist, so the diff and the What's new update silently skipped.
           if [ -z "$DIFF_VERSION" ]; then
-            FULL_VERSION=$(grep -E '^\s*full-version:' antora.yml \
-              | head -1 \
-              | sed -E "s/.*full-version:[[:space:]]*['\"]?([^'\"[:space:]]+).*/\1/")
-            if [ -n "$FULL_VERSION" ]; then
-              DIFF_VERSION="v${FULL_VERSION#v}"
-              echo "Using antora.yml full-version as diff base: $DIFF_VERSION"
+            NEWEST_SNAPSHOT=$(ls docs-data/rpk-v*.json 2>/dev/null | grep -v 'rpk-diff' | sort -V | tail -1)
+            if [ -n "$NEWEST_SNAPSHOT" ]; then
+              DIFF_VERSION=$(basename "$NEWEST_SNAPSHOT" .json)
+              DIFF_VERSION="${DIFF_VERSION#rpk-}"
+              echo "Using newest committed snapshot as diff base: $DIFF_VERSION"
             else
-              echo "Could not read full-version from antora.yml; skipping diff"
+              echo "No committed rpk snapshot found; skipping diff"
             fi
           else
             echo "Using supplied diff version: $DIFF_VERSION"

--- a/.github/workflows/update-rpk-docs.yml
+++ b/.github/workflows/update-rpk-docs.yml
@@ -158,7 +158,11 @@ jobs:
           # documented by other automations on main) — the named snapshot did
           # not exist, so the diff and the What's new update silently skipped.
           if [ -z "$DIFF_VERSION" ]; then
-            NEWEST_SNAPSHOT=$(ls docs-data/rpk-v*.json 2>/dev/null | grep -v 'rpk-diff' | sort -V | tail -1)
+            # Tilde-normalize prerelease suffixes before sorting: plain sort -V
+            # ranks v26.2.1-rc2 AFTER v26.2.1, so once a GA snapshot lands next
+            # to a lingering rc file the rc would win. ~ sorts lowest in GNU
+            # version sort, and rc2 < rc10 ordering is preserved.
+            NEWEST_SNAPSHOT=$(ls docs-data/rpk-v*.json 2>/dev/null | grep -v 'rpk-diff' | sed 's/-rc/~rc/' | sort -V | sed 's/~rc/-rc/' | tail -1)
             if [ -n "$NEWEST_SNAPSHOT" ]; then
               DIFF_VERSION=$(basename "$NEWEST_SNAPSHOT" .json)
               DIFF_VERSION="${DIFF_VERSION#rpk-}"


### PR DESCRIPTION
## Summary

Two related fixes to the RC/stable rpk docs workflow.

### 1. Diff against the newest committed snapshot

The What's-new diff never fired automatically: the diff base was resolved from antora.yml's `full-version`, then looked up as `docs-data/rpk-v<full-version>.json` — a file that doesn't exist whenever full-version has advanced past the newest snapshot. That was every RC run on beta (snapshots carry `-rcN` suffixes), and now main too (post-GA full-version is `26.2.1`, newest snapshot is `rpk-v26.2.1-rc2.json`, so the GA run would diff against itself and skip).

Now the diff base is the newest committed `rpk-v*.json` on the target branch — the version the docs currently document, the correct What's-new baseline in every case. Explicit `diff_version` still wins; the self-diff guard still covers re-dispatches.

| Dispatch | Old behavior | New behavior |
|---|---|---|
| `v26.2.1` (GA) | diff vs itself → skipped | diff vs `v26.2.1-rc2` |
| `v26.2.1-rc2` (re-run) | skipped | skipped (self-diff guard) |
| `v26.2.2` (future) | snapshot missing → skipped | diff vs newest documented |

### 2. Per-plugin version pins for pre-GA plugins

Full regenerations install the latest published version of every plugin, so a beta-only plugin with no version promoted to latest installs nothing and its commands drop out of the docs — how the `rpk k8s` pages went missing during the 26.2 beta window (#1831). A new `plugin_pins` input/payload field (comma-separated `name=version`, e.g. `k8s=26.3.1-beta.1`) forwards `--plugin-pin` flags to the generator so RC regens can install pre-GA plugin versions. Malformed pins fail loudly. Requires doc-tools ≥ 5.3.0 (docs-extensions-and-macros#225), which the same release train delivers.

## Verification

- Diff-base shell logic tested against main's real snapshot state (table above).
- End-to-end: production run [30433604980](https://github.com/redpanda-data/docs/actions/runs/30433604980) exercises the identical downstream path (diff → What's-new → PR) via explicit `diff_version=v26.1.12` for the v26.2.1 GA regen.
- `--plugin-pin` validated in doc-tools (#225) with retry-without-pin fallback and `plugin_versions` recording.

## Related PRs (rpk docs automation train)

| PR | Role | Depends on |
|---|---|---|
| redpanda-data/docs-extensions-and-macros#225 | Generator: `--plugin` mode, change detection, deprecations, What's-new merge, flag extraction, stub reconciler (publishes doc-tools 5.3.0) | — |
| redpanda-data/docs#1834 | Receiver workflow for plugin-release dispatches | #225 |
| redpanda-data/docs#1844 | Release workflow: auto What's-new diff base + pre-GA plugin pins | #225 |
| redpanda-data/docs#1849 | Removes two stale rpk ai partials | merge before #1852/adp-docs#165 activate |
| redpanda-data/docs#1852 | Sender: docs main → adp-docs stub sync dispatch | #225, adp-docs#165 |
| redpanda-data/adp-docs#165 | Receiver: reconciles rpk ai stubs and nav | #225, docs#1852 |
| Senders (merged/open) | redpanda-data/connect#4636, redpanda-operator#1703 (merged), redpanda-check#10, cloudv2#28552 | docs#1834 |

Merge order: #225 → dependency bumps on docs main and beta → #1834 + #1844 (+ #1849) → #1852 + adp-docs#165 → remaining senders. Jira: DOC-2355, DOC-1090.
