### PR TITLE
Correct swapped %a and %% escape descriptions in topic format partial

### DIFF
--- a/modules/reference/partials/topic-format.adoc
+++ b/modules/reference/partials/topic-format.adoc
@@ -37,8 +37,8 @@ The percent encodings are represented like this:
 |`%[` |Partition log start offset
 |`%\|` |Partition last stable offset
 |`%]` |Partition high watermark
-|`%%` |Record attributes (formatting described below)
-|`%a` |Percent sign
+|`%%` |Percent sign
+|`%a` |Record attributes (formatting described below)
 |`%{` |Left brace
 |`%}` |Right brace
 |`%i` |Number of records formatted
@@ -107,7 +107,7 @@ An arbitrary amount of brackets (or braces, or # symbols) can wrap your date
 formatting:
 
 ```go
-%d{strftime=== [%F] ===}
+%d{strftime### [%F] ###}
 ```
 
 This prints `[YYYY-MM-DD]`, while the surrounding three # on each


### PR DESCRIPTION
## What

Ground-truth review of the rpk v26.2.1 `--help` output against the published docs found two factual errors in `modules/reference/partials/topic-format.adoc`, which is included by both `rpk topic consume` and `rpk topic produce`:

- `%a` and `%%` had their descriptions swapped. The help defines `%a` as record attributes and `%%` as the percent sign. The published table says the opposite on both pages.
- The strftime wrap sample reads `%d{strftime=== [%F] ===}` while the prose below it still explains "the surrounding three # on each side". The help sample is `%d{strftime### [%F] ###}`. Restored the sample so it matches both the help and its own explanation.

## How found

Part of the end-to-end review of the rpk docs automation train (see redpanda-data/docs-extensions-and-macros#225): every generated page was compared against `--help` dumps from the same rpk binary. This partial is hand-maintained rather than generated, so it needs a manual fix.

Note: the same review found that this partial documents consume semantics that do not all apply to `rpk topic produce` (produce has different `ascii`/`bool` semantics, encoded rather than raw sizes, and a smaller escape set). That is a larger content split best handled separately.

## Related PRs (rpk docs automation train)

See redpanda-data/docs-extensions-and-macros#225 for the train overview.

## Jira

Part of [DOC-2408](https://redpandadata.atlassian.net/browse/DOC-2408) (stale rpk overrides hide or contradict source help).

[DOC-2408]: https://redpandadata.atlassian.net/browse/DOC-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ