### PR TITLE
build: bump docs-extensions-and-macros to ^5.3.1 for doc-tools --plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@antora/cli": "3.1.15",
         "@antora/site-generator": "3.1.15",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redpanda-data/docs-extensions-and-macros": "^5.1.2",
+        "@redpanda-data/docs-extensions-and-macros": "^5.3.1",
         "@sntke/antora-mermaid-extension": "^0.0.6"
       },
       "devDependencies": {
@@ -2914,9 +2914,9 @@
       "license": "MIT"
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-5.2.5.tgz",
-      "integrity": "sha512-jUZhQ/imCwDVw/3FNDMzIqlHZLrdd513SOpXv6b4ucc278VU1gcYTp3f7IFT0NJTyiCiP1SCX2jO/ukTBlKSfQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-5.3.1.tgz",
+      "integrity": "sha512-CeG7Xh48cePpEroUCIKGNBEMEbMJ21r377ve77zz0DxY46PtC9b+HZ14kENTKJ3FmHRKaDL7K2Jw5SctndQzJg==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@antora/cli": "3.1.15",
     "@antora/site-generator": "3.1.15",
     "@asciidoctor/tabs": "^1.0.0-beta.5",
-    "@redpanda-data/docs-extensions-and-macros": "^5.1.2",
+    "@redpanda-data/docs-extensions-and-macros": "^5.3.1",
     "@sntke/antora-mermaid-extension": "^0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Refresh the lockfile from doc-tools 5.2.5 to 5.3.1 and raise the `package.json` floor from `^5.1.2` to `^5.3.1`.

## Why

The `update-rpk-plugin-docs` workflow installs doc-tools with `npm ci` and calls `doc-tools generate rpk-docs --plugin <name>`, but `--plugin` only exists in doc-tools 5.3.0+ (docs-extensions-and-macros#225, released 2026-07-31). With the lockfile at 5.2.5, every dispatch fails at the Refresh plugin docs step with `error: unknown option '--plugin'` before reaching PR creation. Verified on run [30682273251](https://github.com/redpanda-data/docs/actions/runs/30682273251) (a manual `plugin: ai` dispatch).

Raising the floor to `^5.3.1` keeps a future lockfile regeneration from resolving below the version the workflow depends on.

Verified locally that 5.3.1's `doc-tools generate rpk-docs --help` lists `--plugin`.

@JakeSCahill feel free to close this in favor of a different fix (for example, installing doc-tools explicitly in the workflow) if you'd rather decouple it from the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)