### PR TITLE
Re-render rpk docs when the overrides file changes

### DIFF
--- a/.github/workflows/rerender-rpk-docs-on-overrides-change.yml
+++ b/.github/workflows/rerender-rpk-docs-on-overrides-change.yml
@@ -1,0 +1,123 @@
+# Re-renders the generated rpk reference pages whenever the overrides file
+# changes on a docs branch.
+#
+# The overrides file (docs-data/rpk-overrides.json) is the curated-content
+# store for generated rpk pages: descriptions, flag rewrites, added sections,
+# exclusions. Without this workflow, an overrides edit merges but the rendered
+# pages keep the old content until the next release-driven regeneration, so
+# the repo carries overrides that the published docs do not reflect.
+#
+# This is a pure re-render from the newest committed rpk snapshot: no rpk
+# binary, no diff, no What's new update. The run is idempotent, so a re-render
+# that changes nothing exits green without opening a PR. The PR only touches
+# generated pages, which cannot re-trigger this workflow (it only watches the
+# overrides file and its schema).
+name: Re-render rpk docs on overrides change
+
+on:
+  push:
+    branches: [main, beta]
+    paths:
+      - 'docs-data/rpk-overrides.json'
+      - 'docs-data/rpk-overrides.schema.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+# Only the newest overrides state matters: a superseded run for the same
+# branch is cancelled rather than queued.
+concurrency:
+  group: rpk-overrides-rerender-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  rerender:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve newest rpk snapshot
+        id: snapshot
+        run: |
+          # Tilde-normalize prerelease suffixes first: plain sort -V ranks
+          # 26.2.1-rc2 above 26.2.1, which would re-render GA pages from an
+          # RC snapshot.
+          SNAPSHOT=$(ls docs-data/rpk-v*.json 2>/dev/null | grep -v 'rpk-diff' | sed 's/-rc/~rc/' | sort -V | sed 's/~rc/-rc/' | tail -1)
+          if [ -z "$SNAPSHOT" ]; then
+            echo "::error::No rpk snapshot found in docs-data/"
+            exit 1
+          fi
+          echo "Using snapshot: $SNAPSHOT"
+          echo "snapshot=$SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+      - name: Re-render rpk docs
+        run: |
+          npx --yes -p @redpanda-data/docs-extensions-and-macros@^5.3.0 doc-tools generate rpk-docs \
+            --from-json "${{ steps.snapshot.outputs.snapshot }}" \
+            --summary-file /tmp/pr-summary.md
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            git status --short | head -20
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "Overrides change did not alter any rendered page. Nothing to do."
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+      - name: Fetch actions bot token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+
+      - name: Build PR body
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          {
+            echo "Automated re-render of the generated rpk reference pages after an overrides change on \`${{ github.ref_name }}\` (${{ github.sha }})."
+            echo
+            echo "Review focus: the changed pages should reflect exactly the merged overrides edit, nothing else. The generator version is pinned to the same range the release regeneration uses, so unrelated churn here means the branch missed a regeneration and this PR is catching it up."
+            echo
+            cat /tmp/pr-summary.md 2>/dev/null || true
+          } > /tmp/pr-body.md
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          branch: rpk-docs/overrides-rerender-${{ github.ref_name }}
+          base: ${{ github.ref_name }}
+          title: 'docs: re-render rpk docs for overrides change (${{ github.ref_name }})'
+          body-path: /tmp/pr-body.md
+          commit-message: 'docs: re-render rpk docs for overrides change'
+          labels: |
+            documentation
+            automated
+            rpk
+          delete-branch: true


### PR DESCRIPTION
## What

Closes an automation gap surfaced by #1862: `docs-data/rpk-overrides.json` is the curated-content store for the generated rpk reference pages, but no workflow watched it. An overrides edit merged and the rendered pages kept the old content until the next release-driven regeneration, so the repo carried overrides the published docs did not reflect.

New workflow: on any push to `main` or `beta` that touches the overrides file or its schema, re-render the full rpk tree from the newest committed snapshot and open a PR with the changed pages.

## Design

- **Pure re-render**: `doc-tools generate rpk-docs --from-json <newest snapshot>` with no diff and no What's new update. No rpk binary is needed because the snapshot already carries the tree and flags, so the run takes about two minutes.
- **Snapshot selection** uses the tilde-normalized `sort -V` (GA ranks above rc), same as the plugin receiver workflow in #1834.
- **Bot token** from Secrets Manager for PR creation so the generated PR actually runs checks (`secrets.GITHUB_TOKEN` PRs do not trigger Actions).
- **No loops**: the workflow only watches the overrides file and its schema, and a pure re-render writes only generated pages. Re-renders that change nothing exit green without opening a PR (generation is idempotent).
- **Superseded runs are cancelled** per branch rather than queued, since only the newest overrides state matters.
- `beta` picks the workflow up through the regular main to beta sync.

## Sequencing

Merge after redpanda-data/docs-extensions-and-macros#225 publishes doc-tools 5.3.0 (the workflow resolves `@^5.3.0` at runtime), the same constraint as #1834. Once this is in, merging #1860, #1861, and #1862 automatically produces the re-render PR that brings the pages in line with the fixed overrides.

## Validation

Workflow parses clean (act listing and YAML check). The generation command, snapshot resolution, idempotence, and no-changes behavior are the paths already exercised end to end in the #225 validation (18+ full regeneration rounds on a pristine clone, including repeated no-op re-renders).

## Related PRs (rpk docs automation train)

See redpanda-data/docs-extensions-and-macros#225 for the train overview.

## Jira

Prevention layer for [DOC-2408](https://redpandadata.atlassian.net/browse/DOC-2408), and part of the fix chain for [DOC-2407](https://redpandadata.atlassian.net/browse/DOC-2407): once merged, overrides changes like #1838 regenerate the affected pages automatically.

[DOC-2408]: https://redpandadata.atlassian.net/browse/DOC-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ