### PR TITLE
Schema Registry contexts: SerDes client support via URL prefix (DOC-2397, DOC-2304)

### DIFF
--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -65,7 +65,7 @@ See xref:manage:iceberg/specify-iceberg-schema.adoc#resolve-schemas-within-a-con
 
 Any SerDes client, in any language, can now target a xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry context] through its base URL alone: point the client's `schema.registry.url` at `\http://<host>:8081/contexts/\{context\}`. All endpoints that SerDes clients use are available under the `/contexts/\{context\}/` prefix, and schema ID lookups are scoped to the context automatically. Previously, only the Java Confluent SerDes could target non-default contexts.
 
-Schema Registry contexts are also enabled by default in this release: `schema_registry_enable_qualified_subjects` now defaults to `true`.
+Schema Registry contexts are also enabled by default in this release: `schema_registry_enable_qualified_subjects` now defaults to `true`. This applies to existing clusters when they upgrade, unless the property was explicitly set to `false` before the upgrade. If any of your subject names start with `:.`, review the xref:manage:schema-reg/schema-reg-contexts.adoc#upgrade-considerations[upgrade considerations] before upgrading.
 
 See xref:manage:schema-reg/schema-reg-contexts.adoc#serdes-clients[Use contexts with SerDes clients].
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -166,7 +166,7 @@ NOTE: Cloud Topics requires an Enterprise license. For more information, contact
 == Changed property defaults
 
 * xref:reference:properties/cluster-properties.adoc#min_cleanable_dirty_ratio[`min_cleanable_dirty_ratio`] and the equivalent xref:reference:properties/topic-properties.adoc#min-cleanable-dirty-ratio[`min.cleanable.dirty.ratio`] topic property: the default increased from `0.2` to `0.5`. Compaction now waits for a higher proportion of dirty bytes before a partition becomes eligible, reducing background compaction work on write-heavy clusters.
-* xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`]: the default changed from `false` to `true`. Schema Registry now accepts context-qualified subject names by default.
+* xref:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`]: the default changed from `false` to `true`. Schema Registry now accepts context-qualified subject names by default. The new default applies to existing clusters when they upgrade, unless the property was explicitly set to `false` before the upgrade. See the xref:manage:schema-reg/schema-reg-contexts.adoc#upgrade-considerations[upgrade considerations].
 
 == Deprecated properties
 

--- a/modules/get-started/pages/release-notes/redpanda.adoc
+++ b/modules/get-started/pages/release-notes/redpanda.adoc
@@ -61,6 +61,14 @@ Bind a topic's Iceberg translation to a specific xref:manage:schema-reg/schema-r
 
 See xref:manage:iceberg/specify-iceberg-schema.adoc#resolve-schemas-within-a-context[Resolve schemas within a Schema Registry context].
 
+== Schema Registry contexts: SerDes client support
+
+Any SerDes client, in any language, can now target a xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry context] through its base URL alone: point the client's `schema.registry.url` at `\http://<host>:8081/contexts/\{context\}`. All endpoints that SerDes clients use are available under the `/contexts/\{context\}/` prefix, and schema ID lookups are scoped to the context automatically. Previously, only the Java Confluent SerDes could target non-default contexts.
+
+Schema Registry contexts are also enabled by default in this release: `schema_registry_enable_qualified_subjects` now defaults to `true`.
+
+See xref:manage:schema-reg/schema-reg-contexts.adoc#serdes-clients[Use contexts with SerDes clients].
+
 == Iceberg key and header translation
 
 Independently control how Redpanda translates a record's key, value, and headers into the Iceberg table with a new section-based syntax for the `redpanda.iceberg.mode` topic property. You can decode keys and values using a schema registered in the Schema Registry, store keys or values as UTF-8 strings, or decode header values from raw bytes to strings. The `key_value`, `value_schema_id_prefix`, and `value_schema_latest` modes continue to work as shorthand for common combinations.

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -245,11 +245,13 @@ When you register an evolved schema for an existing subject, the version `id` is
 Starting in Redpanda v26.1, you can use contexts to create isolated namespaces for schemas, subjects, and configuration within a single Schema Registry instance.
 
 ifndef::env-cloud[]
-To use contexts, first set the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`, then restart the brokers. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for setup instructions.
+In Redpanda 26.2 and later, contexts are enabled by default. In earlier versions, first set the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`, then restart the brokers. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for setup instructions.
 endif::env-cloud[]
 ifdef::env-cloud[]
-To use contexts on BYOC and Dedicated clusters, xref:manage:cluster-maintenance/config-cluster.adoc[configure the cluster property] `schema_registry_enable_qualified_subjects`. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for details.
+On BYOC and Dedicated clusters, contexts are enabled by default. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for details.
 endif::env-cloud[]
+
+You can also scope any request to a context by sending it through a `/contexts/\{context\}/` URL prefix instead of using qualified subject names. This is how SerDes clients target a context. See xref:manage:schema-reg/schema-reg-contexts.adoc#serdes-clients[Use contexts with SerDes clients].
 
 Contexts are created implicitly when you register a schema using a context-qualified subject. For example, registering a schema with the subject `:.staging:sensor-value` creates the `.staging` context if it does not already exist:
 

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -245,7 +245,7 @@ When you register an evolved schema for an existing subject, the version `id` is
 Starting in Redpanda v26.1, you can use contexts to create isolated namespaces for schemas, subjects, and configuration within a single Schema Registry instance.
 
 ifndef::env-cloud[]
-In Redpanda 26.2 and later, contexts are enabled by default. In earlier versions, first set the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`, then restart the brokers. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for setup instructions.
+In Redpanda v26.2 and later, contexts are enabled by default. In earlier versions, first set the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`, then restart the brokers. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for setup instructions.
 endif::env-cloud[]
 ifdef::env-cloud[]
 On BYOC and Dedicated clusters, contexts are enabled by default. See xref:manage:schema-reg/schema-reg-contexts.adoc[] for details.

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -684,7 +684,10 @@ For the full metrics reference, see xref:streaming:reference:public-metrics-refe
 
 [IMPORTANT]
 ====
-*Breaking change*: When `schema_registry_enable_qualified_subjects` is enabled, any existing subject whose name matches the qualified subject pattern (for example, `:.staging:user-value`) is reinterpreted as subject `user-value` in context `.staging`, rather than as a literal subject name in the default context. Subjects without a `:.` prefix are unaffected.
+ifndef::env-cloud[]
+*Breaking change*: Upgrading to Redpanda v26.2 or later enables `schema_registry_enable_qualified_subjects` automatically, including on existing clusters, unless you explicitly set the property to `false` before the upgrade.
+endif::env-cloud[]
+When `schema_registry_enable_qualified_subjects` is enabled, any existing subject whose name matches the qualified subject pattern (for example, `:.staging:user-value`) is reinterpreted as subject `user-value` in context `.staging`, rather than as a literal subject name in the default context. Subjects without a `:.` prefix are unaffected.
 
 This edge case is rare. No automatic migration is provided.
 ====
@@ -711,6 +714,8 @@ If you find affected subjects, rename them before enabling the property, or crea
 [IMPORTANT]
 ====
 Remember that changing `schema_registry_enable_qualified_subjects` requires a broker restart in both directions (enabling and disabling).
+
+Treat disabling the property as a stopgap while you rename affected subjects: the property is temporary and planned for removal in a future release, after which qualified subject parsing is always on.
 ====
 
 == Troubleshooting
@@ -742,14 +747,14 @@ endif::env-cloud[]
 
 *Cause 2*: The property was set to `true` but the brokers have not yet been restarted. This property is not dynamic and requires a full broker restart to take effect.
 
-To confirm, check whether the registry lists only the default context while clients are using qualified subjects or context URLs:
+To investigate, list the materialized contexts:
 
 [source,bash]
 ----
 curl -s http://localhost:8081/contexts
 ----
 
-If the response is `["."]`, qualified subject parsing is not active.
+A response of `["."]` alone does not confirm the cause: an enabled registry that has no schemas registered in named contexts returns the same result. To confirm, check the property value and whether the brokers have restarted since it changed, or register a test schema in a non-default context and list the contexts again. If the new context does not appear, qualified subject parsing is not active, and the test schema was stored under a literal subject name. Hard-delete the test subject before enabling the property so that it is not reinterpreted later (see <<upgrade-considerations>>).
 
 *Resolution*:
 

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -66,7 +66,7 @@ ifndef::env-cloud[]
 * You are running xref:streaming:get-started:release-notes/redpanda.adoc[Redpanda v26.1] or later.
 endif::env-cloud[]
 
-* The xref:streaming:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster configuration property is set to `true`.
+* The xref:streaming:reference:properties/cluster-properties.adoc#schema_registry_enable_qualified_subjects[`schema_registry_enable_qualified_subjects`] cluster configuration property is enabled.
 +
 [IMPORTANT]
 ====
@@ -86,7 +86,7 @@ endif::env-cloud[]
 * *`referencedby` endpoint*: `GET /subjects/\{subject\}/versions/\{version\}/referencedby` returns a list of bare schema IDs with no context information. When references span contexts, it is not possible to determine which context each returned ID belongs to.
 * *Cross-context isolation*: Contexts provide organizational and ID-space isolation, but do not prevent cross-context schema references. There is no mechanism to block schemas in one context from referencing schemas in another context.
 * *Default context cannot be deleted*: You cannot delete the default context (`.`).
-* *Breaking change on upgrade*: After enabling `schema_registry_enable_qualified_subjects`, any existing subject whose name matches the qualified subject pattern (for example, `:.staging:user-value`) is reinterpreted as subject `user-value` in context `.staging` rather than as a literal subject name in the default context. See <<upgrade-considerations>>.
+* *Breaking change on upgrade*: When `schema_registry_enable_qualified_subjects` is enabled (the default in Redpanda v26.2 and later, including on upgraded clusters), any existing subject whose name matches the qualified subject pattern (for example, `:.staging:user-value`) is reinterpreted as subject `user-value` in context `.staging` rather than as a literal subject name in the default context. See <<upgrade-considerations>>.
 
 
 == How Schema Registry contexts work
@@ -514,7 +514,7 @@ endif::env-cloud[]
 
 For example, to scope a client to the `.staging` context:
 
-[source,properties]
+[source,ini]
 ----
 schema.registry.url=http://<host>:8081/contexts/.staging
 ----
@@ -546,7 +546,7 @@ curl -s -X POST \
   -d '{"schema": "{\"type\":\"string\"}"}'
 ----
 
-The context segment of the URL accepts equivalent forms: `/contexts/.staging/`, `/contexts/staging/`, and `/contexts/:.staging:/` all target the `.staging` context. Context names that contain a colon (`:`) are rejected as invalid.
+The context segment of the URL accepts equivalent forms: `/contexts/.staging/`, `/contexts/staging/`, and `/contexts/:.staging:/` all target the `.staging` context. Aside from these leading and trailing delimiters, a context name that contains a colon (`:`) is rejected as invalid.
 
 ACLs authorize a prefixed request against the same qualified subject name (for example, `:.staging:my-topic`), so existing grants, including prefix grants, keep working unchanged. See <<acl-authorization>>.
 

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -7,8 +7,8 @@
 :learning-objective-2: Describe how qualified subject syntax maps subjects to contexts.
 :learning-objective-3: Enable and configure Schema Registry contexts using the cluster property and HTTP API.
 
-// Single-sourcing tags: Cloud-only content is wrapped in ifdef::env-cloud[] ... endif::[]
-// Self-managed-only content is wrapped in ifndef::env-cloud[] ... endif::[]
+// Single-sourcing tags: Cloud-only content is wrapped in env-cloud ifdef conditionals.
+// Self-managed-only content is wrapped in env-cloud ifndef conditionals.
 
 // tag::single-source[]
 
@@ -82,7 +82,6 @@ endif::env-cloud[]
 
 == Limitations
 
-* *Non-Java SerDe clients*: Not supported in Schema Registry contexts.
 * *Server-side schema ID validation*: Schema ID validation using Kafka record headers does not support contexts. However, schema ID validation using magic byte and prefix are supported.
 * *`referencedby` endpoint*: `GET /subjects/\{subject\}/versions/\{version\}/referencedby` returns a list of bare schema IDs with no context information. When references span contexts, it is not possible to determine which context each returned ID belongs to.
 * *Cross-context isolation*: Contexts provide organizational and ID-space isolation, but do not prevent cross-context schema references. There is no mechanism to block schemas in one context from referencing schemas in another context.
@@ -103,6 +102,8 @@ With Schema Registry contexts, each context has its own independent ID counter. 
 ----
 GET /schemas/ids/1?subject=:.staging:my-topic
 ----
+
+Alternatively, send the request through a context URL prefix. ID lookups under the prefix are scoped to that context automatically, with no query parameter required. See <<serdes-clients>>.
 
 See also <<schema-id-lookup-fails>>.
 
@@ -193,6 +194,7 @@ Unqualified references in schema definitions resolve to the same context as the 
 }
 ----
 
+[#enable-contexts]
 == Enable Schema Registry contexts
 
 ifndef::env-cloud[]
@@ -217,7 +219,7 @@ rpk cluster config get schema_registry_enable_qualified_subjects
 endif::env-cloud[]
 
 ifdef::env-cloud[]
-NOTE: On BYOC and Dedicated clusters, contact Redpanda support or use the cluster configuration API to enable `schema_registry_enable_qualified_subjects`. This property requires a broker restart.
+NOTE: On BYOC and Dedicated clusters, Schema Registry contexts are enabled by default. To opt out, use the cluster configuration API or contact Redpanda support to set `schema_registry_enable_qualified_subjects` to `false`. This property requires a broker restart.
 endif::env-cloud[]
 
 == Configure Schema Registry contexts
@@ -501,6 +503,58 @@ For additional detail, refer to the full reference documentation for these comma
 * xref:streaming:reference:rpk/rpk-registry/rpk-registry-subject-delete.adoc[]
 * xref:streaming:reference:rpk/rpk-registry/rpk-registry-subject-list.adoc[]
 
+[#serdes-clients]
+== Use contexts with SerDes clients
+
+SerDes clients, such as Kafka producers and consumers that use Schema Registry serializers and deserializers, can target a context through the Schema Registry base URL alone. Append `/contexts/\{context\}` to the URL in the client's `schema.registry.url` setting, and every schema operation that client performs is scoped to that context. Because Redpanda applies the context on the server side, this works with any SerDes client in any language, without client-side context support or code changes. Use this pattern to point different applications or environments at separate contexts through configuration alone.
+
+ifndef::env-cloud[]
+NOTE: Context URL prefixes are available in Redpanda 26.2 and later, and in 26.1 patch releases starting with 26.1.7. In 26.1, you must first <<enable-contexts,enable Schema Registry contexts>>.
+endif::env-cloud[]
+
+For example, to scope a client to the `.staging` context:
+
+[source,properties]
+----
+schema.registry.url=http://<host>:8081/contexts/.staging
+----
+
+All endpoint families that SerDes clients use are available under the `/contexts/\{context\}/` prefix:
+
+* Subject and version operations
+* Compatibility checks
+* Subject-level and context-level configuration and mode
+* Schema type listing (`GET /schemas/types`)
+* Schema ID lookups (`GET /schemas/ids/\{id\}` and related endpoints)
+
+Schema ID lookups sent through the prefix are scoped to that context automatically, so clients do not need to pass the `subject` query parameter.
+
+A request sent through the prefix is equivalent to the same request with a qualified subject. For example, both of the following requests register a schema for subject `my-topic` in the `.staging` context:
+
+[source,bash]
+----
+# Context URL prefix
+curl -s -X POST \
+  http://localhost:8081/contexts/.staging/subjects/my-topic/versions \
+  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  -d '{"schema": "{\"type\":\"string\"}"}'
+
+# Qualified subject
+curl -s -X POST \
+  http://localhost:8081/subjects/:.staging:my-topic/versions \
+  -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  -d '{"schema": "{\"type\":\"string\"}"}'
+----
+
+The context segment of the URL accepts equivalent forms: `/contexts/.staging/`, `/contexts/staging/`, and `/contexts/:.staging:/` all target the `.staging` context. Context names that contain a colon (`:`) are rejected as invalid.
+
+ACLs authorize a prefixed request against the same qualified subject name (for example, `:.staging:my-topic`), so existing grants, including prefix grants, keep working unchanged. See <<acl-authorization>>.
+
+[IMPORTANT]
+====
+If qualified subject parsing is not active on the cluster, requests to `/contexts/` endpoints do not return an error. Instead, the qualified subject names are stored as literal subject names in the default context. See <<qualified-subjects-not-recognized>>.
+====
+
 [#client-integration-status]
 == Client integration status
 
@@ -515,13 +569,13 @@ The following table identifies the status of Schema Registry context client inte
 | Supported
 | Use qualified subjects directly in any endpoint.
 
-| Java SerDe (Confluent)
+| Java SerDes (Confluent)
 | Supported
-| Requires a custom `ContextNameStrategy`. See the Confluent SerDe documentation for details.
+| Point the client's `schema.registry.url` at a context URL prefix (see <<serdes-clients>>), or use a custom `ContextNameStrategy`. See the Confluent SerDes documentation for details.
 
-| Non-Java SerDe
-| Not supported
-| Workaround: set the client's Schema Registry base URL to `\http://<host>:8081/contexts/\{context\}`.
+| Non-Java SerDes
+| Supported
+| Point the client's `schema.registry.url` at a context URL prefix. See <<serdes-clients>>.
 
 | rpk
 | Supported
@@ -640,7 +694,7 @@ To audit your existing subjects for affected names before enabling Schema Regist
 ifndef::env-cloud[]
 [source,bash]
 ----
-rpk registry subject list | grep '^\.'
+rpk registry subject list | grep '^:\.'
 ----
 endif::env-cloud[]
 
@@ -676,13 +730,26 @@ Following is troubleshooting guidance for Schema Registry contexts.
 curl -s "http://localhost:8081/schemas/ids/1?subject=:.staging:my-topic"
 ----
 
+[#qualified-subjects-not-recognized]
 === Qualified subjects not recognized (treated as literal names)
 
-*Symptom*: Subjects with the `:.` prefix are stored as literal subject names in the default context instead of being parsed as context-qualified subjects.
+*Symptom*: Subjects with the `:.` prefix are stored as literal subject names in the default context instead of being parsed as context-qualified subjects. Requests sent through a context URL prefix (see <<serdes-clients>>) show the same behavior: they do not return an error, but all operations land in the default context.
 
-*Cause 1*: `schema_registry_enable_qualified_subjects` is set to `false` (the default).
+*Cause 1*: `schema_registry_enable_qualified_subjects` is set to `false`.
+ifndef::env-cloud[]
+This is the default in Redpanda versions earlier than 26.2.
+endif::env-cloud[]
 
 *Cause 2*: The property was set to `true` but the brokers have not yet been restarted. This property is not dynamic and requires a full broker restart to take effect.
+
+To confirm, check whether the registry lists only the default context while clients are using qualified subjects or context URLs:
+
+[source,bash]
+----
+curl -s http://localhost:8081/contexts
+----
+
+If the response is `["."]`, qualified subject parsing is not active.
 
 *Resolution*:
 
@@ -692,6 +759,9 @@ ifndef::env-cloud[]
 rpk cluster config set schema_registry_enable_qualified_subjects true
 # Then restart all brokers
 ----
+endif::env-cloud[]
+ifdef::env-cloud[]
+On BYOC and Dedicated clusters, use the cluster configuration API or contact Redpanda support to set `schema_registry_enable_qualified_subjects` to `true`. The change requires a broker restart.
 endif::env-cloud[]
 
 === Schema registration fails after upgrading to v26.1
@@ -705,7 +775,7 @@ endif::env-cloud[]
 ifndef::env-cloud[]
 [source,bash]
 ----
-rpk registry subject list | grep '^\.'
+rpk registry subject list | grep '^:\.'
 ----
 endif::env-cloud[]
 

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -737,7 +737,7 @@ curl -s "http://localhost:8081/schemas/ids/1?subject=:.staging:my-topic"
 
 *Cause 1*: `schema_registry_enable_qualified_subjects` is set to `false`.
 ifndef::env-cloud[]
-This is the default in Redpanda versions earlier than 26.2.
+This is the default in Redpanda versions earlier than v26.2.
 endif::env-cloud[]
 
 *Cause 2*: The property was set to `true` but the brokers have not yet been restarted. This property is not dynamic and requires a full broker restart to take effect.

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -71,7 +71,7 @@ endif::env-cloud[]
 [IMPORTANT]
 ====
 ifndef::env-cloud[]
-In Redpanda 26.2 and later, `schema_registry_enable_qualified_subjects` is enabled by default. In earlier versions, it defaults to `false` and you must enable it explicitly. Changing this property requires a broker restart to take effect. If qualified subjects are still being treated as literal names, a broker restart is most likely still needed.
+In Redpanda v26.2 and later, `schema_registry_enable_qualified_subjects` is enabled by default. In earlier versions, it defaults to `false` and you must enable it explicitly. Changing this property requires a broker restart to take effect. If qualified subjects are still being treated as literal names, a broker restart is most likely still needed.
 endif::env-cloud[]
 ifdef::env-cloud[]
 In Redpanda Cloud, Schema Registry contexts are enabled by default.
@@ -198,7 +198,7 @@ Unqualified references in schema definitions resolve to the same context as the 
 == Enable Schema Registry contexts
 
 ifndef::env-cloud[]
-In Redpanda 26.2 and later, Schema Registry contexts are enabled by default. In earlier versions, enable them by setting the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`:
+In Redpanda v26.2 and later, Schema Registry contexts are enabled by default. In earlier versions, enable them by setting the `schema_registry_enable_qualified_subjects` cluster configuration property to `true`:
 
 [source,bash]
 ----
@@ -253,7 +253,7 @@ Example response:
 
 [source,json]
 ----
-[".","staging","production"]
+[".",".production",".staging"]
 ----
 
 NOTE: A context is only listed after at least one schema has been registered in it. Pre-configuring mode or compatibility alone does not cause a context to appear in this list. The default context (`.`) is always included.
@@ -509,7 +509,7 @@ For additional detail, refer to the full reference documentation for these comma
 SerDes clients, such as Kafka producers and consumers that use Schema Registry serializers and deserializers, can target a context through the Schema Registry base URL alone. Append `/contexts/\{context\}` to the URL in the client's `schema.registry.url` setting, and every schema operation that client performs is scoped to that context. Because Redpanda applies the context on the server side, this works with any SerDes client in any language, without client-side context support or code changes. Use this pattern to point different applications or environments at separate contexts through configuration alone.
 
 ifndef::env-cloud[]
-NOTE: Context URL prefixes are available in Redpanda 26.2 and later, and in 26.1 patch releases starting with 26.1.7. In 26.1, you must first <<enable-contexts,enable Schema Registry contexts>>.
+NOTE: Context URL prefixes are available in Redpanda v26.2 and later, and in v26.1 patch releases starting with v26.1.7. In v26.1, you must first <<enable-contexts,enable Schema Registry contexts>>.
 endif::env-cloud[]
 
 For example, to scope a client to the `.staging` context:

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -684,8 +684,10 @@ For the full metrics reference, see xref:streaming:reference:public-metrics-refe
 
 [IMPORTANT]
 ====
+*Breaking change*:
 ifndef::env-cloud[]
-*Breaking change*: Upgrading to Redpanda v26.2 or later enables `schema_registry_enable_qualified_subjects` automatically, including on existing clusters, unless you explicitly set the property to `false` before the upgrade.
+Upgrading to Redpanda v26.2 or later enables `schema_registry_enable_qualified_subjects` automatically, including on existing clusters, unless you explicitly set the property to `false` before the upgrade.
+
 endif::env-cloud[]
 When `schema_registry_enable_qualified_subjects` is enabled, any existing subject whose name matches the qualified subject pattern (for example, `:.staging:user-value`) is reinterpreted as subject `user-value` in context `.staging`, rather than as a literal subject name in the default context. Subjects without a `:.` prefix are unaffected.
 

--- a/modules/upgrade/partials/incompat-changes.adoc
+++ b/modules/upgrade/partials/incompat-changes.adoc
@@ -1,5 +1,8 @@
 === Review incompatible changes
 
+* *Breaking changes in Redpanda 26.2*:
+** Schema Registry contexts are enabled by default: `schema_registry_enable_qualified_subjects` defaults to `true`, including on existing clusters after upgrade, unless you explicitly set the property to `false` before upgrading. Any existing subject whose name starts with `:.` (for example, `:.staging:user-value`) is reinterpreted after the upgrade as a context-qualified subject instead of a literal subject name. Audit your subjects before upgrading with `rpk registry subject list | grep '^:\.'`. See xref:manage:schema-reg/schema-reg-contexts.adoc#upgrade-considerations[Schema Registry contexts upgrade considerations].
+
 * *Breaking changes in Redpanda 26.1*:
 ** If FIPS mode is enabled, change any SASL/SCRAM user passwords shorter than 14 characters to at least 14 characters before upgrading. FIPS 140-3 enforces stricter HMAC key size requirements than FIPS 140-2. Because Redpanda stores passwords in encrypted form, it cannot check the length of existing passwords. Clients with passwords shorter than 14 characters will fail to authenticate after the upgrade. See xref:manage:security/fips-compliance.adoc[Configure Redpanda for FIPS].
 


### PR DESCRIPTION
## Summary

Documents the v26.2 SerDes support for Schema Registry contexts: any SerDes client, in any language, can target a context by pointing `schema.registry.url` at a `/contexts/{context}` URL prefix — no client-side context support needed.

Covers both tickets in one PR since both affected pages are single-sourced into cloud-docs:
- [DOC-2397](https://redpandadata.atlassian.net/browse/DOC-2397) — Self-Managed SerDes contexts support
- [DOC-2304](https://redpandadata.atlassian.net/browse/DOC-2304) — Cloud twin (same epic ENG-1036)

## Changes

**`schema-reg-contexts.adoc`** (single-sourced)
- New `[#serdes-clients]` section: URL-prefix pattern with client config example, endpoint families covered, automatic schema-ID-lookup scoping, prefix/qualified-subject equivalence example, context-name normalization rules, ACL behavior, and an IMPORTANT callout for the silent-failure mode (qualified parsing inactive → `/contexts/` requests silently store literal subjects)
- Client integration table: "Non-Java SerDes: Not supported (workaround)" → Supported via URL prefix; Java SerDes no longer requires `ContextNameStrategy`
- Removed the stale "Non-Java SerDe clients: Not supported" limitation bullet
- Cloud path (per Kat's note on DOC-2304): BYOC/Dedicated "contact support to enable" → enabled by default, with opt-out instructions; added a cloud resolution branch in troubleshooting
- Troubleshooting: expanded the "treated as literal names" entry with the URL-prefix symptom and a `GET /contexts` quick check
- **Fixed the subject audit command**: `grep '^\.'` → `grep '^:\.'` (both occurrences). Only names starting with `:.` are affected by the breaking change; `.foo` stays literal. The old pattern missed affected subjects and false-positived unaffected ones.

**`schema-reg-api.adoc`** (single-sourced)
- Version-conditioned the "first set the property" instruction (26.2 default is `true`); cloud variant updated to enabled-by-default
- Added a pointer to the URL-prefix mechanism and the new section

**`release-notes/redpanda.adoc`**
- New 26.2 entry: SerDes client support for contexts

Companion cloud-docs PR (What's New entry): redpanda-data/cloud-docs#654 — merge this PR first (the What's New entry links the `#serdes-clients` anchor, which reaches cloud-docs through the single-source include).

## Verification

- Property default/visibility/restart verified at the v26.2.1 tag ([configuration.cc:L3979-L3987](https://github.com/redpanda-data/redpanda/blob/v26.2.1/src/v/config/configuration.cc#L3979-L3987))
- Backport availability verified empirically: context routes present in `service.cc` at v26.1.7, absent at v26.1.6 (hence the "26.1.7 and later" version note)
- Implementation PR: redpanda-data/redpanda#30189; source TOI: cupboard v26.2 schema-registry-contexts-on-by-default
- Normalization and silent-failure behavior per TOI (Gellért Peresztegi-Nagy, feature lead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2397]: https://redpandadata.atlassian.net/browse/DOC-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-2304]: https://redpandadata.atlassian.net/browse/DOC-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview pages

- [Schema Registry Contexts](https://deploy-preview-1850--redpanda-docs-preview.netlify.app/streaming/current/manage/schema-reg/schema-reg-contexts/) (updated)
- [Use the Schema Registry API](https://deploy-preview-1850--redpanda-docs-preview.netlify.app/streaming/current/manage/schema-reg/schema-reg-api/) (updated)
- [What's New in Redpanda](https://deploy-preview-1850--redpanda-docs-preview.netlify.app/streaming/current/get-started/release-notes/redpanda/) (updated)
