### PR TITLE
ci: notify adp-docs when rpk ai partials change on main

### DIFF
--- a/.github/workflows/notify-adp-docs-rpk-ai.yml
+++ b/.github/workflows/notify-adp-docs-rpk-ai.yml
@@ -1,0 +1,34 @@
+# When rpk ai partials change on main (a merged plugin refresh or full rpk
+# regeneration), tell adp-docs so it can reconcile its single-source stub
+# pages and nav against the new partial set. adp-docs consumes partials from
+# this repo's main at build time, so the merge to main is the right moment.
+name: Notify adp-docs of rpk ai partial changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'modules/reference/partials/rpk-ai/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+
+      - name: Trigger stub reconciliation in adp-docs
+        env:
+          GH_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+        run: gh api repos/redpanda-data/adp-docs/dispatches -f event_type=sync-rpk-ai-stubs


### PR DESCRIPTION
## Summary

adp-docs publishes the `rpk ai` reference through single-source stubs of this repo's generated partials (redpanda-data/adp-docs#161). When a merged change adds or removes `rpk-ai` partials, adp-docs' static stub pages and nav drift: new commands are invisible on the ADP site, and removed commands leave stubs with unresolved includes.

This dispatches `sync-rpk-ai-stubs` to adp-docs whenever `modules/reference/partials/rpk-ai/**` changes on main — the moment the partials become real for adp-docs' builds. The receiving workflow redpanda-data/adp-docs#165 runs the doc-tools stub reconciler and opens an adp-docs PR with the stub and nav changes, plus proposed page aliases for likely renames.

Together with docs#1834 this closes the loop Michele described: ADP release → docs partials PR → (merge) → adp-docs stub PR → (merge). The only human steps are the two PR reviews.

Depends on docs-extensions-and-macros#225 (`rpk-plugin-stubs` command, doc-tools 5.3.0). Recommend merging docs#1849 first so the first reconcile run doesn't resurrect stubs for the two stale partials it removes (verified in a dry run against current main).

## Related PRs (rpk docs automation train)

| PR | Role | Depends on |
|---|---|---|
| redpanda-data/docs-extensions-and-macros#225 | Generator: `--plugin` mode, change detection, deprecations, What's-new merge, flag extraction, stub reconciler (publishes doc-tools 5.3.0) | — |
| redpanda-data/docs#1834 | Receiver workflow for plugin-release dispatches | #225 |
| redpanda-data/docs#1844 | Release workflow: auto What's-new diff base + pre-GA plugin pins | #225 |
| redpanda-data/docs#1849 | Removes two stale rpk ai partials | merge before #1852/adp-docs#165 activate |
| redpanda-data/docs#1852 | Sender: docs main → adp-docs stub sync dispatch | #225, adp-docs#165 |
| redpanda-data/adp-docs#165 | Receiver: reconciles rpk ai stubs and nav | #225, docs#1852 |
| Senders (merged/open) | redpanda-data/connect#4636, redpanda-operator#1703 (merged), redpanda-check#10, cloudv2#28552 | docs#1834 |

Merge order: #225 → dependency bumps on docs main and beta → #1834 + #1844 (+ #1849) → #1852 + adp-docs#165 → remaining senders. Jira: DOC-2355, DOC-1090.

