### PR TITLE
backport: user-facing fixes from the issues sweep to v/26.1

### DIFF
--- a/modules/deploy/pages/redpanda/kubernetes/local-guide.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/local-guide.adoc
@@ -465,7 +465,7 @@ NOTE: These steps work only on Linux operating systems.
 . Add mappings in your `/etc/hosts` file between your worker nodes' IP addresses and their custom domain names:
 +
 ```bash
-sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "InternalIP" }}{{ .address }} {{ $podName }}.customredpandadomain.local{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
+sudo true && kubectl --namespace <namespace> get endpoints,node -A -o go-template='{{ range $_ := .items }}{{ if and (eq .kind "Endpoints") (eq .metadata.name "redpanda-external") }}{{ range $_ := (index .subsets 0).addresses }}{{ $nodeName := .nodeName }}{{ $podName := .targetRef.name }}{{ range $node := $.items }}{{ if and (eq .kind "Node") (eq .metadata.name $nodeName) }}{{ range $_ := .status.addresses }}{{ if eq .type "InternalIP" }}{{ .address }} {{ $podName }}.customredpandadomain.local{{ "\n" }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}' | envsubst | sudo tee -a /etc/hosts
 ```
 +
 .`/etc/hosts`

--- a/modules/deploy/partials/kubernetes/guides/uninstall.adoc
+++ b/modules/deploy/partials/kubernetes/guides/uninstall.adoc
@@ -19,13 +19,16 @@ kubectl delete users      --namespace <namespace> --all
 kubectl delete topics     --namespace <namespace> --all
 kubectl delete schemas    --namespace <namespace> --all
 kubectl delete redpanda   --namespace <namespace> --all
+kubectl delete consoles   --namespace <namespace> --all
 ----
-
-. Make sure requests for those resources return no results. For example, if you had a Redpanda cluster named `redpanda` in the namespace `<namespace>`, run:
 +
-[,bash]
+The Redpanda Operator creates a Console resource for each Redpanda resource, so you must delete Console resources too. The Redpanda Operator must still be running when you delete these resources. It removes their finalizers as part of its cleanup. If you uninstall the Redpanda Operator first, any remaining resource keeps its finalizer forever and the CRD deletion step below hangs.
+
+. Make sure requests for those resources return no results. Do not continue until every command returns `No resources found`:
++
+[,bash,role="no-wrap"]
 ----
-kubectl get redpanda --namespace <namespace>
+kubectl get users,topics,schemas,redpandas,consoles --namespace <namespace>
 ----
 
 . Uninstall the Redpanda Operator Helm release:

--- a/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-secrets.adoc
@@ -26,7 +26,7 @@ You must have the following:
 ** If you're creating certificates for internal listeners, make sure to include the internal addresses assigned to brokers by Kubernetes through the headless ClusterIP Service.
 ** If you're creating certificates for external listeners, make sure to include the external addresses assigned to brokers through the `external.domain` and/or `external.addresses` Helm values.
 +
-TIP: For an example of creating the TLS certificates, see the https://github.com/redpanda-data/helm-charts/blob/main/.github/create_tls.sh[`helm-charts` GitHub repository].
+TIP: For an example of creating the TLS certificates, see the https://github.com/redpanda-data/helm-charts/blob/d3be1b26cc93d9f836359dec4f5a6cb445554f4a/.github/create_tls.sh[`create_tls.sh` script in the legacy `helm-charts` GitHub repository^].
 
 == Create a Kubernetes Secret
 

--- a/modules/reference/pages/k-connector-helm-spec.adoc
+++ b/modules/reference/pages/k-connector-helm-spec.adoc
@@ -11,7 +11,7 @@ v1.0.31]
 
 This page describes the official Redpanda Connectors Helm Chart. In
 particular, this page describes the contents of the chart’s
-https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml[`values.yaml`
+https://github.com/redpanda-data/redpanda-operator/blob/main/charts/connectors/values.yaml[`values.yaml`
 file]. Each of the settings is listed and described on this page, along
 with any default values.
 

--- a/modules/reference/pages/k-console-helm-spec.adoc
+++ b/modules/reference/pages/k-console-helm-spec.adoc
@@ -11,7 +11,7 @@ v3.7.0]
 
 This page describes the official Redpanda Console Helm Chart. In
 particular, this page describes the contents of the chart’s
-https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml[`values.yaml`
+https://github.com/redpanda-data/redpanda-operator/blob/main/charts/console/chart/values.yaml[`values.yaml`
 file]. Each of the settings is listed and described on this page, along
 with any default values.
 

--- a/modules/reference/pages/k-operator-helm-spec.adoc
+++ b/modules/reference/pages/k-operator-helm-spec.adoc
@@ -11,7 +11,7 @@ v26.1.4]
 
 This page describes the official Redpanda Operator Helm Chart. In
 particular, this page describes the contents of the chart’s
-link:./values.yaml[`values.yaml` file]. Each of the settings is listed
+https://github.com/redpanda-data/redpanda-operator/blob/main/operator/chart/values.yaml[`values.yaml` file]. Each of the settings is listed
 and described on this page, along with any default values.
 
 For instructions on how to install and use the chart, including how to

--- a/modules/reference/pages/k-redpanda-helm-spec.adoc
+++ b/modules/reference/pages/k-redpanda-helm-spec.adoc
@@ -11,7 +11,7 @@ v26.1.6]
 
 This page describes the official Redpanda Helm Chart. In particular,
 this page describes the contents of the chart’s
-https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/chart/values.yaml[`values.yaml`
+https://github.com/redpanda-data/redpanda-operator/blob/main/charts/redpanda/chart/values.yaml[`values.yaml`
 file]. Each of the settings is listed and described on this page, along
 with any default values.
 


### PR DESCRIPTION
Backports the user-facing breakage fixes from #1846 (merge commit `857c2365`) to `v/26.1`, where all of them are still live:

1. **Kind guide hosts-file command (#1754)**: the go-template was missing two `{{ end }}` closers, so the documented command fails with `unexpected EOF` for every 26.1 reader. Verified 7 openers / 7 closers after the fix.
2. **Uninstall procedure hang (shared partial, affects the local, EKS, AKS, and GKE guides)**: the Redpanda Operator creates a Console resource per Redpanda resource, but the documented uninstall never deleted it. After `helm uninstall` removes the operator, the orphaned Console resource keeps its `operator.redpanda.com/finalizer` and the documented CRD-deletion command hangs indefinitely. Found by the Kind guide Doc Detective test on #1846 (CI reliably loses the async-cleanup race that masks this on fast machines). Fix: delete `consoles` with the other custom resources while the operator is still running, and verify all five resource kinds return no results before uninstalling the operator.
3. **Stale `helm-charts` repository links (#1757)**: the charts moved to `redpanda-data/redpanda-operator`, leaving 404s on the Redpanda, Console, Connectors, and Operator Helm spec pages plus the TLS secrets guide. All replacement URLs verified to return 200 during the original fix.

**Deliberately excluded:**
- Property name fixes (#1657): the singular anchors on this branch are better fixed by the post-docs-extensions-and-macros#233 extractor regen against `v/26.1`, which covers all 5 published wrong names instead of 2 (per the discussion on #1846).
- Doc Detective test steps, screenshots, and workflow changes: CI tests run from main only.
- The consumer-offsets/Console visibility notes (#1341): content enhancement, available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
