### PR TITLE
docs: drop the hand-written rpk connect run flags table

### DIFF
--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -338,7 +338,7 @@
         "flags": "g"
       },
       {
-        "description": "Wrap bare flag with adjacent format/value word as inline code before auto-backtick step splits them (e.g. -f json -> `\u200c-f json`, --format yaml -> `--format yaml`)",
+        "description": "Wrap bare flag with adjacent format/value word as inline code before auto-backtick step splits them (e.g. -f json -> `‌-f json`, --format yaml -> `--format yaml`)",
         "pattern": "(?<![`\\w-])(-{1,2}[a-zA-Z][a-z-]*) (json/yaml|json|yaml|text|wide|csv)(?![/a-zA-Z])",
         "replacement": "`$1 $2`",
         "flags": "g"
@@ -1079,29 +1079,74 @@
       "description": "Run a Redpanda Connect pipeline from a configuration file. The pipeline streams data between inputs and outputs with optional processing.",
       "flags": {
         "log.level": {
-          "description": "Logging level: `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`. Default is `INFO`."
+          "description": "Logging level: `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`. Default is `INFO`.",
+          "introducedInVersion": "4.102.0"
         },
         "set": {
-          "description": "Override a configuration field. Format: `path=value`. Can be used multiple times."
+          "description": "Override a configuration field. Format: `path=value`. Can be used multiple times.",
+          "introducedInVersion": "4.102.0"
         },
         "resources": {
-          "description": "Additional resource configuration files containing caches, rate limits, or other shared components."
+          "description": "Additional resource configuration files containing caches, rate limits, or other shared components.",
+          "introducedInVersion": "4.102.0"
+        },
+        "chilled": {
+          "introducedInVersion": "4.102.0"
+        },
+        "watcher": {
+          "introducedInVersion": "4.102.0"
+        },
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "redpanda-license": {
+          "introducedInVersion": "4.102.0"
+        },
+        "disable-telemetry": {
+          "introducedInVersion": "4.102.0"
+        },
+        "telemetry-deployment-type": {
+          "introducedInVersion": "4.102.0"
+        },
+        "telemetry-tenant-id": {
+          "introducedInVersion": "4.102.0"
+        },
+        "rpc-plugins": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
         }
-      },
-      "content": [
-        {
-          "type": "section",
-          "id": "connect-flags",
-          "title": "Flags",
-          "position": "after_description",
-          "headingLevel": 2,
-          "content": "[cols=\"1m,1a,2a\"]\n|===\n|Value |Type |Description\n\n|--log.level |string |Override the configured log level. Acceptable values: `off`, `error`, `warn`, `info`, `debug`, `trace`.\n|--set |stringArray |Set a field (identified by a dot path) in the main configuration file. For example: `metrics.type=prometheus`.\n|--resources, -r |stringArray |Pull in extra resources from a file, which can be referenced the same as resources defined in the main config. This supports glob patterns (requires quotes).\n|--chilled |bool |Continue to execute a config containing linter errors (default: false).\n|--watcher, -w |bool |EXPERIMENTAL: Watch config files for changes and automatically apply them (default: false).\n|--env-file, -e |string |Import environment variables from a dotenv file.\n|--templates, -t |stringArray |EXPERIMENTAL: Import Redpanda Connect templates. This supports glob patterns (requires quotes).\n|==="
-        }
-      ]
+      }
     },
     "rpk connect lint": {
       "description": "Check a Redpanda Connect configuration file for syntax errors and potential issues without running it.",
-      "flags": {},
+      "flags": {
+        "deprecated": {
+          "introducedInVersion": "4.102.0"
+        },
+        "labels": {
+          "introducedInVersion": "4.102.0"
+        },
+        "skip-env-var-check": {
+          "introducedInVersion": "4.102.0"
+        },
+        "verbose": {
+          "introducedInVersion": "4.102.0"
+        },
+        "resources": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      },
       "content": [
         {
           "type": "examples",
@@ -1130,7 +1175,23 @@
     },
     "rpk connect test": {
       "description": "Run unit tests defined in Redpanda Connect configuration files to verify pipeline behavior.",
-      "flags": {},
+      "flags": {
+        "log": {
+          "introducedInVersion": "4.102.0"
+        },
+        "verbose": {
+          "introducedInVersion": "4.102.0"
+        },
+        "resources": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      },
       "seeAlso": [
         "xref:connect:configuration:unit_testing.adoc[Unit Testing]"
       ],
@@ -1319,7 +1380,14 @@
       "description": "List available Redpanda Connect components. Shows inputs, outputs, processors, caches, rate limits, buffers, metrics, and tracers that can be used in pipelines.",
       "flags": {
         "format": {
-          "description": "Output format: `text` (human-readable table), `json` (machine-readable), `cue` (CUE schema). Default is `text`."
+          "description": "Output format: `text` (human-readable table), `json` (machine-readable), `cue` (CUE schema). Default is `text`.",
+          "introducedInVersion": "4.102.0"
+        },
+        "status": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
         }
       },
       "content": [
@@ -2076,7 +2144,21 @@
             }
           ]
         }
-      ]
+      ],
+      "flags": {
+        "verbose": {
+          "introducedInVersion": "4.102.0"
+        },
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "redpanda-license": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect help": {},
     "rpk connect mcp-server init": {
@@ -2097,7 +2179,27 @@
           "position": "after_description",
           "content": "This command is experimental and subject to change."
         }
-      ]
+      ],
+      "flags": {
+        "deprecated": {
+          "introducedInVersion": "4.102.0"
+        },
+        "labels": {
+          "introducedInVersion": "4.102.0"
+        },
+        "skip-env-var-check": {
+          "introducedInVersion": "4.102.0"
+        },
+        "verbose": {
+          "introducedInVersion": "4.102.0"
+        },
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect mcp-server": {
       "description": "Execute an MCP server against a suite of Redpanda Connect resources. Each resource will be exposed as a tool that AI can interact with.",
@@ -2107,7 +2209,27 @@
           "position": "after_description",
           "content": "This command is experimental and subject to change."
         }
-      ]
+      ],
+      "flags": {
+        "address": {
+          "introducedInVersion": "4.102.0"
+        },
+        "observability-address": {
+          "introducedInVersion": "4.102.0"
+        },
+        "tag": {
+          "introducedInVersion": "4.102.0"
+        },
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "redpanda-license": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect streams": {
       "description": "Run Redpanda Connect in streams mode, where multiple pipelines can be executed in a single process and can be created, updated, and removed via REST HTTP endpoints. The config field specified with the `--observability`/`-o` flag is known as the root config and should only contain observability and service-wide config fields such as http, metrics, logger, resources, and so on.",
@@ -2138,7 +2260,57 @@
             }
           ]
         }
-      ]
+      ],
+      "flags": {
+        "no-api": {
+          "introducedInVersion": "4.102.0"
+        },
+        "prefix-stream-endpoints": {
+          "introducedInVersion": "4.102.0"
+        },
+        "observability": {
+          "introducedInVersion": "4.102.0"
+        },
+        "log.level": {
+          "introducedInVersion": "4.102.0"
+        },
+        "set": {
+          "introducedInVersion": "4.102.0"
+        },
+        "resources": {
+          "introducedInVersion": "4.102.0"
+        },
+        "chilled": {
+          "introducedInVersion": "4.102.0"
+        },
+        "watcher": {
+          "introducedInVersion": "4.102.0"
+        },
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "redpanda-license": {
+          "introducedInVersion": "4.102.0"
+        },
+        "disable-telemetry": {
+          "introducedInVersion": "4.102.0"
+        },
+        "telemetry-deployment-type": {
+          "introducedInVersion": "4.102.0"
+        },
+        "telemetry-tenant-id": {
+          "introducedInVersion": "4.102.0"
+        },
+        "rpc-plugins": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk container start": {
       "seeAlso": [
@@ -2492,7 +2664,12 @@
           "position": "after_description",
           "content": "This command is experimental and subject to change."
         }
-      ]
+      ],
+      "flags": {
+        "name": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect agent run": {
       "description": "Run a Redpanda Connect agent from a repository directory. Each resource in the mcp subdirectory will create tools that can be used, then the redpanda_agents.yaml file along with Python agent modules will be invoked.",
@@ -2520,7 +2697,15 @@
           "position": "after_description",
           "content": "This command is experimental and subject to change."
         }
-      ]
+      ],
+      "flags": {
+        "secrets": {
+          "introducedInVersion": "4.102.0"
+        },
+        "redpanda-license": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect agent": {
       "description": "Manage Redpanda Connect agents. Agents allow you to build AI-powered workflows using Redpanda Connect resources.",
@@ -2561,7 +2746,15 @@
           "position": "after_description",
           "content": "This command is experimental and subject to change."
         }
-      ]
+      ],
+      "flags": {
+        "language": {
+          "introducedInVersion": "4.102.0"
+        },
+        "component": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect plugin": {
       "description": "Manage custom Redpanda Connect plugins. Use these commands to create and initialize plugin projects for extending Redpanda Connect with custom components.",
@@ -2596,10 +2789,35 @@
             }
           ]
         }
-      ]
+      ],
+      "flags": {
+        "small": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect echo": {
-      "description": "Parse a config file and echo back a normalized version. This command is useful for sanity checking a config if it isn't behaving as expected, as it shows you a normalised version after environment variables have been resolved."
+      "description": "Parse a config file and echo back a normalized version. This command is useful for sanity checking a config if it isn't behaving as expected, as it shows you a normalised version after environment variables have been resolved.",
+      "flags": {
+        "set": {
+          "introducedInVersion": "4.102.0"
+        },
+        "resources": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect blobl server": {
       "description": "Run a web server that provides an interactive application for writing and testing Bloblang mappings.",
@@ -2609,7 +2827,27 @@
           "position": "after_description",
           "content": "This server is intended for local debugging and experimentation purposes only. Do NOT expose it to the internet."
         }
-      ]
+      ],
+      "flags": {
+        "host": {
+          "introducedInVersion": "4.102.0"
+        },
+        "port": {
+          "introducedInVersion": "4.102.0"
+        },
+        "no-open": {
+          "introducedInVersion": "4.102.0"
+        },
+        "mapping-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "input-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "write": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect template lint": {
       "description": "Lint Redpanda Connect template files. Exits with a status code 1 if any linting errors are detected. If a path ends with '...' then Redpanda Connect will walk the target and lint any files with the .yaml or .yml extension.",
@@ -2637,7 +2875,18 @@
             }
           ]
         }
-      ]
+      ],
+      "flags": {
+        "verbose": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "templates": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk connect template": {
       "description": "Work with Redpanda Connect templates. Templates allow you to define reusable configuration patterns.",
@@ -2677,7 +2926,30 @@
             }
           ]
         }
-      ]
+      ],
+      "flags": {
+        "threads": {
+          "introducedInVersion": "4.102.0"
+        },
+        "raw": {
+          "introducedInVersion": "4.102.0"
+        },
+        "pretty": {
+          "introducedInVersion": "4.102.0"
+        },
+        "file": {
+          "introducedInVersion": "4.102.0"
+        },
+        "input": {
+          "introducedInVersion": "4.102.0"
+        },
+        "max-token-length": {
+          "introducedInVersion": "4.102.0"
+        },
+        "env-file": {
+          "introducedInVersion": "4.102.0"
+        }
+      }
     },
     "rpk registry mode set": {
       "content": [


### PR DESCRIPTION
## Summary

Resolves the duplicate-Flags conflict found in review on docs-extensions-and-macros#225: `rpk connect run` had a hand-written Flags table (authored in `rpk-overrides.json` back when plugin help exposed no flag data) that now collides with the auto-extracted table. The generator's conflict rule keeps the curated section and skips extraction with a warning — this PR takes the warning's advice and adopts the extracted table, which is both fresher and fuller:

| | Hand-written | Extracted |
|---|---|---|
| Flags documented | 7 (stale) | 13, incl. `--secrets`, `--redpanda-license`, the telemetry flags, `--rpc-plugins` |
| Stays current | manual edits only | every regeneration |

The per-flag **description overrides stay** — they merge onto the extracted rows, so the curated `log.level`/`set`/`resources` wording survives (verified: regenerated with the 5.3.0 branch, one `== Flags` section, 13 rows, curated descriptions applied).

Note: the page won't reflect this until the first regeneration with doc-tools ≥ 5.3.0 lands (flag extraction doesn't exist before it), so merge order vs #225's release train doesn't matter — this just needs to be in before the next regen.