### PR TITLE
docs: update rpk ai plugin docs (0.2.33)

### DIFF
--- a/docs-data/rpk-overrides.json
+++ b/docs-data/rpk-overrides.json
@@ -338,7 +338,7 @@
         "flags": "g"
       },
       {
-        "description": "Wrap bare flag with adjacent format/value word as inline code before auto-backtick step splits them (e.g. -f json -> `\u200c-f json`, --format yaml -> `--format yaml`)",
+        "description": "Wrap bare flag with adjacent format/value word as inline code before auto-backtick step splits them (e.g. -f json -> `‌-f json`, --format yaml -> `--format yaml`)",
         "pattern": "(?<![`\\w-])(-{1,2}[a-zA-Z][a-z-]*) (json/yaml|json|yaml|text|wide|csv)(?![/a-zA-Z])",
         "replacement": "`$1 $2`",
         "flags": "g"
@@ -3217,7 +3217,12 @@
       "description": "Revoke every refresh token the AI gateway has issued for the named OAuth client. Forces all users who connected this client to sign in again.\n\nAlready-issued short-lived access tokens may continue working until natural expiry (typically minutes).\n\nThis command is idempotent: running it again returns 0."
     },
     "rpk ai oauth-client create": {
-      "description": "Register an OAuth client with the AI gateway. The generated client secret is printed once and cannot be retrieved afterward. Save it immediately in a secret manager."
+      "description": "Register an OAuth client with the AI gateway. The generated client secret is printed once and cannot be retrieved afterward. Save it immediately in a secret manager.",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai oauth-client dcr get": {
       "description": "Show the Dynamic Client Registration (DCR) settings for the current tenant, including whether DCR is enabled and the configured admission mode."
@@ -3520,7 +3525,12 @@
       "introducedInVersion": "0.2.28"
     },
     "rpk ai llm-provider create": {
-      "introducedInVersion": "0.2.28"
+      "introducedInVersion": "0.2.28",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai llm-provider delete": {
       "introducedInVersion": "0.2.28"
@@ -3535,7 +3545,12 @@
       "introducedInVersion": "0.2.28"
     },
     "rpk ai llm-provider update": {
-      "introducedInVersion": "0.2.28"
+      "introducedInVersion": "0.2.28",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai mcp-server": {
       "introducedInVersion": "0.2.28"
@@ -3544,7 +3559,12 @@
       "introducedInVersion": "0.2.28"
     },
     "rpk ai mcp-server create": {
-      "introducedInVersion": "0.2.28"
+      "introducedInVersion": "0.2.28",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai mcp-server delete": {
       "introducedInVersion": "0.2.28"
@@ -3571,10 +3591,20 @@
       "introducedInVersion": "0.2.28"
     },
     "rpk ai mcp-server update": {
-      "introducedInVersion": "0.2.28"
+      "introducedInVersion": "0.2.28",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai oauth-client update": {
-      "introducedInVersion": "0.2.28"
+      "introducedInVersion": "0.2.28",
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     },
     "rpk ai policy": {
       "introducedInVersion": "0.2.26"
@@ -3714,6 +3744,20 @@
     },
     "rpk generate license": {
       "selfHostedOnly": true
+    },
+    "rpk ai oauth-provider create": {
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
+    },
+    "rpk ai oauth-provider update": {
+      "flags": {
+        "tags": {
+          "introducedInVersion": "0.2.33"
+        }
+      }
     }
   }
 }

--- a/docs-data/rpk-v26.2.1.json
+++ b/docs-data/rpk-v26.2.1.json
@@ -1,11 +1,11 @@
 {
   "rpk_version": "v26.2.1",
   "plugin_versions": {
-    "ai": "0.2.32",
+    "ai": "0.2.33",
     "connect": "4.103.1",
     "k8s": "26.2.1"
   },
-  "generated_at": "2026-08-03T06:41:37.753Z",
+  "generated_at": "2026-08-04T11:41:14.556Z",
   "tree": {
     "name": "rpk",
     "version": "(Redpanda CLI):  (rev )",
@@ -575,7 +575,7 @@
             "commands": [
               {
                 "name": "login",
-                "description": "Run the OAuth 2.0 device authorization grant against Redpanda Cloud, persist the resulting credentials, and prompt to select an environment whose AI Gateway URL becomes the active profile's dataplane URL.",
+                "description": "Run the OAuth 2.0 device authorization grant against Redpanda Cloud, persist the resulting credentials, and prompt to select an environment whose AI Gateway URL becomes the active profile's dataplane URL.\n\nCredentials are stored in the `rpk ai` credentials file with `0600` permissions, keyed by organization.\n\nA successful login rewrites the config in the current schema, so running `rpk ai auth login` is also how you migrate a config left over from an older version of the plugin.\n\nIf the current environment's organization still holds valid credentials, login is a no-op and prints \"Already logged in\". Run `rpk ai auth logout` first to re-authenticate, or `rpk ai auth logout --all` for a full clean slate.",
                 "usage": "rpk ai auth login [flags]",
                 "aliases": [],
                 "flags": [
@@ -863,7 +863,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "check",
@@ -875,7 +876,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "create",
@@ -995,6 +997,12 @@
                     "description": "Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock provider the guardrail uses AWS Bedrock Guardrail directly. For all other providers the proxy evaluates user input against the Bedrock Guardrail's standalone backend. In both cases a guardrail intervention short-circuits the request."
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to create from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -1010,7 +1018,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "delete",
@@ -1022,7 +1031,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "diff",
@@ -1041,7 +1051,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "get",
@@ -1053,7 +1064,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "list",
@@ -1091,7 +1103,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "update",
@@ -1210,6 +1223,12 @@
                     "description": "Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock providers the guardrail rides the upstream call via AWS guardrail headers and is enforced by Bedrock itself. For all other providers the proxy evaluates user input against the guardrail's standalone ApplyGuardrail backend before forwarding the request upstream. In both cases a guardrail intervention short-circuits the request."
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to update from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -1235,13 +1254,15 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               }
             ],
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "0.2.28"
           },
           {
             "name": "mcp-server",
@@ -1267,7 +1288,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "create",
@@ -1300,6 +1322,12 @@
                     "name": "response-format",
                     "type": "string",
                     "description": "Output format for tool results (token optimization). (one of: jton, toon)"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
                   },
                   {
                     "name": "remote.url",
@@ -1407,7 +1435,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "delete",
@@ -1419,7 +1448,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "diff",
@@ -1438,7 +1468,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "get",
@@ -1450,7 +1481,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "list",
@@ -1488,7 +1520,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "tools",
@@ -1518,7 +1551,8 @@
                     "platforms": [
                       "linux",
                       "darwin"
-                    ]
+                    ],
+                    "introducedInVersion": "0.2.28"
                   },
                   {
                     "name": "list",
@@ -1536,13 +1570,15 @@
                     "platforms": [
                       "linux",
                       "darwin"
-                    ]
+                    ],
+                    "introducedInVersion": "0.2.28"
                   }
                 ],
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "types",
@@ -1554,7 +1590,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               },
               {
                 "name": "update",
@@ -1586,6 +1623,12 @@
                     "name": "response-format",
                     "type": "string",
                     "description": "Output format for tool results (token optimization). (one of: jton, toon)"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
                   },
                   {
                     "name": "remote.url",
@@ -1703,13 +1746,15 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               }
             ],
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "0.2.28"
           },
           {
             "name": "model",
@@ -1833,6 +1878,12 @@
                     "description": "Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass --enabled=false to disable)"
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to create from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -1852,7 +1903,7 @@
               },
               {
                 "name": "dcr",
-                "description": "Manage Dynamic Client Registration (DCR) settings for the AI gateway. DCR allows OAuth clients to register themselves programmatically at a public endpoint.",
+                "description": "Manage Dynamic Client Registration (DCR) settings for the AI gateway. DCR allows OAuth clients to register themselves programmatically at a public endpoint.\n\nWhen DCR is enabled, spec-conformant MCP clients (such as Claude and Cursor) self-register at the public `/oauth/idp/register` endpoint with no admin pre-provisioning. Admission is governed by the mode:\n\n* `open`: anyone may register (rate limit and client cap still apply)\n* `initial-access-token`: callers must present an admin-minted one-shot bearer token\n* `software-statement`: reserved, not yet supported\n\nDCR is disabled per tenant by default. The gateway operator must also enable the global `ingress.idp.dcr.global_enabled` flag.",
                 "usage": "rpk ai oauth-client dcr [flags]",
                 "aliases": [],
                 "flags": [],
@@ -2061,7 +2112,7 @@
               },
               {
                 "name": "revoke-tokens",
-                "description": "Revoke every refresh token the AI gateway has issued for the named OAuth client. Forces all users who connected this client to sign in again.",
+                "description": "Revoke every refresh token the AI gateway has issued for the named OAuth client. Forces all users who connected this client to sign in again.\n\nAlready-issued short-lived access tokens may continue working until natural expiry (typically minutes).\n\nThis command is idempotent: running it again returns 0.",
                 "usage": "rpk ai oauth-client revoke-tokens [flags]",
                 "aliases": [],
                 "flags": [],
@@ -2118,6 +2169,12 @@
                     "description": "Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass --enabled=false to disable)"
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to update from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -2143,7 +2200,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.28"
               }
             ],
             "platforms": [
@@ -2252,6 +2310,12 @@
                     "name": "register-from-url",
                     "type": "string",
                     "description": "Remote MCP server URL to auto-detect OAuth from. The gateway discovers endpoints and registers a client automatically."
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
                   },
                   {
                     "name": "filename",
@@ -2419,6 +2483,12 @@
                     "description": "Whether this provider accepts new connections. (true when set; pass --enabled=false to disable)"
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)",
+                    "introducedInVersion": "0.2.33"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to update from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -2476,7 +2546,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "create",
@@ -2514,7 +2585,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "delete",
@@ -2532,7 +2604,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "diff",
@@ -2551,7 +2624,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "get",
@@ -2563,7 +2637,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "list",
@@ -2575,7 +2650,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               },
               {
                 "name": "update",
@@ -2613,13 +2689,15 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "0.2.26"
               }
             ],
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "0.2.26"
           },
           {
             "name": "run",
@@ -2823,7 +2901,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "v26.2.1"
           },
           {
             "name": "uninstall",
@@ -2835,7 +2914,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "v26.2.1"
           },
           {
             "name": "upgrade",
@@ -2855,13 +2935,15 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "v26.2.1"
           }
         ],
         "platforms": [
           "linux",
           "darwin"
-        ]
+        ],
+        "introducedInVersion": "v26.2.1"
       },
       {
         "name": "cloud",
@@ -2902,7 +2984,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   }
                 ],
                 "commands": [],
@@ -3146,7 +3229,7 @@
             "commands": [
               {
                 "name": "install",
-                "description": "Install the MCP client configuration to connect your AI assistant to the local MCP server for Redpanda Cloud.\n\nThis command generates and installs the necessary configuration files for your MCP client (like Claude Code) to automatically connect to the local MCP server for Redpanda Cloud. The local MCP server provides your AI assistant with tools to manage your Redpanda Cloud account and clusters.\n\nSupports Claude Desktop and Claude Code.",
+                "description": "Install the MCP client configuration to connect your AI assistant to the local MCP server for Redpanda Cloud.\n\nThis command generates and installs the necessary configuration files for your MCP client (like Claude Code) to automatically connect to the local MCP server for Redpanda Cloud. The local MCP server provides your AI assistant with tools to manage your Redpanda Cloud account and clusters.\n\nSupports Claude Desktop and Claude Code.\n\nThis command writes an `mcpServer` entry named `redpandaCloud` into the appropriate config file.",
                 "usage": "rpk cloud mcp install [flags]",
                 "aliases": [],
                 "flags": [
@@ -3312,6 +3395,7 @@
                   "linux",
                   "darwin"
                 ],
+                "introducedInVersion": "v26.2.1",
                 "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission.adoc"
               },
               {
@@ -3349,6 +3433,7 @@
                   "linux",
                   "darwin"
                 ],
+                "introducedInVersion": "v26.2.1",
                 "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers-decommission-status.adoc"
               },
               {
@@ -3362,6 +3447,7 @@
                   "linux",
                   "darwin"
                 ],
+                "introducedInVersion": "v26.2.1",
                 "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers-recommission.adoc"
               }
             ],
@@ -3369,11 +3455,13 @@
               "linux",
               "darwin"
             ],
-            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers.adoc"
+            "introducedInVersion": "v26.2.1",
+            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-brokers.adoc",
+            "selfHostedOnly": true
           },
           {
             "name": "config",
-            "description": "View and modify cluster-wide configuration properties. Changes take effect across all brokers.",
+            "description": "View and modify Redpanda cluster configuration properties.\n\nModified properties are propagated immediately to all brokers. Use `rpk cluster config status` to verify that all brokers are up to date, and to identify any settings that were rejected, for example, if a broker is still restarting.",
             "usage": "rpk cluster config [flags]",
             "aliases": [],
             "flags": [],
@@ -3396,7 +3484,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "selfHostedOnly": true
               },
               {
                 "name": "export",
@@ -3424,7 +3513,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "selfHostedOnly": true
               },
               {
                 "name": "force-reset",
@@ -3444,7 +3534,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "selfHostedOnly": true
               },
               {
                 "name": "get",
@@ -3491,11 +3582,12 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "selfHostedOnly": true
               },
               {
                 "name": "lint",
-                "description": "Identify any Redpanda configuration properties that are not recognized. These may be properties that were valid in earlier versions of Redpanda but are now managed via the central configuration store.",
+                "description": "Remove any deprecated content from redpanda.yaml.\n\nDeprecated content includes properties which were set via redpanda.yaml\nin earlier versions of redpanda, but are now managed via Redpanda's\ncentral configuration store (and via 'rpk cluster config edit').\n",
                 "usage": "rpk cluster config lint [flags]",
                 "aliases": [],
                 "flags": [],
@@ -3503,7 +3595,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "selfHostedOnly": true
               },
               {
                 "name": "list",
@@ -3531,7 +3624,8 @@
                     "type": "int",
                     "description": "If set, route the cluster configuration request to the given broker instead of any broker",
                     "default": 0,
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   }
                 ],
                 "commands": [],
@@ -3671,7 +3765,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   }
                 ],
                 "commands": [],
@@ -3865,7 +3960,7 @@
           },
           {
             "name": "health",
-            "description": "Query cluster health and display the overall health status of the cluster. Redpanda collects health reports periodically from all nodes and aggregates them into a health overview.",
+            "description": "Queries cluster for health overview.\n\nHealth overview is created based on the health reports collected periodically\nfrom all nodes in the cluster. A cluster is considered healthy when the\nfollowing conditions are met:\n\n  * All cluster nodes are responding\n  * All partitions have leaders\n  * The cluster controller is present\n\nIf the cluster is reported as unhealthy, rpk will exit with code 10.\n",
             "usage": "rpk cluster health [flags]",
             "aliases": [],
             "examples": "\nBasic usage, get cluster health information:\n  rpk cluster health\n\nGet cluster health information and watch for changes:\n  rpk cluster health --watch\n\nGet cluster health information and exit when the cluster is healthy:\n  rpk cluster health --exit-when-healthy\n",
@@ -3899,15 +3994,7 @@
               "linux",
               "darwin"
             ],
-            "content": [
-              {
-                "type": "section",
-                "id": "health-criteria",
-                "title": null,
-                "position": "after_description",
-                "content": "A cluster is considered healthy when the following conditions are met:\n\n* All cluster nodes are responding\n* All partitions have leaders\n* The cluster controller is present"
-              }
-            ]
+            "selfHostedOnly": true
           },
           {
             "name": "info",
@@ -3923,7 +4010,8 @@
                 "type": "bool",
                 "description": "Augment the brokers section with Admin API metadata (cores, membership, liveness, version, UUID, and disk space)",
                 "default": false,
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "format",
@@ -3937,7 +4025,8 @@
                 "type": "bool",
                 "description": "Append decommissioned nodes to the brokers section using their UUID",
                 "default": false,
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "print-brokers",
@@ -4018,7 +4107,7 @@
               },
               {
                 "name": "set",
-                "description": "Upload a license to the cluster using a file path, inline string, or default location.",
+                "description": "Upload license to the cluster\n\nYou can either provide a path to a file containing the license:\n\n    rpk cluster license set --path /home/organization/redpanda.license\n\nOr inline the license string:\n\n    rpk cluster license set <license string>\n\nIf neither are present, rpk will look for the license in the\ndefault location '/etc/redpanda/redpanda.license'.\n",
                 "usage": "rpk cluster license set [flags]",
                 "aliases": [],
                 "flags": [
@@ -4040,7 +4129,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "logdirs",
@@ -4051,7 +4141,7 @@
             "commands": [
               {
                 "name": "describe",
-                "description": "Describe log directories on Redpanda brokers.\n\nThis command prints information about log directories on brokers, as well as the number of records in those log directories. The information is sorted first by topic, then by partition, and last by broker.\n\nThe directory returned is the root directory for partitions. Within Redpanda, the partition data lives underneath the returned root directory in `+kafka/{topic}/{partition}_{revision}/+`, where `revision` is a Redpanda internal concept.",
+                "description": "Describe log directories on Redpanda brokers.\n\nThis command prints information about log directories on brokers, particularly,\nthe base directory that topics and partitions are located in, and the size of\ndata that has been written to the partitions. The size you see may not exactly\nmatch the size on disk as reported by du: Redpanda allocates files in chunks.\nThe chunks will show up in du, while the actual bytes so far written to the\nfile will show up in this command.\n\nThe directory returned is the root directory for partitions. Within Redpanda,\nthe partition data lives underneath the the returned root directory in\n\n    kafka/{topic}/{partition}_{revision}/\n\nwhere revision is a Redpanda internal concept.\n",
                 "usage": "rpk cluster logdirs describe [flags]",
                 "aliases": [],
                 "flags": [
@@ -4075,7 +4165,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   },
                   {
                     "name": "human-readable",
@@ -4137,7 +4228,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "set",
@@ -4174,6 +4266,7 @@
                   "linux",
                   "darwin"
                 ],
+                "introducedInVersion": "v26.2.1",
                 "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level-set.adoc"
               }
             ],
@@ -4181,11 +4274,13 @@
               "linux",
               "darwin"
             ],
-            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level.adoc"
+            "introducedInVersion": "v26.2.1",
+            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-config-log-level.adoc",
+            "selfHostedOnly": true
           },
           {
             "name": "maintenance",
-            "description": "Manage cluster maintenance mode for performing rolling upgrades and other maintenance operations.",
+            "description": "Interact with cluster maintenance mode.\n\nMaintenance mode is a state that a node may be placed into in which the node\nmay be shutdown or restarted with minimal disruption to client workloads. The\nprimary use of maintenance mode is to perform a rolling upgrade in which each\nnode is placed into maintenance mode prior to upgrading the node.\n\nUse the 'enable' and 'disable' subcommands to place a node into maintenance mode\nor remove it, respectively. Only one node at a time may be in maintenance mode.\n\nWhen a node is placed into maintenance mode the following occurs:\n\nLeadership draining. All raft leadership is transferred to another eligible\nnode, and the node in maintenance mode rejects new leadership requests. By\ntransferring leadership off of the node in maintenance mode all client traffic\nand requests are directed to other nodes minimizing disruption to client\nworkloads when the node is shutdown.\n\nCurrently leadership is not transferred for partitions with one replica.\n",
             "usage": "rpk cluster maintenance [flags]",
             "aliases": [],
             "flags": [],
@@ -4204,7 +4299,7 @@
               },
               {
                 "name": "enable",
-                "description": "Enable maintenance mode on a broker. While in maintenance mode, the broker drains partition leadership to other brokers. Use this command before performing broker upgrades or hardware maintenance. After maintenance is complete, run `rpk cluster maintenance disable <broker-id>` to restore normal operation.",
+                "description": "Enable maintenance mode for a node.\n\nThis command enables maintenance mode for the node with the specified ID. If a\nnode exists that is already in maintenance mode then an error will be returned.\n",
                 "usage": "rpk cluster maintenance enable [BROKER-ID] [flags]",
                 "aliases": [],
                 "flags": [
@@ -4221,11 +4316,18 @@
                 "platforms": [
                   "linux",
                   "darwin"
+                ],
+                "content": [
+                  {
+                    "type": "section",
+                    "position": "after_description",
+                    "content": "Use this command before performing broker upgrades or hardware maintenance. After maintenance is complete, run `rpk cluster maintenance disable <broker-id>` to restore normal operation."
+                  }
                 ]
               },
               {
                 "name": "status",
-                "description": "Report maintenance status.\n\nThis command reports maintenance status for each broker in the cluster. The output is presented as a table with each row representing a broker in the cluster. The output can be used to monitor the progress of node draining.",
+                "description": "Report maintenance status.\n\nThis command reports maintenance status for each node in the cluster. The output\nis presented as a table with each row representing a node in the cluster.  The\noutput can be used to monitor the progress of node draining.\n\n   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED\n   1        false     false     false   0           0         0             0\n\nField descriptions:\n\n        NODE-ID: the node ID\n        ENABLED: true if the node is currently in maintenance mode (draining)\n       FINISHED: leadership draining has completed\n         ERRORS: errors have been encountered while draining\n     PARTITIONS: number of partitions whose leadership has moved\n       ELIGIBLE: number of partitions with leadership eligible to move\n   TRANSFERRING: current active number of leadership transfers\n         FAILED: number of failed leadership transfers\n\nNotes:\n\n   - When errors are present further information will be available in the logs\n     for the corresponding node.\n\n   - Only partitions with more than one replica are eligible for leadership\n     transfer.\n\n   - FINISHED, ERRORS, PARTITIONS, ELIGIBLE, TRANSFERRING, and FAILED are only\n     populated while a node is in maintenance mode (ENABLED=true).\n",
                 "usage": "rpk cluster maintenance status [flags]",
                 "aliases": [],
                 "flags": [
@@ -4234,7 +4336,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   }
                 ],
                 "commands": [],
@@ -4256,7 +4359,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "partitions",
@@ -4267,7 +4371,7 @@
             "commands": [
               {
                 "name": "balance",
-                "description": "Trigger on-demand partition balancing to redistribute partitions evenly across brokers. Redpanda automatically balances partitions when it detects imbalance; run this command to trigger balancing manually.",
+                "description": "Triggers on-demand partition balancing.\n\nThis command allows you to trigger on-demand partition balancing.\n\nWith Redpanda Community Edition, the partition count on each broker\ncan easily become uneven, which leads to data skewing. To distribute\npartitions across brokers, you can run this command to trigger\non-demand partition balancing.\n\nWith Redpanda Enterprise Edition, Continuous Data Balancing monitors\nbroker and rack availability, as well as disk usage, to avoid topic\nhotspots. However, there are edge cases where users should manually\ntrigger partition balancing (such as a node becoming unavailable for\na prolonged time and rejoining the cluster thereafter). In such cases,\nyou should run this command to trigger partition balancing manually.\n\nAfter you run this command, monitor the balancer progress using:\n\n    rpk cluster partitions balancer-status\n\nTo see more detailed movement status, monitor the progress using:\n\n    rpk cluster partitions move-status\n",
                 "usage": "rpk cluster partitions balance [flags]",
                 "aliases": [],
                 "flags": [],
@@ -4288,7 +4392,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   }
                 ],
                 "commands": [],
@@ -4357,7 +4462,7 @@
               },
               {
                 "name": "list",
-                "description": "List partitions in the cluster. This command lists the cluster-level metadata of all partitions, including current replica assignments on brokers and CPU cores for given topics.",
+                "description": "List partitions in the cluster\n\nThis commands lists the cluster-level metadata of all partitions in the cluster.\nIt shows the current replica assignments on both brokers and CPU cores for given\ntopics. By default, it assumes the \"kafka\" namespace, but you can specify an\ninternal namespace using the \"{namespace}/\" prefix.\n\nThe REPLICA-CORE column displayed in the output table contains a list of\nreplicas assignments in the form of: <Node-ID>-<Core>.\n\nIf the DISABLED column contains a '-' value, then it means you are running this\ncommand against a cluster that does not support the underlying API.\n\nENABLED/DISABLED\n\nDisabling a partition in Redpanda involves prohibiting any data consumption or\nproduction to and from it. All internal processes associated with the partition\nare stopped, and it remains unloaded during system startup. This measure aims to\nmaintain cluster health by preventing issues caused by specific corrupted\npartitions that may lead to Redpanda crashes. Although the data remains stored\non disk, Redpanda ceases interaction with the disabled partitions to ensure\nsystem stability.\n\nYou may disable/enable partition using 'rpk cluster partitions enable/disable'.\t\n\nEXAMPLES\n\nList all partitions in the cluster.\n  rpk cluster partitions list --all\n\nList all partitions in the cluster, filtering for topic foo and bar.\n  rpk cluster partitions list foo bar\n\nList partitions which replicas are assigned to brokers 1 and 2.\n  rpk cluster partitions list foo --node-ids 1,2\n\nList only the disabled partitions.\n  rpk cluster partitions list -a --disabled-only\n\nList all in json format.\n  rpk cluster partition list -a --format json\n",
                 "usage": "rpk cluster partitions list [TOPICS...] [flags]",
                 "aliases": [
                   "ls",
@@ -4449,7 +4554,7 @@
               },
               {
                 "name": "move",
-                "description": "Move partition replicas across nodes / cores.\n\nThis command changes replica assignments for given partitions. By default, it\nassumes the `kafka` namespace, but you can specify an internal namespace using\nthe `{namespace}/` prefix.",
+                "description": "Move partition replicas across nodes / cores.\n\nThis command changes replica assignments for given partitions. By default, it\nassumes the \"kafka\" namespace, but you can specify an internal namespace using\nthe \"{namespace}/\" prefix.\n\nTo move replicas, use the following syntax:\n\n    rpk cluster partitions move foo --partition 0:1,2,3 -p 1:2,3,4\n\nHere, the command assigns new replicas for partition 0 to brokers [1, 2, 3] and\nfor partition 1 to brokers [2, 3, 4] for the topic \"foo\".\n\nYou can also specify the core id with \"-{core_id}\" where the new replicas\nshould be placed:\n\n    rpk cluster partitions move foo -p 0:1-0,2-0,3-0\n\nHere all new replicas [1, 2, 3] will be assigned on core 0 on the nodes.\n\nThe command does not change a \"core\" assignment unless it is explicitly\nspecified. When a core is not specified for a new node, the command randomly\npicks a core and assign a replica on the core.\n\nTopic arguments are optional. For more control, you can specify the topic name\nin the \"--partition\" flag:\n\n    rpk cluster partitions move -p foo/0:1,2,3 -p kafka_internal/tx/0:1-0,2-0,3-0\n",
                 "usage": "rpk cluster partitions move [flags]",
                 "aliases": [],
                 "flags": [
@@ -4527,7 +4632,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   },
                   {
                     "name": "no-confirm",
@@ -4562,7 +4668,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   },
                   {
                     "name": "human-readable",
@@ -4694,7 +4801,8 @@
               "linux",
               "darwin"
             ],
-            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-partitions.adoc"
+            "pageAliases": "reference:rpk/rpk-redpanda/rpk-redpanda-admin-partitions.adoc",
+            "selfHostedOnly": true
           },
           {
             "name": "quotas",
@@ -4852,7 +4960,7 @@
               },
               {
                 "name": "import",
-                "description": "Use this command to import client quotas in the format produced by `rpk cluster quotas describe --format json/yaml`.",
+                "description": "Use this command to import client quotas in the format produced by `rpk cluster quotas describe --format json/yaml`.\n\nThe schema of the import string matches the schema from `rpk cluster quotas describe --format help`:\n\n[,text]\n----\n{\n  quotas: []{\n    entity: []{\n      name: string\n      type: string\n    }\n    values: []{\n      key: string\n      values: string\n    }\n  }\n}\n----\n\nUse the `--no-confirm` flag if you wish to avoid the confirmation prompt.",
                 "usage": "rpk cluster quotas import [flags]",
                 "aliases": [],
                 "examples": "\nImport client quotas from a file:\n  rpk cluster quotas import --from /path/to/file\n\nImport client quotas from a string:\n  rpk cluster quotas import --from '{\"quotas\":...}'\n",
@@ -4903,7 +5011,7 @@
             "commands": [
               {
                 "name": "start",
-                "description": "Starts one or more benchmark tests on one or more nodes of the cluster.",
+                "description": "Starts one or more benchmark tests on one or more nodes of the cluster.\n\nNOTE: Redpanda self-test runs benchmarks that consume significant system resources. Do not start self-test if large workloads are already running on the system.\n\nAvailable tests to run:\n\n* Disk tests:\n  ** Throughput test: 512 KB messages, sequential read/write\n     *** Uses a larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.\n  ** Latency and io depth tests: 4 KB messages, sequential read/write, varying io depth\n     *** Uses small IO sizes and varying levels of parallelism to determine the relationship between io depth and IOPS\n     *** Includes one test without using dsync (fdatasync) on each write to establish the cost of dsync\n  ** 16 KB test\n     *** One high io depth test at 16 KB to reflect performance at Redpanda's default chunk size\n* Network tests:\n  ** Throughput test: 8192-bit messages\n     *** Unique pairs of Redpanda nodes each act as a client and a server.\n     *** The test pushes as much data over the wire, within the test parameters.\n* Cloud storage tests\n  ** Configuration/Latency test: 1024-byte object.\n  ** If cloud storage is enabled ('cloud_storage_enabled'), a series of remote operations are performed:\n     *** Upload an object (a random buffer of 1024 bytes) to the cloud storage bucket/container.\n     *** List objects in the bucket/container.\n     *** Download the uploaded object from the bucket/container.\n     *** Download the uploaded object's metadata from the bucket/container.\n     *** Delete the uploaded object from the bucket/container.\n     *** Upload and then delete multiple objects (random buffers of 1024 bytes) at once from the bucket/container.\n\nThis command prompts users for confirmation (unless the flag '--no-confirm' is specified), then returns a test identifier ID, and runs the tests.\n\nTo view the test status, poll 'rpk cluster self-test status'. Once the tests end, the cached results will be available with 'rpk cluster self-test status'.",
                 "usage": "rpk cluster self-test start [flags]",
                 "aliases": [],
                 "flags": [
@@ -4978,20 +5086,6 @@
                 ],
                 "seeAlso": [
                   "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-status.adoc[`rpk cluster self-test status`]"
-                ],
-                "content": [
-                  {
-                    "type": "note",
-                    "position": "after_description",
-                    "content": "Redpanda self-test runs benchmarks that consume significant system resources. Do not start self-test if large workloads are already running on the system."
-                  },
-                  {
-                    "type": "section",
-                    "id": "available-tests",
-                    "title": null,
-                    "position": "after_description",
-                    "content": "Available tests to run:\n\n* *Disk tests*\n** Throughput test: 512 KB messages, sequential read/write\n*** Uses larger request message sizes and deeper I/O queue depth to write/read more bytes in a shorter amount of time, at the cost of IOPS/latency.\n** Latency test: 4 KB messages, sequential read/write\n*** Uses smaller request message sizes and lower levels of parallelism to achieve higher IOPS and lower latency.\n* *Network tests*\n** Throughput test: 8192-bit messages\n*** Unique pairs of Redpanda nodes each act as a client and a server.\n*** The test pushes as much data over the wire, within the test parameters.\n* *Cloud storage tests*\n** Configuration/latency test: 1024-byte object.\n** If cloud storage is enabled (xref:reference:properties/object-storage-properties.adoc#cloud_storage_enabled[`cloud_storage_enabled`]), a series of remote operations are performed:\n+\n--\ninclude::reference:partial$rpk-self-test-cloud-tests.adoc[]\n--\n\nThis command prompts users for confirmation (unless the flag `--no-confirm` is specified), then returns a test identifier ID, and runs the tests.\n\nTo view the test status, poll xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-status.adoc[`rpk cluster self-test status`]. Once the tests end, the cached results will be available with `rpk cluster self-test status`."
-                  }
                 ]
               },
               {
@@ -5076,7 +5170,8 @@
               "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-start.adoc[rpk cluster self-test start]",
               "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-status.adoc[rpk cluster self-test status]",
               "xref:reference:rpk/rpk-cluster/rpk-cluster-self-test-stop.adoc[rpk cluster self-test stop]"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "storage",
@@ -5212,7 +5307,7 @@
               },
               {
                 "name": "mount",
-                "description": "Mount a topic from Tiered Storage, making it available for reads.",
+                "description": "Mount a topic to the Redpanda cluster from Tiered Storage.\n\nThis command mounts a topic in the Redpanda cluster using log segments stored\nin Tiered Storage. The topic may be optionally renamed with the --to flag.\n\nRequirements:\n- Tiered Storage must be enabled.\n- Log segments for the topic must be available in Tiered Storage.\n- A topic with the same name must not already exist in the cluster.",
                 "usage": "rpk cluster storage mount [TOPIC] [flags]",
                 "aliases": [],
                 "examples": "\nMounts topic my-typic from Tiered Storage to the cluster in the my-namespace\n\trpk cluster storage mount my-topic\n\nMount topic my-topic from Tiered Storage to the cluster in the my-namespace \nwith my-new-topic as the new topic name\n\trpk cluster storage mount my-namespace/my-topic --to my-namespace/my-new-topic\n",
@@ -5330,7 +5425,8 @@
                 "seeAlso": [
                   "xref:manage:whole-cluster-restore.adoc[Whole-Cluster Restore]"
                 ],
-                "pageAliases": "reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc"
+                "pageAliases": "reference:rpk/rpk-cluster/rpk-cluster-storage-recovery.adoc",
+                "selfHostedOnly": true
               },
               {
                 "name": "status-mount",
@@ -5375,7 +5471,7 @@
               },
               {
                 "name": "unmount",
-                "description": "Unmount a topic, removing it from local storage while preserving data in Tiered Storage.",
+                "description": "Unmount a topic from the Redpanda cluster and secure it in Tiered\nStorage.\n\nThis command performs an operation that:\n1. Rejects all writes to the topic\n2. Flushes data to Tiered Storage\n3. Removes the topic from the cluster\n\nKey Points:\n- During unmounting, any attempted writes or reads will receive an\n  UNKNOWN_TOPIC_OR_PARTITION error.\n- The unmount operation works independently of other topic configurations like\n  remote.delete=false.\n- After unmounting, the topic can be remounted to this cluster or a different\n  cluster if the log segments are moved to that cluster's Tiered Storage.\n",
                 "usage": "rpk cluster storage unmount [TOPIC] [flags]",
                 "aliases": [],
                 "examples": "\nUnmount topic 'my-topic' from the cluster in the 'my-namespace'\n  rpk cluster storage unmount my-namespace/my-topic\n",
@@ -5537,7 +5633,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "status",
@@ -5557,13 +5654,16 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "v26.2.1"
               }
             ],
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "v26.2.1",
+            "selfHostedOnly": true
           }
         ],
         "platforms": [
@@ -5941,7 +6041,7 @@
           },
           {
             "name": "echo",
-            "description": "Parse a config file and echo back a normalized version. This command is useful for sanity checking a config if it isn't behaving as expected, as it shows you a normalised version after environment variables have been resolved.",
+            "description": "Parse a config file and echo back a normalized version. This command is useful for sanity checking a config if it isn't behaving as expected, as it shows you a normalised version after environment variables have been resolved.\n\nExamples:\n\n[,bash]\n----\nrpk connect echo ./config.yaml | less\nrpk connect echo --set 'input.generate.mapping=root.id = uuid_v4()'\n----",
             "usage": "rpk connect echo [flags]",
             "aliases": [],
             "flags": [
@@ -5990,7 +6090,7 @@
           },
           {
             "name": "install",
-            "description": "Install Redpanda Connect. This command installs the latest version by default. Use the `--connect-version` flag to specify a version.",
+            "description": "Install Redpanda Connect. This command installs the latest version by default. Use the `--connect-version` flag to specify a version.\n\nYou may force the installation using the `--force` flag.",
             "usage": "rpk connect install [flags]",
             "aliases": [],
             "flags": [
@@ -6017,7 +6117,7 @@
           },
           {
             "name": "lint",
-            "description": "Check a Redpanda Connect configuration file for syntax errors and potential issues without running it.",
+            "description": "Check a Redpanda Connect configuration file for syntax errors and potential issues without running it.\n\nThis command exits with status code 1 if any linting errors are detected.",
             "usage": "rpk connect lint [flags]",
             "aliases": [],
             "flags": [
@@ -6097,7 +6197,7 @@
           },
           {
             "name": "list",
-            "description": "List available Redpanda Connect components. Shows inputs, outputs, processors, caches, rate limits, buffers, metrics, and tracers that can be used in pipelines.",
+            "description": "List available Redpanda Connect components. Shows inputs, outputs, processors, caches, rate limits, buffers, metrics, and tracers that can be used in pipelines.\n\nIf any component types are explicitly listed, only types of those components are shown.\n\nWhen using `--format jsonschema` with `bloblang-functions` or `bloblang-methods`, you can optionally specify function or method names to retrieve metadata for only those items, for example `rpk connect list --format jsonschema bloblang-functions uuid_v4`.",
             "usage": "rpk connect list [flags]",
             "aliases": [],
             "flags": [
@@ -6375,13 +6475,13 @@
               },
               {
                 "name": "chilled",
-                "description": "continue to execute a config containing linter errors",
+                "description": "Continue to execute a config containing linter errors.",
                 "type": "bool",
                 "default": "false"
               },
               {
                 "name": "watcher",
-                "description": "EXPERIMENTAL: watch config files for changes and automatically apply them",
+                "description": "EXPERIMENTAL: Watch config files for changes and automatically apply them.",
                 "shorthand": "w",
                 "type": "bool",
                 "default": "false"
@@ -6430,13 +6530,13 @@
               },
               {
                 "name": "env-file",
-                "description": "import environment variables from a dotenv file",
+                "description": "Import environment variables from a dotenv file.",
                 "shorthand": "e",
                 "type": "strings"
               },
               {
                 "name": "templates",
-                "description": "EXPERIMENTAL: import Redpanda Connect templates, supports glob patterns (requires quotes)",
+                "description": "EXPERIMENTAL: Import Redpanda Connect templates. This supports glob patterns (requires quotes).",
                 "shorthand": "t",
                 "type": "strings"
               }
@@ -6445,16 +6545,6 @@
             "platforms": [
               "linux",
               "darwin"
-            ],
-            "content": [
-              {
-                "type": "section",
-                "id": "connect-flags",
-                "title": "Flags",
-                "position": "after_description",
-                "headingLevel": 2,
-                "content": "[cols=\"1m,1a,2a\"]\n|===\n|Value |Type |Description\n\n|--log.level |string |Override the configured log level. Acceptable values: `off`, `error`, `warn`, `info`, `debug`, `trace`.\n|--set |stringArray |Set a field (identified by a dot path) in the main configuration file. For example: `metrics.type=prometheus`.\n|--resources, -r |stringArray |Pull in extra resources from a file, which can be referenced the same as resources defined in the main config. This supports glob patterns (requires quotes).\n|--chilled |bool |Continue to execute a config containing linter errors (default: false).\n|--watcher, -w |bool |EXPERIMENTAL: Watch config files for changes and automatically apply them (default: false).\n|--env-file, -e |string |Import environment variables from a dotenv file.\n|--templates, -t |stringArray |EXPERIMENTAL: Import Redpanda Connect templates. This supports glob patterns (requires quotes).\n|==="
-              }
             ]
           },
           {
@@ -6602,7 +6692,7 @@
           },
           {
             "name": "template",
-            "description": "Work with Redpanda Connect templates. Templates allow you to define reusable configuration patterns.",
+            "description": "Work with Redpanda Connect templates. Templates allow you to define reusable configuration patterns.\n\nWARNING: This subcommand, and templates in general, are experimental and subject to change outside of major version releases.",
             "usage": "rpk connect template [flags]",
             "aliases": [],
             "flags": [],
@@ -6681,7 +6771,7 @@
           },
           {
             "name": "test",
-            "description": "Run unit tests defined in Redpanda Connect configuration files to verify pipeline behavior.",
+            "description": "Run unit tests defined in Redpanda Connect configuration files to verify pipeline behavior.\n\nIf one or more tests fail, the command reports the errors and exits with status code 1.",
             "usage": "rpk connect test [flags]",
             "aliases": [],
             "flags": [
@@ -7230,7 +7320,7 @@
               },
               {
                 "name": "download",
-                "description": "Download the debug bundle from a remote cluster configured in flags, environment variables, or your rpk profile.",
+                "description": "Download the debug bundle from a remote cluster configured in flags, environment variables, or your rpk profile.\n\nUse the `--job-id` flag to only download the debug bundle with the given job ID.\n\nUse the `--no-confirm` flag to avoid the confirmation prompt.",
                 "usage": "rpk debug remote-bundle download [flags]",
                 "aliases": [],
                 "flags": [
@@ -7442,7 +7532,7 @@
         "commands": [
           {
             "name": "app",
-            "description": "Generate application code to connect to Redpanda. Creates starter code for various programming languages.",
+            "description": "Generate a sample application to connect with Redpanda.\n\nThis command generates a starter application to produce and consume from the\nsettings defined in the rpk profile. Its goal is to get you producing and\nconsuming quickly with Redpanda in a language that is familiar to you.\n\nBy default, this will run interactively, prompting you to select a language and\na user with which to create your application. To use this without interactivity,\nspecify how you would like your application to be created using flags.\n\nThe --language option allows you to specify the language. The default is 'go'. Available language: 'go'.\n\nThe --new-sasl-credentials <user>:<password> allows you to generate a new SASL\nuser with admin ACLs. If you don't want to use your current profile user nor\ncreate a new one, you may use --no-user flag to generate the starter app without\nthe user.\n\nIf you are having trouble connecting to your cluster, you can use -X\nadmin.hosts=comma,delimited,host:ports to pass a specific admin api address.\n\nEXAMPLES\n\nGenerate an app with interactive prompts:\n  rpk generate app\n\nGenerate an app in a specified language with the existing SASL user:\n  rpk generate app --language <lang>\n\nGenerate an app in the specified language with a new SASL user:\n  rpk generate app -l <lang> --new-sasl-credentials <user>:<password>\n\nGenerate an app in the 'tmp' dir, but take no action on the user:\n  rpk generate app -l <lang> --no-user --output /tmp\n",
             "usage": "rpk generate app [flags]",
             "aliases": [],
             "flags": [
@@ -7492,21 +7582,12 @@
                 "type": "self-hosted",
                 "position": "after_description",
                 "content": "If you are having trouble connecting to your cluster, you can use the common xref:reference:rpk/rpk-x-options.adoc#adminhosts[`-X admin.hosts=<host:ports>`] flag to pass a specific Admin API address."
-              },
-              {
-                "type": "section",
-                "id": "supported-languages",
-                "title": "Supported languages",
-                "position": "after_usage",
-                "content": "The following programming languages are supported:\n\n* Python\n* Go\n* Java\n* JavaScript/Node.js\n* Rust",
-                "parent": "usage",
-                "headingLevel": 3
               }
             ]
           },
           {
             "name": "grafana-dashboard",
-            "description": "Generate Grafana dashboards for Redpanda metrics. Use this command to generate sample Grafana dashboards that can be imported into a Grafana or Grafana Cloud instance.",
+            "description": "Generate Grafana Dashboards for Redpanda Metrics\n\nUse this command to generate sample Grafana dashboards for Redpanda metrics. \nThese dashboards can be imported into a Grafana or Grafana Cloud instance.\n\nTo select a specific dashboard, use the '--dashboard' flag followed by the \ndashboard name. For example, to generate the operations dashboard, run:\n\n    rpk generate grafana-dashboard --dashboard operations\n\nThe selected dashboard will be downloaded from our GitHub repository:\n\n  https://github.com/redpanda-data/observability\n\nNote that the legacy dashboard is still available as an option, and will not be \ndownloaded from github. Instead, the dashboard will be generated based on the \nmetrics endpoint used.\n\nTo see a list of all available dashboards, use the '--dashboard help' flag.\n",
             "usage": "rpk generate grafana-dashboard [flags]",
             "aliases": [],
             "flags": [
@@ -7548,7 +7629,7 @@
           },
           {
             "name": "license",
-            "description": "Generate a trial license for a 30-day Redpanda Enterprise Edition trial. The license is saved in your working directory or the specified path.",
+            "description": "Generate a trial license\n\nThis command generates a license for a 30-day trial of Redpanda Enterprise \nEdition.\n\nTo get a permanent license, contact us: https://www.redpanda.com/contact\n\nThe license is saved in your working directory or the specified path, based \non the --path flag.\n\nTo apply the license to your cluster, use the --apply flag.\n",
             "usage": "rpk generate license [flags]",
             "aliases": [],
             "flags": [
@@ -7606,7 +7687,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "prometheus-config",
@@ -7682,7 +7764,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "shell-completion",
@@ -7705,7 +7788,7 @@
       },
       {
         "name": "group",
-        "description": "Manage Kafka consumer groups, including listing groups, viewing lag, and resetting offsets.",
+        "description": "Describe, list, and delete consumer groups and manage their offsets.\n\nConsumer groups allow you to horizontally scale consuming from topics. A\nnon-group consumer consumes all records from all partitions you assign it. In\ncontrast, consumer groups allow many consumers to coordinate and divide work.\nIf you have two members in a group consuming topics A and B, each with three\npartitions, then both members consume three partitions. If you add another\nmember to the group, then each of the three members will consume two\npartitions. This allows you to horizontally scale consuming of topics.\n\nThe unit of scaling is a single partition. If you add more consumers to a group\nthan there are total partitions to consume, then some consumers will be\nidle. More commonly, you have many more partitions than consumer group members\nand each member consumes a chunk of available partitions. One scenario where\nyou may want more members than partitions is if you want active standby's to\ntake over load immediately if any consuming member dies.\n\nHow group members divide work is entirely client driven (the \"partition\nassignment strategy\" or \"balancer\" depending on the client). Brokers know\nnothing about how consumers are assigning partitions. A broker's role in group\nconsuming is to choose which member is the leader of a group, forward that\nmember's assignment to every other member, and ensure all members are alive\nthrough heartbeats.\n\nConsumers periodically commit their progress when consuming partitions. Through\nthese commits, you can monitor just how far behind a consumer is from the\nlatest messages in a partition. This is called \"lag\". Large lag implies that\nthe client is having problems, which could be from the server being too slow,\nor the client being oversubscribed in the number of partitions it is consuming,\nor the server being in a bad state that requires restarting or removing from\nthe server pool, and so on.\n\nYou can manually manage offsets for a group, which allows you to rewind or\nforward commits. If you notice that a recent deploy of your consumers had a\nbug, you may want to stop all members, rewind the commits to before the latest\ndeploy, and restart the members with a patch.\n\nThis command allows you to list all groups, describe a group (to view the\nmembers and their lag), and manage offsets.\n",
         "usage": "rpk group [flags]",
         "aliases": [
           "g"
@@ -7714,7 +7797,7 @@
         "commands": [
           {
             "name": "delete",
-            "description": "Delete one or more consumer groups from Redpanda brokers. A group must have no active members to be deleted.",
+            "description": "Delete one or more consumer groups.\n\nYou may want to delete groups to clean up committed offsets sooner than they expire automatically, such as when you create temporary groups for quick investigation or testing. This command helps you do that.",
             "usage": "rpk group delete [GROUPS...] [flags]",
             "aliases": [],
             "flags": [
@@ -7723,7 +7806,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               }
             ],
             "commands": [],
@@ -7748,7 +7832,7 @@
           },
           {
             "name": "describe",
-            "description": "Display detailed information about a consumer group, including member assignments, lag per partition, and group state.",
+            "description": "Describe group offset status & lag.\n\nThis command describes group members, calculates their lag, and prints detailed\ninformation about the members. COORDINATOR-PARTITION indicates the partition in\nthe __consumer_offsets topic responsible for the group, if topic details are\navailable; run with –verbose for more info if it is missing.\n\nThe --regex flag (-r) parses arguments as regular expressions\nand describes groups that match any of the expressions.\n",
             "usage": "rpk group describe [GROUPS...] [flags]",
             "aliases": [],
             "examples": "\nDescribe groups foo and bar:\n  rpk group describe foo bar\n\nDescribe any group starting with f or ending in r:\n  rpk group describe '^f.*' '.*r$' --regex\n\nDescribe all groups:\n  rpk group describe -r '*'\n\nDescribe any one-character group:\n  rpk group describe -r .\n",
@@ -7845,7 +7929,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "states",
@@ -7864,7 +7949,7 @@
           },
           {
             "name": "offset-delete",
-            "description": "Forcefully delete offsets for a Kafka group.",
+            "description": "Forcefully delete offsets for a kafka group.\n\nThe broker will only allow the request to succeed if the group is in a dead\nstate (no subscriptions) or there are no subscriptions for offsets for\ntopic/partitions requested to be deleted.\n\nUse either the --from-file or the --topic option. They are mutually exclusive.\nTo indicate which topics or topic partitions you'd like to remove offsets from use\nthe --topic (-t) flag, followed by a comma separated list of partition ids. Supplying\nno list will delete all offsets for all partitions for a given topic.\n\nYou may also provide a text file to indicate topic/partition tuples. Use the\n--from-file flag for this option. The file must contain lines of topic/partitions\nseparated by a tab or space. Example:\n\ntopic_a 0\ntopic_a 1\ntopic_b 0\n",
             "usage": "rpk group offset-delete [GROUP] --from-file FILE --topic foo:0,1,2 [flags]",
             "aliases": [],
             "flags": [
@@ -7873,7 +7958,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "from-file",
@@ -7900,7 +7986,7 @@
           },
           {
             "name": "seek",
-            "description": "Modify a group's current offsets.\n\nThis command allows you to modify a group's offsets. Sometimes, you may need to rewind a group if you had a mistaken deploy, or fast-forward a group if it is falling behind.\n\nThe `--to` option allows you to seek to a specific offset, or to the start or end of partitions. The offset can be at any timestamp precision (seconds since epoch, millis since epoch, etc). The start and end options are self explanatory. If any partition is deleted and recreated (a la `rpk topic delete; rpk topic create`), the prior commits are wiped out and the group will be committed to the earliest offset (similar to if specifying start).\n\nThe `--to-group` option allows you to seek to commits that are in another group. This is a merging operation: if g1 is consuming topics A and B, and g2 is consuming only topic B, `rpk group seek g1 --to-group g2` will update g1's commits for topic B only. The `--topics` flag can be used to further narrow which topics are updated. Unlike `--to`, all non-filtered topics are committed, even topics not yet being consumed, meaning `--allow-new-topics` is not needed.\n\nThe `--to-file` option allows to seek to offsets specified in a text file with the following format:\n\n[,text]\n----\n<TOPIC> <PARTITION> <OFFSET>\n<TOPIC> <PARTITION> <OFFSET>\n...\n----\n\nEach line contains the topic, the partition, and the offset to seek to. As with the prior options, `--topics` allows filtering which topics are updated. Similar to `--to-group`, all non-filtered topics are committed, even topics not yet being consumed, meaning `--allow-new-topics` is not needed.\n\nThe `--to`, `--to-group`, and `--to-file` options are mutually exclusive. If you are not authorized to describe or read some topics used in a group, you will not be able to modify offsets for those topics.",
+            "description": "Modify a group's current offsets.\n\nThis command allows you to modify a group's offsets. Sometimes, you may need to\nrewind a group if you had a mistaken deploy, or fast-forward a group if it is\nfalling behind on messages that can be skipped.\n\nThe --to option allows you to seek to the start of partitions, end of\npartitions, or after a specific timestamp. The default is to seek any topic\npreviously committed. Using --topics allows to you set commits for only the\nspecified topics; all other commits will remain untouched. Topics with no\ncommits will not be committed unless allowed with --allow-new-topics.\n\nThe --to-group option allows you to seek to commits that are in another group.\nThis is a merging operation: if g1 is consuming topics A and B, and g2 is\nconsuming only topic B, \"rpk group seek g1 --to-group g2\" will update g1's\ncommits for topic B only. The --topics flag can be used to further narrow which\ntopics are updated. Unlike --to, all non-filtered topics are committed, even\ntopics not yet being consumed, meaning --allow-new-topics is not needed.\n\nThe --to-file option allows to seek to offsets specified in a text file with\nthe following format:\n    [TOPIC] [PARTITION] [OFFSET]\n    [TOPIC] [PARTITION] [OFFSET]\n    ...\nEach line contains the topic, the partition, and the offset to seek to. As with\nthe prior options, --topics allows filtering which topics are updated. Similar\nto --to-group, all non-filtered topics are committed, even topics not yet being\nconsumed, meaning --allow-new-topics is not needed.\n\nThe --to, --to-group, and --to-file options are mutually exclusive. If you are\nnot authorized to describe or read some topics used in a group, you will not be\nable to modify offsets for those topics.\n\nEXAMPLES\n\nSeek group G to June 1st, 2021:\n    rpk group seek g --to 1622505600\n    or, rpk group seek g --to 1622505600000\n    or, rpk group seek g --to 1622505600000000000\nSeek group X to the commits of group Y topic foo:\n    rpk group seek X --to-group Y --topics foo\nSeek group G's topics foo, bar, and biz to the end:\n    rpk group seek G --to end --topics foo,bar,biz\nSeek group G to the beginning of a topic it was not previously consuming:\n    rpk group seek G --to start --topics foo --allow-new-topics\n",
             "usage": "rpk group seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ... [flags]",
             "aliases": [],
             "flags": [
@@ -7916,7 +8002,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "to",
@@ -8101,7 +8188,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "26.2.1"
           },
           {
             "name": "multicluster",
@@ -8198,7 +8286,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "26.2.1"
               },
               {
                 "name": "bundle",
@@ -8291,7 +8380,8 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "26.2.1"
               },
               {
                 "name": "status",
@@ -8332,13 +8422,15 @@
                 "platforms": [
                   "linux",
                   "darwin"
-                ]
+                ],
+                "introducedInVersion": "26.2.1"
               }
             ],
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "26.2.1"
           },
           {
             "name": "uninstall",
@@ -8365,7 +8457,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "26.2.1"
           },
           {
             "name": "upgrade",
@@ -8385,7 +8478,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "26.2.1"
           },
           {
             "name": "version",
@@ -8397,13 +8491,15 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "introducedInVersion": "26.2.1"
           }
         ],
         "platforms": [
           "linux",
           "darwin"
-        ]
+        ],
+        "introducedInVersion": "26.2.1"
       },
       {
         "name": "oxla",
@@ -8465,7 +8561,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "local",
@@ -8513,7 +8610,7 @@
       },
       {
         "name": "profile",
-        "description": "Manage rpk configuration profiles. Profiles store connection settings for different clusters, making it easy to switch between environments.",
+        "description": "Manage rpk profiles.\n\nAn rpk profile talks to a single Redpanda cluster. You can create multiple\nprofiles for multiple clusters and swap between them with 'rpk profile use'.\nMultiple profiles may be useful if, for example, you use rpk to talk to\na localhost cluster, a dev cluster, and a prod cluster, and you want to keep\nyour configuration in one place.\n\nYou can also use the RPK_PROFILE environment variable to temporarily override\nthe current profile without modifying your configuration. The --profile flag\ntakes precedence over the environment variable if both are set.\n",
         "usage": "rpk profile [flags]",
         "aliases": [],
         "flags": [],
@@ -8667,7 +8764,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               }
             ],
             "commands": [],
@@ -8702,7 +8800,7 @@
           },
           {
             "name": "prompt",
-            "description": "Prompt a profile name formatted for a PS1 prompt.\n\nThis command prints ANSI-escaped text per your current profile's `prompt`\nfield. If the current profile does not have a prompt, this prints nothing.\nIf the prompt is invalid, this exits 0 with no message. To validate the\ncurrent prompt, use the `--validate` flag.\n\nThis command may introduce other `%` variables in the future, if you want to\nprint a `%` directly, use `%%` to escape it.\n\nTo use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.\nTo edit your PS1, use something like `PS1='$(rpk profile prompt)` in your\nshell rc file.\n\nFORMAT\n\nThe \"prompt\" field supports space or comma separated modifiers and a quoted\nstring that is be modified. Inside the string, the variable %p or %n refers to\nthe profile name. As a few examples:\n\n    prompt: hi-white, bg-red, bold, \"[%p]\"\n    prompt: hi-red  \"PROD\"\n    prompt: white, \"dev-%n\n\nIf you want to have multiple formats, you can wrap each formatted section in\nparentheses.\n\n    prompt: (\"--\") (hi-white bg-red bold \"[%p]\")\n\nCOLORS\n\nAll ANSI colors are supported, with names matching the color name:\n\"black\", \"red\", \"green\", \"yellow\", \"blue\", \"magenta\", \"cyan\", \"white\".\n\nThe \"hi-\" prefix indicates a high-intensity color: \"hi-black\", \"hi-red\", etc.\nThe \"bg-\" prefix modifies the background color: \"bg-black\", \"bg-hi-red\", etc.\n\nMODIFIERS\n\nFour modifiers are supported, \"bold\", \"faint\", \"underline\", and \"invert\".\n\nRAW MODE\n\nThe \"raw\" modifier disables ANSI color escapes entirely, outputting plain text.\nThis is useful when your shell has issues with ANSI escape sequences affecting\nterminal width calculations.\n\n    prompt: raw, \"%n\"\n    prompt: raw, \"[%p]\"",
+            "description": "Prompt a profile name formatted for a PS1 prompt.\n\nThis command prints ANSI-escaped text per your current profile's \"prompt\"\nfield. If the current profile does not have a prompt, this prints nothing.\nIf the prompt is invalid, this exits 0 with no message. To validate the\ncurrent prompt, use the --validate flag.\n\nThis command may introduce other % variables in the future, if you want to\nprint a % directly, use %% to escape it.\n\nTo use this in zsh, be sure to add setopt PROMPT_SUBST to your .zshrc.\nTo edit your PS1, use something like PS1='$(rpk profile prompt)' in your\nshell rc file.\n\nFORMAT\n\nThe \"prompt\" field supports space or comma separated modifiers and a quoted\nstring that is be modified. Inside the string, the variable %p or %n refers to\nthe profile name. As a few examples:\n\n    prompt: hi-white, bg-red, bold, \"[%p]\"\n    prompt: hi-red  \"PROD\"\n    prompt: white, \"dev-%n\n\nIf you want to have multiple formats, you can wrap each formatted section in\nparentheses.\n\n    prompt: (\"--\") (hi-white bg-red bold \"[%p]\")\n\nCOLORS\n\nAll ANSI colors are supported, with names matching the color name:\n\"black\", \"red\", \"green\", \"yellow\", \"blue\", \"magenta\", \"cyan\", \"white\".\n\nThe \"hi-\" prefix indicates a high-intensity color: \"hi-black\", \"hi-red\", etc.\nThe \"bg-\" prefix modifies the background color: \"bg-black\", \"bg-hi-red\", etc.\n\nMODIFIERS\n\nFour modifiers are supported, \"bold\", \"faint\", \"underline\", and \"invert\".\n\nRAW MODE\n\nThe \"raw\" modifier disables ANSI color escapes entirely, outputting plain text.\nThis is useful when your shell has issues with ANSI escape sequences affecting\nterminal width calculations.\n\n    prompt: raw, \"%n\"\n    prompt: raw, \"[%p]\"\n",
             "usage": "rpk profile prompt [flags]",
             "aliases": [],
             "flags": [
@@ -8736,7 +8834,7 @@
           },
           {
             "name": "set",
-            "description": "Set a configuration field in the current rpk profile.",
+            "description": "Set fields in the current rpk profile.\n\nAs in the create command, this command takes a list of key=value pairs to write\nto the current profile.\n\nThe key can either be the name of a -X flag or the path to the field in the\nprofile's yaml format. For example, using --set tls.enabled=true OR --set\nkafka_api.tls.enabled=true is equivalent. The former corresponds to the -X flag\ntls.enabled, while the latter corresponds to the path kafka_api.tls.enabled in\nthe profile's yaml. To see all available -X fields, run 'rpk -X help'.\n\nThis command supports autocompletion of valid keys, suggesting the -X key\nformat. If you begin writing a YAML path, this command will suggest the rest of\nthe path.\n\nYou can also use the format 'set key value' if you intend to only set one key.\n",
             "usage": "rpk profile set [KEY=VALUE]+ [flags]",
             "aliases": [],
             "flags": [],
@@ -8788,7 +8886,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           }
         ],
         "platforms": [
@@ -9910,7 +10009,7 @@
         "commands": [
           {
             "name": "acl",
-            "description": "Manage Kafka ACLs (Access Control Lists) for authorization. ACLs control which principals can perform operations on resources.",
+            "description": "Manage ACLs and SASL users.\n\nThis command space creates, lists, and deletes ACLs, as well as creates SASL users. This page is specific to ACLs. To learn about SASL users, see xref:reference:rpk/rpk-security/rpk-security-user.adoc[`rpk security user`].\n\nWhen using SASL, ACLs allow or deny you access to certain requests. The `create`, `delete`, and `list` commands help you manage your ACLs.\n\nAn ACL is made up of five components:\n\n* A principal (the user) or role\n* A host, which the principal (or role) is allowed or denied requests from\n* What resource to access (such as a topic name or group ID)\n* The operation (such as read or write)\n* The permission: whether to allow or deny the above\n\nACL commands work on a multiplicative basis. If creating, specifying two principals and two permissions creates four ACLs: both permissions for the first principal, as well as both permissions for the second principal. Adding two resources further doubles the ACLs created.\n\nIt is recommended to be as specific as possible when granting ACLs. Granting more ACLs than necessary per principal may inadvertently allow clients to do things they should not, such as deleting topics or joining the wrong consumer group.\n\nIn flag form, to set up a general producing and consuming client, you can invoke `rpk security acl create` three times with the following (including your `--allow-principal`):\n\n* `--operation write,read,describe --topic [topics]`\n* `--operation describe,read --group [group.id]`\n* `--operation describe,write --transactional-id [id]`",
             "usage": "rpk security acl [flags]",
             "aliases": [],
             "flags": [
@@ -10106,7 +10205,7 @@
                   {
                     "type": "note",
                     "position": "after_usage",
-                    "content": "The schema migration examples above are Schema Registry ACLs only. You also require Kafka ACLs for topics, consumer groups, and cluster operations. See xref:manage:security/authorization/acl.adoc[Configure Access Control Lists]."
+                    "content": "The schema migration examples on this page are Schema Registry ACLs only. You also require Kafka ACLs for topics, consumer groups, and cluster operations. See xref:manage:security/authorization/acl.adoc[Configure Access Control Lists]."
                   }
                 ]
               },
@@ -10178,7 +10277,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   },
                   {
                     "name": "group",
@@ -10815,7 +10915,8 @@
                     "type": "string",
                     "description": "Output format (json,yaml,text,wide,help)",
                     "default": "text",
-                    "required": false
+                    "required": false,
+                    "introducedInVersion": "v26.2.1"
                   },
                   {
                     "name": "name-contains",
@@ -11047,7 +11148,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "create",
@@ -11162,7 +11264,7 @@
           },
           {
             "name": "describe",
-            "description": "Describe one or more shadow links. For Redpanda Cloud, `rpk` uses the Redpanda ID of the cluster you are currently logged in to.",
+            "description": "Describe one or more shadow links. For Redpanda Cloud, `rpk` uses the Redpanda ID of the cluster you are currently logged in to.\n\nThis command shows the Shadow Link configuration, including connection settings, synchronization options, and filters. By default, the command displays the overview and client configuration sections. Use the flags to display additional sections such as topic synchronization, consumer offset synchronization, and security synchronization settings.\n\nUsing the `--format` flag with JSON or YAML outputs the full configuration in the specified format, ignoring section flags.",
             "usage": "rpk shadow describe [LINK_NAME] [flags]",
             "aliases": [],
             "examples": "\nDescribe a Shadow Link with default sections (overview and client):\n  rpk shadow describe my-shadow-link\n\nDisplay all configuration sections:\n  rpk shadow describe my-shadow-link --print-all\n\nDisplay specific sections:\n  rpk shadow describe my-shadow-link --print-overview --print-topic\n\nDisplay only the client configuration:\n  rpk shadow describe my-shadow-link -c\n\nDisplay output as JSON:\n  rpk shadow describe my-shadow-link --format json\n",
@@ -11219,7 +11321,8 @@
                 "type": "bool",
                 "description": "Print the detailed role sync configuration section",
                 "default": false,
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "print-security",
@@ -11353,7 +11456,7 @@
           },
           {
             "name": "status",
-            "description": "Display the status of a shadow link. When using `--format json` or `--format yaml`, the command outputs all sections by default.",
+            "description": "Get the status of a Redpanda Shadow Link.\n\nThis command shows the current status of a Shadow Link, including the overall\nstate, task statuses, and per-topic replication progress. Use this command to\nmonitor replication health and track how closely shadow topics follow the source\ncluster.\n\nBy default, the command displays all status sections. Use the flags to display\nspecific sections such as overview, task status, or topic status. When using\nthis command with the --format json/yaml flag, we default to all sections.\n",
             "usage": "rpk shadow status [LINK_NAME] [flags]",
             "aliases": [],
             "examples": "\nDisplay the status of a Shadow Link:\n  rpk shadow status my-shadow-link\n\nDisplay specific sections:\n  rpk shadow status my-shadow-link --print-overview --print-topic\n",
@@ -11387,7 +11490,8 @@
                 "type": "bool",
                 "description": "Print the schema registry sync status section",
                 "default": false,
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "print-task",
@@ -11487,7 +11591,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "num",
@@ -11544,7 +11649,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "no-confirm",
@@ -11660,7 +11766,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "consume",
@@ -11817,7 +11924,7 @@
                 "position": "after_usage",
                 "parent": "usage",
                 "headingLevel": 3,
-                "content": "Text fields without modifiers default to writing the raw bytes. Alternatively, there are the following modifiers:\n\n[cols=\"1m,2a\"]\n|===\n|Modifier |Description\n\n|%t{hex} |Hex encoding\n|%k{base64} |Base64 standard encoding\n|%k{base64raw} |Base64 encoding raw\n|%v{unpack[<bBhH>iIqQc.$]} |The unpack modifier has a further internal specification, similar to timestamps above.\n|===\n\nUnpacking text can allow translating binary input into readable output. If a value is a big-endian uint32, `%v` prints the raw four bytes, while `%v{unpack[>I]}` prints the number as ASCII. If unpacking exhausts the input before something is unpacked fully, an error message is appended to the output."
+                "content": "Text fields without modifiers default to writing the raw bytes. Alternatively, there are the following modifiers:\n\n[cols=\"1m,2a\"]\n|===\n|Modifier |Description\n\n|%t{hex} |Hex encoding\n|%k{base64} |Base64 standard encoding\n|%k{base64raw} |Base64 encoding raw\n|%v{unpack[<bBhH>iIqQc.$]} |The unpack modifier has a further internal specification, similar to timestamps above.\n|===\n\nUnpacking text can allow translating binary input into readable output. If a value is a big-endian uint32, `%v` prints the raw four bytes, while `%v{unpack[>I]}` prints the number as ASCII. If unpacking exhausts the input before something is unpacked fully, an error message is appended to the output.\n\nThe unpack modifier has a further internal specification:\n\n[cols=\"1m,2a\"]\n|===\n|Character |Meaning\n\n|x |Pad character (does not parse input)\n|< |Switch what follows to little endian\n|> |Switch what follows to big endian\n|b |Signed byte\n|B |Unsigned byte\n|h |int16 (\"half word\")\n|H |uint16 (\"half word\")\n|i |int32\n|I |uint32\n|q |int64 (\"quad word\")\n|Q |uint64 (\"quad word\")\n|c |Any character\n|. |Alias for `c`\n|s |Consume the rest of the input as a string\n|$ |Match the end of the line (append error string if anything remains)\n|==="
               },
               {
                 "type": "section",
@@ -11826,7 +11933,7 @@
                 "position": "after_usage",
                 "parent": "usage",
                 "headingLevel": 3,
-                "content": "Headers are formatted with percent encoding inside of the modifier:\n\n[,bash]\n----\n%h{%k=%v{hex}}\n----\n\nThis prints all headers with a space before the key and after the value, an equals sign between the key and value, and with the value hex encoded. Header formatting actually just parses the internal format as a record format, so all of the above rules about `%K`, `%V`, text, and numbers apply."
+                "content": "Headers are formatted with percent encoding inside of the modifier:\n\n[,bash]\n----\n%h{ %k=%v{hex} }\n----\n\nThis prints all headers with a space before the key and after the value, an equals sign between the key and value, and with the value hex encoded. Header formatting actually just parses the internal format as a record format, so all of the above rules about `%K`, `%V`, text, and numbers apply."
               },
               {
                 "type": "section",
@@ -11845,6 +11952,12 @@
                 "parent": "usage",
                 "headingLevel": 3,
                 "content": "The `--offset` flag allows for specifying where to begin consuming, and optionally, where to stop consuming. The literal words `start` and `end` specify consuming from the start and the end.\n\n[cols=\"1m,2a\"]\n|===\n|Offset |Description\n\n|start |Consume from the beginning\n|end |Consume from the end\n|:end |Consume until the current end\n|+oo |Consume oo after the current start offset\n|-oo |Consume oo before the current end offset\n|oo |Consume after an exact offset\n|oo: |Alias for oo\n|:oo |Consume until an exact offset\n|o1:o2 |Consume from exact offset o1 until exact offset o2\n|@t |Consume starting from a given timestamp\n|@t: |Alias for @t\n|@:t |Consume until a given timestamp\n|@t1:t2 |Consume from timestamp t1 until timestamp t2\n|===\n\nEach timestamp option is evaluated until one succeeds.\n\n[cols=\"1m,2a\"]\n|===\n|Timestamp |Description\n\n|13 digits |Parsed as a unix millisecond\n|9 digits |Parsed as a unix second\n|YYYY-MM-DD |Parsed as a day, UTC\n|YYYY-MM-DDTHH:MM:SSZ |Parsed as RFC3339, UTC; fractional seconds optional (.MMM)\n|-dur |Duration; from now (as t1) or from t1 (as t2)\n|dur |For t2 in @t1:t2, relative duration from t1\n|end |For t2 in @t1:t2, the current end of the partition\n|===\n\nDurations are parsed simply:\n\n[,bash]\n----\n3ms    three milliseconds\n10s    ten seconds\n9m     nine minutes\n1h     one hour\n1m3ms  one minute and three milliseconds\n----"
+              },
+              {
+                "type": "section",
+                "title": "Connection behavior",
+                "position": "after_usage",
+                "content": "By default, `rpk topic consume` runs continuously, waiting for new records to arrive. It does not exit after consuming existing records. To stop consuming, press Ctrl+C. You can also use `--num` to exit after a fixed number of records, or use `--offset` to define a stop point (for example, `-o :end` stops at the current log end)."
               },
               {
                 "type": "section",
@@ -11897,7 +12010,7 @@
           },
           {
             "name": "create",
-            "description": "Create one or more Kafka topics with configurable partitions, replication factor, and topic-level settings.",
+            "description": "Create one or more Kafka topics with configurable partitions, replication factor, and topic-level settings.\n\nAll topics created with one invocation have the same number of partitions, replication factor, and key/value configs. For example, `rpk topic create -c cleanup.policy=compact -r 3 -p 20 foo bar` creates two topics, `foo` and `bar`, each with 20 partitions, 3 replicas, and the `cleanup.policy=compact` config option set.",
             "usage": "rpk topic create [TOPICS...] [flags]",
             "aliases": [],
             "flags": [
@@ -12036,7 +12149,7 @@
           },
           {
             "name": "delete",
-            "description": "Delete one or more Kafka topics. This operation is irreversible and removes all data in the topics.",
+            "description": "Delete one or more Kafka topics.\n\nThis command deletes all requested topics, printing the success or fail status per topic.\n\nThe `--regex` flag (`-r`) opts into parsing the input topics as regular expressions and deleting any non-internal topic that matches any of the expressions. Each expression is wrapped with `^` and `$`, so it must match a whole topic name rather than part of one. Anchoring does not make broad expressions safe: `.*` still matches, and deletes, every non-internal topic.\n\nThe topic list command accepts the same input regex format as this delete command. To check what your regular expressions will delete before actually deleting them, check the output of `rpk topic list -r`.",
             "usage": "rpk topic delete [TOPICS...] [flags]",
             "aliases": [],
             "flags": [
@@ -12045,7 +12158,8 @@
                 "type": "string",
                 "description": "Output format (json,yaml,text,wide,help)",
                 "default": "text",
-                "required": false
+                "required": false,
+                "introducedInVersion": "v26.2.1"
               },
               {
                 "name": "regex",
@@ -12062,6 +12176,11 @@
               "darwin"
             ],
             "content": [
+              {
+                "type": "caution",
+                "position": "after_description",
+                "content": "Deleting a topic is irreversible and removes all data in the topic."
+              },
               {
                 "type": "section",
                 "id": "examples",
@@ -12175,7 +12294,7 @@
           },
           {
             "name": "describe-storage",
-            "description": "Describe the cloud storage status of a topic, including storage mode, offset availability, segment sizes, and synchronization state.\n\nSUMMARY\n\nThe summary section contains general information about the topic, the cloud\nstorage mode (one of disabled, write_only, read_only, full, read_replica,\ncloud_topic, and cloud_topic_read_replica),\nand the delta in milliseconds since the last upload of either the partition\nmanifest or a segment.\n\nOFFSET\n\nThe offset section contains the start and last offsets (inclusive) per\npartition of data available in both the cloud and on local disk.\n\nSIZE\n\nFor tiered storage topics, the size section contains the total bytes per\npartition in the cloud and on local disk, the total size of the log of each\npartition (excluding cloud and local overlap), and the number of segments in\nthe cloud and on local disk. The cloud segment count does not include segments\nqueued for deletion.\n\nFor cloud topics, the size section shows the L0 (level zero) and L1 (level\none) byte breakdown, the total bytes, and the number of L1 extents.\n\nSYNC\n\nThe sync section contains the state of cloud synchronization: milliseconds\nsince the last upload of the partition manifest, milliseconds since the last\nsegment upload, milliseconds since the last manifest sync (for read replicas),\nand whether the remote metadata has a pending update to include all uploaded\nsegments.",
+            "description": "Describe the topic storage status.\n\nThis commands prints detailed information about the cloud storage status of a\ngiven topic, the information is divided in 4 sections:\n\nSUMMARY\n\nThe summary section contains general information about the topic, the cloud\nstorage mode (one of disabled, write_only, read_only, full, read_replica,\ncloud_topic, and cloud_topic_read_replica),\nand the delta in milliseconds since the last upload of either the partition\nmanifest or a segment.\n\nOFFSET\n\nThe offset section contains the start and last offsets (inclusive) per\npartition of data available in both the cloud and on local disk.\n\nSIZE\n\nFor tiered storage topics, the size section contains the total bytes per\npartition in the cloud and on local disk, the total size of the log of each\npartition (excluding cloud and local overlap), and the number of segments in\nthe cloud and on local disk. The cloud segment count does not include segments\nqueued for deletion.\n\nFor cloud topics, the size section shows the L0 (level zero) and L1 (level\none) byte breakdown, the total bytes, and the number of L1 extents.\n\nSYNC\n\nThe sync section contains the state of cloud synchronization: milliseconds\nsince the last upload of the partition manifest, milliseconds since the last\nsegment upload, milliseconds since the last manifest sync (for read replicas),\nand whether the remote metadata has a pending update to include all uploaded\nsegments.\n",
             "usage": "rpk topic describe-storage [TOPIC] [flags]",
             "aliases": [],
             "flags": [
@@ -12232,11 +12351,12 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "list",
-            "description": "List topics, optionally listing specific topics. This command lists all topics that you have access to by default.",
+            "description": "List topics, optionally listing specific topics.\n\nThis command lists all topics that you have access to by default. If specifying\ntopics or regular expressions, this command can be used to know exactly what\ntopics you would delete if using the same input to the delete command.\n\nAlternatively, you can request specific topics to list, which can be used to\ncheck authentication errors (do you not have access to a topic you were\nexpecting to see?), or to list all topics that match regular expressions.\n\nThe --regex flag (-r) opts into parsing the input topics as regular expressions\nand listing any non-internal topic that matches any of expressions. The input\nexpressions are wrapped with ^ and $ so that the expression must match the\nwhole topic name. Regular expressions cannot be used to match internal topics,\nas such, specifying both -i and -r will exit with failure.\n\nLastly, --detailed flag (-d) opts in to printing extra per-partition\ninformation.\n",
             "usage": "rpk topic list [flags]",
             "aliases": [
               "ls"
@@ -12419,7 +12539,7 @@
                 "id": "formatting",
                 "title": null,
                 "position": "after_description",
-                "content": "The input formatter understands a wide variety of formats. Parsing input operates on either sizes or on delimiters, both of which can be specified in the same formatting options.\n\ninclude::reference:partial$topic-format.adoc[]"
+                "content": "The input formatter understands a wide variety of formats. Parsing input operates on either sizes or on delimiters, both of which can be specified in the same formatting options.\n\ninclude::reference:partial$topic-format-produce.adoc[]"
               },
               {
                 "type": "section",
@@ -12491,7 +12611,7 @@
           },
           {
             "name": "trim-prefix",
-            "description": "Trim records from topics by setting the LogStartOffset for partitions to the requested offset. All segments whose base offset is less than the requested offset are deleted, and any records within the segment before the requested offset can no longer be read.",
+            "description": "Trim records from topics\n\nThis command allows you to trim records from topics, to trim the topics Redpanda\nsets the LogStartOffset for partitions to the requested offset. All segments\nwhose base offset is less than the requested offset are deleted, and any records\nwithin the segment before the requested offset can no longer be read.\n\nThe --offset/-o flag allows you to indicate which index you want to set the\npartition's low watermark (start offset) to. It can be a single integer value\ndenoting the offset or a timestamp if you prefix the offset with an '@'. You may\nselect which partition you want to trim the offset from with the --partitions/-p\nflag.\n\nThe --from-file option allows to trim the offsets specified in a text file with\nthe following format:\n    [TOPIC] [PARTITION] [OFFSET]\n    [TOPIC] [PARTITION] [OFFSET]\n    ...\nor the equivalent keyed JSON/YAML file.\n\nEXAMPLES\n\nTrim records in 'foo' topic to offset 120 in partition 1\n    rpk topic trim-prefix foo --offset 120 --partitions 1\n\nTrim records in all partitions of topic foo previous to an specific timestamp\n    rpk topic trim-prefix foo -o \"@1622505600\"\n\nTrim records from a JSON file\n    rpk topic trim-prefix --from-file /tmp/to_trim.json\n",
             "usage": "rpk topic trim-prefix [TOPIC] [flags]",
             "aliases": [
               "trim"
@@ -12728,7 +12848,7 @@
           },
           {
             "name": "init",
-            "description": "Initialize a new data transform project. Creates a new directory with the required project files. To initialize in a new subdirectory, specify the directory name as an argument.",
+            "description": "Initialize a new data transform project. Creates a new directory with the required project files. To initialize in a new subdirectory, specify the directory name as an argument.\n\nThe project is created from a template. For example, `rpk transform init foobar` initializes a transform project in the `foobar` directory.",
             "usage": "rpk transform init [DIRECTORY] [flags]",
             "aliases": [],
             "flags": [
@@ -12795,7 +12915,7 @@
           },
           {
             "name": "logs",
-            "description": "View logs for a data transform. Streams STDOUT and STDERR output captured during runtime to your terminal.\n\nFILTERING\n\nThe --head and --tail flags are mutually exclusive and limit the number of log\nentries from the beginning or end of the range, respectively.\n\nThe --since and --until flags define a time range. Use one of both flags to\nlimit the log output to a desired period of time.\n\nBoth flags accept values in the following formats:\n    \n    now                   the current time, useful for --since=now\n    13 digits             parsed as a Unix millisecond\n    9 digits              parsed as a Unix second\n    YYYY-MM-DD            parsed as a day, UTC\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\n    -dur                  a negative duration from now\n    dur                   a positive duration from now\n\nDurations are parsed simply:\n\n    3ms    three milliseconds\n    10s    ten seconds\n    9m     nine minutes\n    1h     one hour\n    1m3ms  one minute and three milliseconds\n\nFor example,\n\n    --since=-1h   reads logs within the last hour\n    --until=-30m  reads logs prior to 30 minutes ago\n\nThe following command reads logs between noon and 1pm on March 12th:\n\n    rpk transform logs my-transform --since=2024-03-12T12:00:00Z --until=2024-03-12T13:00:00Z\n\nFORMATTING\n\nLogs can be displayed in a variety of formats using --format.\n\nThe default --format=text prints the log record's body line by line.\n\nWhen --format=wide is specified, the output includes a prefix that is the\ndate of the log line and a level for the record. The INFO level corresponds \nto being emitted on the transform's STDOUT, while the WARN level is used\nfor STDERR.\n\nThe --format=json flag emits logs in the JSON encoded version of \nthe Open Telemetry LogRecord protocol buffer.",
+            "description": "View logs for a transform.\n\nData transform's STDOUT and STDERR are captured during runtime and written to \nan internally managed topic _redpanda.transform_logs.\nThis command outputs logs for a single transform over a period of time and \nprinting them to STDOUT. The logs can be printed in various formats.\n\nBy default, only logs that have been emitted are displayed.\nUse the --follow flag to stream new logs continuously.\n\nFILTERING\n\nThe --head and --tail flags are mutually exclusive and limit the number of log\nentries from the beginning or end of the range, respectively.\n\nThe --since and --until flags define a time range. Use one of both flags to\nlimit the log output to a desired period of time.\n\nBoth flags accept values in the following formats:\n    \n    now                   the current time, useful for --since=now\n    13 digits             parsed as a Unix millisecond\n    9 digits              parsed as a Unix second\n    YYYY-MM-DD            parsed as a day, UTC\n    YYYY-MM-DDTHH:MM:SSZ  parsed as RFC3339, UTC; fractional seconds optional (.MMM)\n    -dur                  a negative duration from now\n    dur                   a positive duration from now\n\nDurations are parsed simply:\n\n    3ms    three milliseconds\n    10s    ten seconds\n    9m     nine minutes\n    1h     one hour\n    1m3ms  one minute and three milliseconds\n\nFor example,\n\n    --since=-1h   reads logs within the last hour\n    --until=-30m  reads logs prior to 30 minutes ago\n\nThe following command reads logs between noon and 1pm on March 12th:\n\n    rpk transform logs my-transform --since=2024-03-12T12:00:00Z --until=2024-03-12T13:00:00Z\n\nFORMATTING\n\nLogs can be displayed in a variety of formats using --format.\n\nThe default --format=text prints the log record's body line by line.\n\nWhen --format=wide is specified, the output includes a prefix that is the\ndate of the log line and a level for the record. The INFO level corresponds \nto being emitted on the transform's STDOUT, while the WARN level is used\nfor STDERR.\n\nThe --format=json flag emits logs in the JSON encoded version of \nthe Open Telemetry LogRecord protocol buffer.",
             "usage": "rpk transform logs NAME [flags]",
             "aliases": [
               "log"
@@ -12861,7 +12981,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           },
           {
             "name": "resume",
@@ -12873,7 +12994,8 @@
             "platforms": [
               "linux",
               "darwin"
-            ]
+            ],
+            "selfHostedOnly": true
           }
         ],
         "platforms": [
@@ -13904,6 +14026,11 @@
                     "description": "Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock provider the guardrail uses AWS Bedrock Guardrail directly. For all other providers the proxy evaluates user input against the Bedrock Guardrail's standalone backend. In both cases a guardrail intervention short-circuits the request."
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to create from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -14119,6 +14246,11 @@
                     "description": "Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock providers the guardrail rides the upstream call via AWS guardrail headers and is enforced by Bedrock itself. For all other providers the proxy evaluates user input against the guardrail's standalone ApplyGuardrail backend before forwarding the request upstream. In both cases a guardrail intervention short-circuits the request."
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to update from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -14209,6 +14341,11 @@
                     "name": "response-format",
                     "type": "string",
                     "description": "Output format for tool results (token optimization). (one of: jton, toon)"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update)"
                   },
                   {
                     "name": "remote.url",
@@ -14497,6 +14634,11 @@
                     "description": "Output format for tool results (token optimization). (one of: jton, toon)"
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update)"
+                  },
+                  {
                     "name": "remote.url",
                     "type": "string",
                     "description": "Endpoint URL of the remote MCP server. (required in its group) (alias: --url)"
@@ -14740,6 +14882,11 @@
                     "name": "enabled",
                     "type": "bool",
                     "description": "Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass --enabled=false to disable)"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
                   },
                   {
                     "name": "filename",
@@ -15027,6 +15174,11 @@
                     "description": "Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass --enabled=false to disable)"
                   },
                   {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
+                  },
+                  {
                     "name": "filename",
                     "type": "string",
                     "description": "manifest to update from (YAML or JSON; \"-\" for stdin); flags override file values",
@@ -15161,6 +15313,11 @@
                     "name": "register-from-url",
                     "type": "string",
                     "description": "Remote MCP server URL to auto-detect OAuth from. The gateway discovers endpoints and registers a client automatically."
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
                   },
                   {
                     "name": "filename",
@@ -15326,6 +15483,11 @@
                     "name": "enabled",
                     "type": "bool",
                     "description": "Whether this provider accepts new connections. (true when set; pass --enabled=false to disable)"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "stringArray",
+                    "description": "Tags. (repeatable key=value; replaces the full map on update)"
                   },
                   {
                     "name": "filename",

--- a/modules/reference/partials/rpk-ai/rpk-ai-llm-provider-create.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-llm-provider-create.adoc
@@ -58,6 +58,7 @@ rpai llm-provider create my-llm-provider \
 |--transcripts.record-input-messages |bool |Capture full request bodies (`prompts`) on observability traces. (true when set; pass `--transcripts`.record-input-messages=false to disable).
 |--transcripts.record-output-messages |bool |Capture full response bodies (`completions`) on observability traces. (true when set; pass `--transcripts`.record-output-messages=false to disable).
 |--guardrail |string |Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock provider the guardrail uses AWS Bedrock Guardrail directly. For all other providers the proxy evaluates user input against the Bedrock Guardrail's standalone backend. In both cases a guardrail intervention short-circuits the request.
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to create from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |===

--- a/modules/reference/partials/rpk-ai/rpk-ai-llm-provider-update.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-llm-provider-update.adoc
@@ -45,6 +45,7 @@ rpk ai llm-provider update [flags]
 |--transcripts.record-input-messages |bool |Capture full request bodies (`prompts`) on observability traces. (true when set; pass `--transcripts`.record-input-messages=false to disable).
 |--transcripts.record-output-messages |bool |Capture full response bodies (`completions`) on observability traces. (true when set; pass `--transcripts`.record-output-messages=false to disable).
 |--guardrail |string |Name of a Guardrail to attach to this provider. Leave empty for no guardrail. For Bedrock providers the guardrail rides the upstream call via AWS guardrail headers and is enforced by Bedrock itself. For all other providers the proxy evaluates user input against the guardrail's standalone ApplyGuardrail backend before forwarding the request upstream. In both cases a guardrail intervention short-circuits the request.
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to update from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |--clear |strings |field paths to clear (added to the update mask with the field unset), for example, `--clear` guardrail.

--- a/modules/reference/partials/rpk-ai/rpk-ai-mcp-server-create.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-mcp-server-create.adoc
@@ -42,6 +42,7 @@ rpai mcp-server create my-mcp-server \
 |--code-mode |bool |Enable code mode: adds \{name}_search and \{name}_execute tools alongside existing tools. (true when set; pass `--code-mode=false` to disable).
 |--data-policies |stringArray |Data policies shaping this server's tool calls (see MCPServer.data_policies). (repeatable; protojson object; replaces the full list on update).
 |--response-format |string |Output format for tool results (token optimization). (one of: jton, toon).
+|--tags |stringArray |Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |--remote.url |string |Endpoint URL of the remote MCP server. (required in its group) (alias: `--url`).
 |--remote.transport |string |MCP transport protocol. SSE for server-sent events, Streamable HTTP for newer bidirectional protocol. (one of: sse, streamable-http; required in its group) (alias: `--transport`).
 |--remote.none |bool |None. (selects this auth mode; takes no value).

--- a/modules/reference/partials/rpk-ai/rpk-ai-mcp-server-update.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-mcp-server-update.adoc
@@ -28,6 +28,7 @@ rpk ai mcp-server update [flags]
 |--code-mode |bool |Enable code mode: adds \{name}_search and \{name}_execute tools alongside existing tools. (true when set; pass `--code-mode=false` to disable).
 |--data-policies |stringArray |Data policies shaping this server's tool calls (see MCPServer.data_policies). (repeatable; protojson object; replaces the full list on update).
 |--response-format |string |Output format for tool results (token optimization). (one of: jton, toon).
+|--tags |stringArray |Arbitrary key/value metadata tags (see MCPServer.tags). (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |--remote.url |string |Endpoint URL of the remote MCP server. (required in its group) (alias: `--url`).
 |--remote.transport |string |MCP transport protocol. SSE for server-sent events, Streamable HTTP for newer bidirectional protocol. (one of: sse, streamable-http; required in its group) (alias: `--transport`).
 |--remote.none |bool |None. (selects this auth mode; takes no value).

--- a/modules/reference/partials/rpk-ai/rpk-ai-oauth-client-create.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-oauth-client-create.adoc
@@ -29,6 +29,7 @@ rpk ai oauth-client create [flags]
 |--token-endpoint-auth-method |string |How the client authenticates to the token endpoint. Phase 1 supports client_secret_basic and client_secret_post. (one of: oauth-client-token-endpoint-auth-method-client-secret-basic, oauth-client-token-endpoint-auth-method-client-secret-post, oauth-client-token-endpoint-auth-method-none).
 |--pkce-required |bool |Require PKCE (RFC 7636) on authorization requests. Strongly recommended and enforced by default. (true when set; pass `--pkce-required=false` to disable).
 |--enabled |bool |Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass `--enabled=false` to disable).
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to create from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |===

--- a/modules/reference/partials/rpk-ai/rpk-ai-oauth-client-update.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-oauth-client-update.adoc
@@ -31,6 +31,7 @@ rpk ai oauth-client update [flags]
 |--token-endpoint-auth-method |string |How the client authenticates to the token endpoint. Phase 1 supports client_secret_basic and client_secret_post. (one of: oauth-client-token-endpoint-auth-method-client-secret-basic, oauth-client-token-endpoint-auth-method-client-secret-post, oauth-client-token-endpoint-auth-method-none).
 |--pkce-required |bool |Require PKCE (RFC 7636) on authorization requests. Strongly recommended and enforced by default. (true when set; pass `--pkce-required=false` to disable).
 |--enabled |bool |Whether this client may request new tokens. Disabled clients are rejected at the authorize endpoint. (true when set; pass `--enabled=false` to disable).
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to update from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |--clear |strings |field paths to clear (added to the update mask with the field unset), for example, `--clear` guardrail.

--- a/modules/reference/partials/rpk-ai/rpk-ai-oauth-provider-create.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-oauth-provider-create.adoc
@@ -35,6 +35,7 @@ rpk ai oauth-provider create [flags]
 |--extra-token-params |stringArray |Additional parameters sent in the token exchange request body. (repeatable key=value; replaces the full map on update).
 |--enabled |bool |Whether this provider accepts new connections. (true when set; pass `--enabled=false` to disable).
 |--register-from-url |string |Remote MCP server URL to auto-detect OAuth from. The gateway discovers endpoints and registers a client automatically.
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to create from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |===

--- a/modules/reference/partials/rpk-ai/rpk-ai-oauth-provider-update.adoc
+++ b/modules/reference/partials/rpk-ai/rpk-ai-oauth-provider-update.adoc
@@ -33,6 +33,7 @@ rpk ai oauth-provider update [flags]
 |--extra-auth-params |stringArray |Additional query parameters appended to the authorization URL. (repeatable key=value; replaces the full map on update).
 |--extra-token-params |stringArray |Additional parameters sent in the token exchange request body. (repeatable key=value; replaces the full map on update).
 |--enabled |bool |Whether this provider accepts new connections. (true when set; pass `--enabled=false` to disable).
+|--tags |stringArray |Tags. (repeatable key=value; replaces the full map on update). _(New in 0.2.33)_
 |-f, --filename |string |manifest to update from (YAML or JSON; "-" for stdin); flags override file values.
 |--dry-run |bool |print the request that would be sent (with the computed update mask) and exit without calling the server.
 |--clear |strings |field paths to clear (added to the update mask with the field unset), for example, `--clear` guardrail.


### PR DESCRIPTION
## Summary

Automated update of a single rpk plugin's documentation, triggered by a plugin release.

**Plugin**: `rpk ai`
**Released version**: `0.2.33`

Only the `rpk ai` subtree was refreshed in the rpk snapshot. All other pages were re-rendered from the committed snapshot and should show no changes. If a later release supersedes this one before merge, this PR updates in place.

## rpk ai Plugin Documentation Update

**Plugin version:** 0.2.33
**Base rpk snapshot:** v26.2.1

The `rpk ai` subtree was refreshed in the snapshot, then the full rpk reference was re-rendered from it as a converge. Pages outside `rpk ai` can carry template-level or consistency updates, and stale generated files are cleaned up, so the change list may be wider than the plugin itself.

### Generation Statistics

| Metric | Count |
|--------|-------|
| Commands documented | 361 |
| Files generated | 355 |
| Files skipped (excluded) | 6 |

### Changes from Previous Version

| Change Type | Count |
|-------------|-------|
| New flags | 8 |

<details>
<summary>New Flags</summary>

- `rpk ai llm-provider create`: `--tags` (stringArray)
- `rpk ai llm-provider update`: `--tags` (stringArray)
- `rpk ai mcp-server create`: `--tags` (stringArray)
- `rpk ai mcp-server update`: `--tags` (stringArray)
- `rpk ai oauth-client create`: `--tags` (stringArray)
- `rpk ai oauth-client update`: `--tags` (stringArray)
- `rpk ai oauth-provider create`: `--tags` (stringArray)
- `rpk ai oauth-provider update`: `--tags` (stringArray)

</details>

### Curated descriptions replacing source help

These overrides replace substantially longer help text from the rpk source. Confirm the curated version still carries every operational detail (or intentionally omits it):

| Command | Override | Source help |
|---------|----------|-------------|
| `rpk topic consume` | 159 chars | 9372 chars |
| `rpk topic produce` | 137 chars | 6181 chars |
| `rpk security acl` | 1543 chars | 5912 chars |
| `rpk debug bundle` | 244 chars | 3442 chars |
| `rpk group delete` | 244 chars | 983 chars |
| `rpk cluster config` | 292 chars | 991 chars |
| `rpk topic describe` | 216 chars | 748 chars |

### Validation Report

| Severity | Count |
|----------|-------|
| ⚠️ Warnings | 1 |

<details>
<summary>Issues by Rule</summary>

- **duplicate-content**: 1 warnings

</details>

---
*Generated by rpk-docs automation*
> Note: the first regeneration after a doc-tools template change can
> carry one-time churn on pages outside this plugin (for example, a
> template-level attribute change touches every rpk page).

## Automation

Generated by [rpk-docs automation](https://github.com/redpanda-data/docs-extensions-and-macros/tree/main/tools/rpk-docs).

Review the changes and merge when ready.
