### PR TITLE
docs: migrate stale rpk ai llm overrides to the renamed command

### DIFF
--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -3050,8 +3050,8 @@
       "exclude": true,
       "_note": "Command mentions \"coming soon\" and needs proper review before inclusion in docs"
     },
-    "rpk ai llm": {
-      "appendToDescription": "\n\nSupported provider types: `openai`, `anthropic`, `google`, `bedrock`."
+    "rpk ai llm-provider": {
+      "appendToDescription": "\n\nSupported provider types: `openai`, `anthropic`, `google`, `bedrock`, `openai-compatible`."
     },
     "rpk ai model": {
       "appendToDescription": "\n\nThe catalog is read-only. The catalog is populated from each LLM provider's metadata plus any extras the operator has pinned to a tenant."
@@ -3185,9 +3185,7 @@
     "rpk ai agent stop": {
       "description": "Stop a managed agent, setting its desired state to stopped."
     },
-    "rpk ai llm check": {
-      "description": "Run a lightweight probe against the configured LLM provider to verify credentials and reachability."
-    },
+
     "rpk ai agent credential create": {
       "description": "Create a client ID and secret pair for an agent. The client secret is shown once and cannot be retrieved again."
     },


### PR DESCRIPTION
## Summary

Flagged in review on docs-extensions-and-macros#225: every rpk docs regeneration prints override validation errors for `rpk ai llm` and `rpk ai llm check` — the rpai plugin renamed `llm` → `llm-provider`, so those entries silently do nothing.

- The provider-type note moves to `rpk ai llm-provider` (with `openai-compatible` added, matching the plugin's current config groups).
- The `llm check` description override is dropped: the renamed command's own help ("Runs a lightweight probe against the upstream to verify credentials and reachability") already covers it.

The remaining two validation errors (`rpk cluster storage restore-start`, `rpk connect studio sync-schema`) are left for their owners to triage — this PR only handles the rename casualties.

Related: the generator now surfaces these validation errors in automated PR bodies (docs-extensions-and-macros#225), so future stale entries won't hide.