### PR TITLE
Update 26.2 (client compatibility, Iceberg translation) single sourcing for Cloud

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -18,12 +18,7 @@ Use this reference to:
 
 == Kafka client compatibility
 
-ifndef::env-cloud[]
 Redpanda validates the Apache Kafka Java client and a set of widely used non-Java clients, at their current versions that support Kafka 4.x, using the ducktape and chaos test suites. Validation confirms connectivity and correctness across core Kafka APIs, such as produce, consume, and transaction operations, at current client versions. Modern clients auto-negotiate protocol versions or use an earlier protocol version accepted by Redpanda brokers.
-endif::[]
-ifdef::env-cloud[]
-Clients developed for Kafka versions 0.11 or later are compatible with Redpanda. The Apache Kafka Java client at version 4.x is validated against Redpanda using the ducktape and chaos test suites; other clients in the table here remain compatible with the Kafka protocol versions they have always supported. Modern clients auto-negotiate protocol versions or use an earlier protocol version accepted by Redpanda brokers.
-endif::[]
 
 TIP: Always use the latest supported version of a Kafka client.
 
@@ -39,25 +34,15 @@ The following clients have been validated with Redpanda.
 | https://github.com/confluentinc/librdkafka[librdkafka^]
 
 | Go
-ifndef::env-cloud[]
 a|
 * https://github.com/twmb/franz-go[franz-go^]
 * https://github.com/confluentinc/confluent-kafka-go[confluent-kafka-go^]
 * https://github.com/IBM/sarama[Sarama^]
-endif::[]
-ifdef::env-cloud[]
-| https://github.com/twmb/franz-go[franz-go^]
-endif::[]
 
 | Python
-ifndef::env-cloud[]
 a|
 * https://github.com/dpkp/kafka-python[kafka-python^]
 * https://github.com/confluentinc/confluent-kafka-python[confluent-kafka-python^]
-endif::[]
-ifdef::env-cloud[]
-| https://github.com/dpkp/kafka-python[kafka-python^]
-endif::[]
 
 | Rust
 | https://github.com/kafka-rust/kafka-rust[kafka-rust^]

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -430,7 +430,6 @@ rpk topic describe orders -c | grep redpanda.iceberg.mode
 
 NOTE: If a section-based configuration is equivalent to one of the modes described in <<supported-iceberg-modes,Supported Iceberg modes>>, `rpk topic describe` displays it using that mode's name instead of the section syntax.
 
-ifndef::env-cloud[]
 [[resolve-schemas-within-a-context]]
 == Resolve schemas within a Schema Registry context
 
@@ -438,7 +437,12 @@ If you use xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry conte
 
 Both modes rely on a schema registered in Schema Registry to determine the Iceberg table structure.
 
+ifndef::env-cloud[]
 Starting in Redpanda 26.2, Schema Registry contexts are enabled by default. See xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] to learn about contexts and qualified subject naming before you configure this property.
+endif::[]
+ifdef::env-cloud[]
+Schema Registry contexts are enabled by default. See xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] to learn about contexts and qualified subject naming before you configure this property.
+endif::[]
 
 .Set the Schema Registry context on a new topic
 [,bash]
@@ -467,7 +471,6 @@ To change the Schema Registry context on a topic that is actively translating to
 . Change `redpanda.schema.registry.context`.
 . Re-enable Iceberg translation.
 ====
-endif::[]
 
 == How Iceberg modes translate to table format
 

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -433,7 +433,7 @@ NOTE: If a section-based configuration is equivalent to one of the modes describ
 [[resolve-schemas-within-a-context]]
 == Resolve schemas within a Schema Registry context
 
-If you use xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] to isolate schemas (for example, by environment or tenant), set the `redpanda.schema.registry.context` topic property to bind the topic to that context. Redpanda then resolves the schemas referenced by records in the topic against the configured context instead of the default context (`.`). Depending on the topic's Iceberg mode, Redpanda looks up either the schema ID embedded in each record (`value_schema_id_prefix` mode) or the latest schema for a subject (`value_schema_latest` mode) within that context.
+If you use xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] to isolate schemas (for example, by environment or tenant), set the `redpanda.schema.registry.context` topic property to bind the topic to that context. Redpanda then resolves the schemas referenced by records in the topic against the configured context instead of the default context (`.`). This applies to all schema-decoding modes, for both keys and values: the `value_schema_id_prefix` and `value_schema_latest` shorthand modes, and any `key` or `value` section that uses `mode=schema_id_prefix` or `mode=schema_latest`.
 
 Both modes rely on a schema registered in Schema Registry to determine the Iceberg table structure.
 

--- a/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
+++ b/modules/manage/pages/iceberg/specify-iceberg-schema.adoc
@@ -120,10 +120,14 @@ value_schema_latest:subject=<subject-name>,protobuf_name=<protobuf-message-full-
 +
 NOTE: If you don't specify the fully qualified Protobuf message name, Redpanda pauses the data translation to the Iceberg table until you fix the topic misconfiguration.
 
-ifndef::env-cloud[]
 == Configure key, value, and header translation
 
+ifndef::env-cloud[]
 For Redpanda clusters version 26.2 and later, in addition to the <<supported-iceberg-modes,supported modes>>, `redpanda.iceberg.mode` also accepts a section-based syntax that lets you independently configure how Redpanda translates the record key, value, and headers into the Iceberg table. The `key_value`, `value_schema_id_prefix`, and `value_schema_latest` modes are shorthand for common combinations of these sections (see <<iceberg-mode-shorthands>>).
+endif::[]
+ifdef::env-cloud[]
+In addition to the <<supported-iceberg-modes,supported modes>>, `redpanda.iceberg.mode` also accepts a section-based syntax that lets you independently configure how Redpanda translates the record key, value, and headers into the Iceberg table. The `key_value`, `value_schema_id_prefix`, and `value_schema_latest` modes are shorthand for common combinations of these sections (see <<iceberg-mode-shorthands>>).
+endif::[]
 
 The `key` and `headers` sections change fields inside the `redpanda` system struct column (`redpanda.key` and the `value` field of each entry in `redpanda.headers`), while the `value` section changes the columns outside that struct. See <<how-iceberg-modes-translate-to-table-format,How Iceberg modes translate to table format>> for the base row structure that every generated table includes.
 
@@ -369,6 +373,7 @@ Redpanda rejects the following configurations when you create or alter a topic:
 NOTE: Option values cannot contain `,` or `;`, and whitespace is not trimmed. Avoid extra spaces around subject names or Protobuf message names.
 
 // Broker-upgrade gating not applicable in RP Cloud
+ifndef::env-cloud[]
 [IMPORTANT]
 ====
 Configuring anything beyond `key:mode=binary` and `headers:value_type=binary` requires every broker in the cluster to be running Redpanda version 26.2 or later. Until all brokers are upgraded, Redpanda rejects these configurations with an error.
@@ -380,6 +385,7 @@ The following configurations require all brokers to be running version 26.2 or l
 * `value:layout=nested`
 * `value:mode=string`
 ====
+endif::[]
 
 === Example configurations
 
@@ -423,7 +429,6 @@ rpk topic describe orders -c | grep redpanda.iceberg.mode
 ----
 
 NOTE: If a section-based configuration is equivalent to one of the modes described in <<supported-iceberg-modes,Supported Iceberg modes>>, `rpk topic describe` displays it using that mode's name instead of the section syntax.
-endif::[]
 
 ifndef::env-cloud[]
 [[resolve-schemas-within-a-context]]


### PR DESCRIPTION
## Description

Related: https://github.com/redpanda-data/cloud-docs/pull/657

This pull request updates documentation to unify and clarify instructions for both self-hosted and cloud environments, primarily by removing conditional content that previously differentiated between the two. It also makes version requirements and feature availability clearer for Redpanda features such as Kafka client compatibility and Iceberg schema translation.

**Documentation unification and clarification:**

* Removed environment-specific (`env-cloud`) conditionals from the Kafka client compatibility section, presenting a single, unified explanation of validated clients and compatibility for both self-hosted and cloud users.
* Unified and clarified instructions for configuring Iceberg schema translation, including section-based syntax and configuration examples, so that both cloud and self-hosted environments receive the same guidance.

**Version requirement and feature availability updates:**

* Added explicit notes about version requirements for advanced Iceberg configuration options, ensuring users are aware that certain settings require all brokers to be running Redpanda version 26.2 or later.
* Clarified that Schema Registry contexts are enabled by default (and since when), and provided consistent guidance for both environments on how to configure and use contexts.
* Cleaned up lingering conditional blocks at the end of the Iceberg schema documentation for consistency.

Resolves https://redpandadata.atlassian.net/browse/<jira-ticket>
Review deadline:

## Page previews

These pages are single-sourced, and this PR contains the source/`env-cloud` conditional changes. Review **both** renderings:

**Cloud (single-sourced) rendering — for SME review of Cloud accuracy.** Built by the tandem cloud-docs PR #657, which pulls this branch and applies the `env-cloud` attribute:

- Specify Iceberg Schema (key/value/header translation + Schema Registry context): https://deploy-preview-657--rp-cloud.netlify.app/cloud-data-platform/manage/iceberg/specify-iceberg-schema/
- Kafka Compatibility (validated clients): https://deploy-preview-657--rp-cloud.netlify.app/cloud-data-platform/develop/kafka-clients/

**Self-managed (streaming) rendering:**

- Specify Iceberg Schema: https://deploy-preview-1857--redpanda-docs-preview.netlify.app/streaming/current/manage/iceberg/specify-iceberg-schema/
- Kafka Compatibility: https://deploy-preview-1857--redpanda-docs-preview.netlify.app/streaming/current/develop/kafka-clients/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
