### PR TITLE
docs: clean up stale rpk command overrides

### DIFF
--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -1086,18 +1086,20 @@
         },
         "resources": {
           "description": "Additional resource configuration files containing caches, rate limits, or other shared components."
+        },
+        "chilled": {
+          "description": "Continue to execute a config containing linter errors."
+        },
+        "watcher": {
+          "description": "EXPERIMENTAL: Watch config files for changes and automatically apply them."
+        },
+        "env-file": {
+          "description": "Import environment variables from a dotenv file."
+        },
+        "templates": {
+          "description": "EXPERIMENTAL: Import Redpanda Connect templates. This supports glob patterns (requires quotes)."
         }
-      },
-      "content": [
-        {
-          "type": "section",
-          "id": "connect-flags",
-          "title": "Flags",
-          "position": "after_description",
-          "headingLevel": 2,
-          "content": "[cols=\"1m,1a,2a\"]\n|===\n|Value |Type |Description\n\n|--log.level |string |Override the configured log level. Acceptable values: `off`, `error`, `warn`, `info`, `debug`, `trace`.\n|--set |stringArray |Set a field (identified by a dot path) in the main configuration file. For example: `metrics.type=prometheus`.\n|--resources, -r |stringArray |Pull in extra resources from a file, which can be referenced the same as resources defined in the main config. This supports glob patterns (requires quotes).\n|--chilled |bool |Continue to execute a config containing linter errors (default: false).\n|--watcher, -w |bool |EXPERIMENTAL: Watch config files for changes and automatically apply them (default: false).\n|--env-file, -e |string |Import environment variables from a dotenv file.\n|--templates, -t |stringArray |EXPERIMENTAL: Import Redpanda Connect templates. This supports glob patterns (requires quotes).\n|==="
-        }
-      ]
+      }
     },
     "rpk connect lint": {
       "description": "Check a Redpanda Connect configuration file for syntax errors and potential issues without running it.",
@@ -3050,9 +3052,6 @@
       "exclude": true,
       "_note": "Command mentions \"coming soon\" and needs proper review before inclusion in docs"
     },
-    "rpk ai llm": {
-      "appendToDescription": "\n\nSupported provider types: `openai`, `anthropic`, `google`, `bedrock`."
-    },
     "rpk ai model": {
       "appendToDescription": "\n\nThe catalog is read-only. The catalog is populated from each LLM provider's metadata plus any extras the operator has pinned to a tenant."
     },
@@ -3075,9 +3074,6 @@
     },
     "rpk cluster config lint": {
       "description": "Identify any Redpanda configuration properties that are not recognized. These may be properties that were valid in earlier versions of Redpanda but are now managed via the central configuration store."
-    },
-    "rpk cluster storage restore-start": {
-      "description": "Start a topic recovery operation from Tiered Storage. If the `--wait` (`-w`) flag is set, the command polls the status of the recovery process until it finishes."
     },
     "rpk cluster logdirs describe": {
       "flags": {
@@ -3161,9 +3157,6 @@
     "rpk connect install": {
       "description": "Install Redpanda Connect. This command installs the latest version by default. Use the `--connect-version` flag to specify a version."
     },
-    "rpk connect studio sync-schema": {
-      "description": "Synchronize the schema of a Redpanda Connect instance with a Redpanda Connect Studio session. This command ensures that your pipeline components are configured and linted correctly within Redpanda Connect Studio."
-    },
     "rpk transform logs": {
       "description": "View logs for a data transform. Streams STDOUT and STDERR output captured during runtime to your terminal."
     },
@@ -3185,7 +3178,7 @@
     "rpk ai agent stop": {
       "description": "Stop a managed agent, setting its desired state to stopped."
     },
-    "rpk ai llm check": {
+    "rpk ai llm-provider check": {
       "description": "Run a lightweight probe against the configured LLM provider to verify credentials and reachability."
     },
     "rpk ai agent credential create": {


### PR DESCRIPTION
## Summary

Cleanup of `docs-data/rpk-overrides.json`. Four entries pointed at command paths that no longer exist, so they silently did nothing and surfaced as validation errors on every generator run. One more override duplicated content the generator already produces, giving a page two conflicting Flags tables.

Override validation now reports **zero errors**, down from four.

## Stale command paths

| Entry | Action | Why |
|---|---|---|
| `rpk ai llm check` | Migrated to `rpk ai llm-provider check` | Renamed command. The curated wording ("the configured LLM provider") is clearer than the source's "the upstream" |
| `rpk ai llm` | Deleted | The provider-type list was already stale, missing `openai-compatible`, and is the kind of enumeration that drifts |
| `rpk cluster storage restore-start` | Deleted | Now `rpk cluster storage restore start`. The source description is more complete, covering `--wait`/`-w`, `--cluster-uuid-override`, and a link to the whole-cluster-restore docs. The page already carries an alias from the old name |
| `rpk connect studio sync-schema` | Deleted | `rpk connect studio` is gone from the command tree, with no equivalent and no pages in this repo |

## Duplicate Flags table

`rpk connect run` carried both a supported `flags:` map and a legacy `content` section hardcoding a full Flags table, so the page rendered two `== Flags` sections with conflicting content. The hardcoded table was also stale: `--secrets`, `--redpanda-license`, `--disable-telemetry`, `--telemetry-deployment-type`, `--telemetry-tenant-id`, and `--rpc-plugins` were missing from the published page.

Its curated descriptions moved into the `flags:` map, so the page keeps the polished wording and picks up the six missing flags. This also restores Usage ahead of Flags, since the removed section was positioned `after_description`.

## Verification

Ran the generator against the committed `v26.2.1-rc2` snapshot with a live plugin binary for flag extraction:

- `rpk connect run`: one `== Flags` section with 13 rows (was 7), all descriptions sentence-capitalized, curated wording intact for `log.level`, `set`, and `resources`, Usage back ahead of Flags
- `rpk ai llm-provider check` renders the migrated description
- `rpk cluster storage restore start` renders the fuller source description
- Override validation: zero errors, previously four unknown command paths
- All regenerated files parse cleanly under Asciidoctor

## Note on scope

An earlier revision of this PR also fixed the duplicate `== Example` heading on `rpk container status`. That change is covered by #1860, which makes the identical override edit and additionally fixes the rendered page, so it has been dropped here to avoid a conflict. This PR no longer touches that override.

No `.adoc` files change in this PR, so there is nothing to preview. The generated pages update the next time the rpk docs automation runs.