### PR TITLE
docs: stop excluding rpk ai connection from the rpk reference

### DIFF
--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -3373,15 +3373,6 @@
         }
       ]
     },
-    "rpk ai connection": {
-      "exclude": true
-    },
-    "rpk ai connection list": {
-      "exclude": true
-    },
-    "rpk ai connection revoke": {
-      "exclude": true
-    },
     "rpk redpanda mode": {
       "content": [
         {


### PR DESCRIPTION
## What

Remove the three `exclude` overrides for `rpk ai connection`, `rpk ai connection list`, and `rpk ai connection revoke` from `docs-data/rpk-overrides.json`.

## Why

The `rpk ai connection` group graduated from a coming-soon stub to working commands in plugin v0.2.32, and the ADP release notes announce it as a feature. The excludes date from the stub era. With them in place, the plugin-docs regen (#1868) refreshes the snapshot correctly (the connection commands are present with real help text) but renders no pages for them: `shouldExcludeCommand` walks these entries and drops the subtree.

After this merges, re-dispatching `update-rpk-plugin-docs.yml` for `ai` updates #1868 in place with the connection partials.

Related: #1865 cleans up other stale rpk ai override paths (the `rpk ai llm check` warnings in the regen log) but doesn't touch these entries; the two changes are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)