### PR TITLE
Expose cluster health metrics to Cloud (DOC-2308)

### DIFF
--- a/modules/manage/partials/monitor-health.adoc
+++ b/modules/manage/partials/monitor-health.adoc
@@ -428,11 +428,16 @@ Leaderless partitions can be caused by unresponsive brokers. When an alert on `r
 
 Redpanda's Raft implementation exchanges periodic status RPCs between a broker and its peers. The xref:reference:public-metrics-reference.adoc#redpanda_node_status_rpcs_timed_out[`redpanda_node_status_rpcs_timed_out`] gauge increases when a status RPC times out for a peer, which indicates that a peer may be unresponsive and may lead to problems with partition replication that Raft manages. Monitor for non-zero values of this gauge, and correlate it with any logged errors or changes in partition replication.
 
-ifndef::env-cloud[]
 [[cluster-health]]
 === Cluster health
 
-A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda continuously assembles these signals into a cluster health summary. Redpanda can export this summary as a set of <<available-metrics,Prometheus metrics>>, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
+A healthy cluster has all brokers responding, a leader for every partition, and an elected controller. Redpanda continuously assembles these signals into a cluster health summary.
+ifndef::env-cloud[]
+Redpanda can export this summary as a set of <<available-metrics,Prometheus metrics>>, so you can alert on overall cluster health from your metrics system instead of polling xref:reference:rpk/rpk-cluster/rpk-cluster-health.adoc[`rpk cluster health`] or the link:/api/doc/admin/operation/operation-get_cluster_health_overview[health overview Admin API].
+endif::[]
+ifdef::env-cloud[]
+Redpanda can export this summary as a set of <<available-metrics,Prometheus metrics>> on the public metrics endpoint, so you can alert on overall cluster health directly from your metrics system.
+endif::[]
 
 These metrics are disabled by default. When enabled, every broker periodically assembles its own view of the health overview and exposes it on the public metrics endpoint, prefixed with `redpanda_cluster_health_`. For most of these metrics, a value of `0` means healthy and any value greater than `0` indicates a problem.
 
@@ -440,6 +445,10 @@ NOTE: Cluster health metrics require Redpanda version 26.2 or later.
 
 ==== Enable cluster health metrics
 
+ifdef::env-cloud[]
+xref:manage:cluster-maintenance/config-cluster.adoc[Edit your cluster's configuration] to set `health_monitor_metrics_enabled` to `true`. This property requires a broker restart to take effect.
+endif::[]
+ifndef::env-cloud[]
 Set xref:reference:properties/cluster-properties.adoc#health_monitor_metrics_enabled[`health_monitor_metrics_enabled`] to `true`. This property requires a broker restart to take effect.
 
 ifndef::env-kubernetes[]
@@ -511,6 +520,10 @@ helm upgrade --install redpanda redpanda/redpanda \
 endif::[]
 
 By default, each broker refreshes the metrics every 100 seconds (10 times the value of xref:reference:properties/cluster-properties.adoc#health_monitor_max_metadata_age[`health_monitor_max_metadata_age`]). Enabling the metrics causes a modest increase in CPU usage and network traffic.
+endif::[]
+ifdef::env-cloud[]
+By default, each broker refreshes the metrics every 100 seconds. Enabling the metrics causes a modest increase in CPU usage and network traffic.
+endif::[]
 
 ==== Available metrics
 
@@ -566,7 +579,6 @@ sum(redpanda_raft_leader_for{namespace="redpanda",topic="controller",partition="
 ----
 
 A controller election creates a brief window where no broker is the leader, and the joined series drops out. To avoid spurious alerts during these normal elections, configure the alerts to fire only after the metric has been non-zero for at least one minute (for example, with a Prometheus `for` duration of `1m`).
-endif::[]
 
 [[consumers]]
 === Consumer group lag

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -92,12 +92,15 @@ endif::[]
 
 ---
 
-ifndef::env-cloud[]
 === redpanda_cluster_health_bytes_in_cloud_storage
 
 Bytes stored in object storage. Informational; `0` if Tiered Storage isn't enabled.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -107,6 +110,10 @@ Number of known cluster members. Informational.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_health_high_disk_usage_nodes
@@ -114,6 +121,10 @@ Number of known cluster members. Informational.
 Number of brokers past the storage-space alert threshold.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -123,6 +134,10 @@ Number of partitions without a leader.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_health_metadata_age_seconds
@@ -130,6 +145,10 @@ Number of partitions without a leader.
 Seconds since the last successful refresh on the broker. Reports a very large value before the first refresh so that staleness alerts fire.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -139,6 +158,10 @@ Reports `1` if no controller is elected, otherwise `0`.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_health_no_health_report
@@ -146,6 +169,10 @@ Reports `1` if no controller is elected, otherwise `0`.
 Reports `1` if the most recent refresh attempt failed, otherwise `0`.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -155,6 +182,10 @@ Number of brokers not responding to liveness checks.
 
 *Type*: gauge
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_health_nodes_in_recovery_mode
@@ -162,6 +193,10 @@ Number of brokers not responding to liveness checks.
 Number of brokers in recovery mode. Informational; does not affect the health verdict.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -171,6 +206,10 @@ Number of successful refreshes on the broker.
 
 *Type*: counter
 
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
+
 ---
 
 === redpanda_cluster_health_under_replicated_partitions
@@ -178,6 +217,10 @@ Number of successful refreshes on the broker.
 Number of partitions that are not fully replicated.
 
 *Type*: gauge
+
+ifdef::env-cloud[]
+*Available in Serverless*: No
+endif::[]
 
 ---
 
@@ -187,8 +230,11 @@ Number of reasons the cluster is currently unhealthy. A value of `0` means healt
 
 *Type*: gauge
 
----
+ifdef::env-cloud[]
+*Available in Serverless*: No
 endif::[]
+
+---
 
 === redpanda_cluster_latest_cluster_metadata_manifest_age
 


### PR DESCRIPTION
## Summary

Cloud slice of the 26.2 cluster health monitoring feature ([DOC-2308](https://redpandadata.atlassian.net/browse/DOC-2308), Aha E-190; core twin DOC-2016 is Done). Product confirmed on the ticket that the `redpanda_cluster_health_*` metrics are available on the Cloud public metrics endpoint, so this PR removes the `ifndef::env-cloud[]` gates that hid the content from Cloud builds.

## Changes

**`modules/reference/pages/public-metrics-reference.adoc`** (single-sourced into cloud-docs)
- Un-gates the 12 `redpanda_cluster_health_*` metric entries and adds the standard `*Available in Serverless*: No` marker to each (matching every other cloud-visible metric; monitoring is not supported on Serverless per DOC-1682).

**`modules/manage/partials/monitor-health.adoc`** (single-sourced into cloud-docs `monitor-cloud.adoc`)
- Exposes the Cluster health section to Cloud with targeted conditionals:
  - Cloud intro drops the `rpk cluster health` and Admin API links (cloud-docs has neither page).
  - Cloud enable instructions go through `xref:manage:cluster-maintenance/config-cluster.adoc` instead of `rpk cluster config` / Helm.
  - Cloud refresh-cadence sentence drops the `health_monitor_max_metadata_age` xref (anchor doesn't exist in the cloud properties page — see follow-up below).
- Self-managed rendering is unchanged (verified: all self-managed content sits in `ifndef::env-cloud` branches identical to before).

A companion cloud-docs PR adds the What's New entry.

## Follow-up flagged (not in this PR)

The generated cluster-properties partial is self-contradictory for the two health properties: their sections carry the `ifdef::env-cloud` "Available in the Redpanda Cloud Console" marker, but they sit **outside** the `redpanda-cloud` tag regions, so the cloud properties page never renders them. If the properties are genuinely customer-manageable in Cloud (the marker's source suggests yes), the generator's tag placement needs fixing — same class of generator bug as DOC-2401. Needs confirmation with product/engineering before touching the generated partial.

## Verification

- Cloud xref targets verified present in cloud-docs: `manage:cluster-maintenance/config-cluster.adoc`, `reference:public-metrics-reference.adoc` (stub consuming this file's single-source tag).
- Conditional balance verified (16 opens / 16 endifs in the partial; 234/234 in the metrics reference).
- Metrics table xrefs resolve in cloud builds after the un-gating (anchors now included in the single-sourced region).

⚠️ **Timing**: content claims require Redpanda 26.2 (stated in the section NOTE). Self-managed 26.2 is GA; confirm Cloud fleet rollout before the cloud-docs What's New merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2308]: https://redpandadata.atlassian.net/browse/DOC-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview pages

- [Public Metrics](https://deploy-preview-1855--redpanda-docs-preview.netlify.app/streaming/current/reference/public-metrics-reference/#redpanda_cluster_health_metadata_age_seconds) (updated)
- [Monitor Redpanda](https://deploy-preview-1855--redpanda-docs-preview.netlify.app/streaming/current/manage/monitoring/#cluster-health) (consumer of the updated `monitor-health.adoc` partial)
- [Monitor Redpanda in Kubernetes](https://deploy-preview-1855--redpanda-docs-preview.netlify.app/streaming/current/manage/kubernetes/monitoring/k-monitor-redpanda/#cluster-health) (consumer of the updated `monitor-health.adoc` partial)

Note: this preview shows the self-managed build, which is unchanged by design. The cloud rendering can only be previewed from a cloud-docs build after this PR merges.
