### PR TITLE
Detect page-set changes when flagging adp-docs follow-ups

### DIFF
--- a/.github/workflows/update-rpk-plugin-docs.yml
+++ b/.github/workflows/update-rpk-plugin-docs.yml
@@ -209,10 +209,23 @@ jobs:
             git diff --staged --name-only | head -20
           fi
 
-          # Structural changes (commands added/removed/deprecated) matter for
-          # downstream consumers with static stubs (adp-docs for rpk ai)
-          if grep -qE '\| (New|Removed|Deprecated) commands +\|' "${{ runner.temp }}/pr-summary.md" 2>/dev/null; then
+          # Structural changes matter for downstream consumers with static
+          # stubs (adp-docs for rpk ai). Two independent signals, because the
+          # command tree and the page set can change independently: the rpk ai
+          # connection pages appeared with ZERO tree changes (the commands
+          # existed as stubs in 0.2.31; removing their overrides excludes is
+          # what created the pages), so the summary-table grep alone missed
+          # it. Any added, deleted, or renamed page/partial for this plugin is
+          # structural; pure content modifications are not.
+          PLUGIN="${{ steps.params.outputs.plugin }}"
+          PAGESET_CHANGE=$(git diff --staged --name-status -- \
+            "modules/reference/partials/rpk-${PLUGIN}" \
+            "modules/reference/pages/rpk/rpk-${PLUGIN}" \
+            | grep -cE '^[ADR]' || true)
+          if [ "$PAGESET_CHANGE" -gt 0 ] || \
+             grep -qE '\| (New|Removed|Deprecated) commands +\|' "${{ runner.temp }}/pr-summary.md" 2>/dev/null; then
             echo "structural=true" >> $GITHUB_OUTPUT
+            [ "$PAGESET_CHANGE" -gt 0 ] && echo "Page-set change detected: $PAGESET_CHANGE added/deleted/renamed page(s)"
           else
             echo "structural=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fixes the first of @micheleRP's follow-ups from the first production rpk ai run: the "Flag adp-docs follow-up" step skipped even though three connection pages were new.

**Root cause is a detection-model gap, not a broken grep**: the step keys on the diff summary's New/Removed/Deprecated command rows, which reflect the *command tree*. The connection pages appeared with **zero tree changes** — `rpk ai connection` existed in the 0.2.31 tree already (as coming-soon stubs), and what created the pages was #1869 removing their overrides excludes. Tree diff said nothing changed, so `structural=false` was computed correctly and was still the wrong answer for adp-docs, whose stubs track the **page set**.

**Fix**: the step now treats any added, deleted, or renamed page/partial under the plugin's own directories (`partials/rpk-<plugin>`, `pages/rpk/rpk-<plugin>`) as structural — via `git diff --staged --name-status` — while keeping the summary grep as the second signal for tree-level changes. Pure content modifications remain non-structural, so routine description refreshes don't spam the label.

Verified against the actual production case: the 03:57 run's changeset (three added `rpk-ai-connection*` partials) matches `^A` and would have set `structural=true`. The merge-time notify hook covered this instance, so this is belt-and-braces for visibility at PR time.

## Related PRs (rpk docs automation train)

Follow-up from the #1868/#1869 production run.