### PR TITLE
docs: note S3-compatible object storage for Tiered Storage

### DIFF
--- a/modules/manage/partials/tiered-storage.adoc
+++ b/modules/manage/partials/tiered-storage.adoc
@@ -47,6 +47,8 @@ To set up Tiered Storage:
 
 Redpanda natively supports Tiered Storage with Amazon Simple Storage Service (S3), Google Cloud Storage (GCS, which uses the Google Cloud Platform S3 API), and Microsoft Azure Blob Storage (ABS) and Azure Data Lake Storage (ADLS).
 
+NOTE: Because Tiered Storage speaks the S3 API, you can also point it at an S3-compatible object store. Set xref:reference:properties/object-storage-properties.adoc#cloud_storage_api_endpoint[`cloud_storage_api_endpoint`] to your provider's endpoint (for example, `<s3-compatible-endpoint>`), and check your provider's documentation for the xref:reference:properties/object-storage-properties.adoc#cloud_storage_url_style[`cloud_storage_url_style`] it requires.
+
 ifdef::env-kubernetes[]
 ==== Amazon S3
 


### PR DESCRIPTION
## Description

Adds one NOTE to the "Configure object storage" step of the Tiered Storage partial (`modules/manage/partials/tiered-storage.adoc`), directly after the sentence listing the natively supported backends (Amazon S3, Google Cloud Storage, and Azure Blob Storage / Azure Data Lake Storage).

That sentence is the only guidance on the page about which object stores work, so a reader whose store is not one of those has no next step, even though Tiered Storage talks to object storage over the S3 API and the property reference already describes `cloud_storage_url_style` as the addressing style for S3-compatible object storage. The NOTE points at the two properties involved:

- `cloud_storage_api_endpoint` for the provider endpoint, shown as the placeholder `<s3-compatible-endpoint>`.
- `cloud_storage_url_style`, deferring to the provider's documentation for the value it requires, which mirrors the wording already in that property's own description.

No provider is named and no real endpoint is used. Both xrefs use the same `reference:properties/object-storage-properties.adoc#<property>` form already used in `manage/partials/remote-read-replicas.adoc`. The partial is not `env-cloud` gated, so the NOTE renders in both the Linux and Kubernetes versions of the Tiered Storage page. Nothing else in the partial changes.

Review deadline:

## Page previews

Deploy preview links to be added once the Netlify build for this PR is available. Pages rendered from the edited partial:

- `manage/tiered-storage/` (updated)
- `manage/kubernetes/tiered-storage/k-tiered-storage/` (updated)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
