### PR TITLE
DOC-2303: Add local-build GitHub auth instructions for private content repos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,20 +60,20 @@ Check the open docs issues. If you find an issue you'd like to work on:
 - If the issue is already assigned to someone else, please consider another one.
 - If the issue is unassigned, add a comment expressing your interest in working on it.
 
-== Prerequisites: GitHub authentication
+== Set up GitHub authentication
 
-The Antora playbook in this repository fetches content from private GitHub repositories (`cloud-docs`, `rp-connect-docs`, and `adp-docs`), so building the site requires a GitHub token — even for read-only builds.
+The Antora playbook in this repository fetches content from other GitHub repositories, including the private `cloud-docs` and `rp-connect-docs` repositories and this repository's own versioned branches, so building the site requires a GitHub token, even for read-only builds.
 
-IMPORTANT: Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so this step is required even if `git clone` already works on your machine. Antora reads credentials only from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file.
+IMPORTANT: Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so you must complete this step even if `git clone` already works on your machine. By default, Antora reads credentials from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file (with a fallback to `$XDG_CONFIG_HOME/git/credentials`).
 
-One-time setup using the https://cli.github.com[GitHub CLI]:
+To store credentials one time using the https://cli.github.com[GitHub CLI^], run:
 
 ```bash
 echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
 chmod 600 ~/.git-credentials
 ```
 
-If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
 
 NOTE: Tokens from `gh auth token` rotate when you sign in to the GitHub CLI again. If Antora builds start failing with `401` or `404` errors on remote content sources, remove the stale `github.com` line from `~/.git-credentials` and re-run the setup command.
 

--- a/README.adoc
+++ b/README.adoc
@@ -66,14 +66,14 @@ The Antora playbook in this repository fetches content from other GitHub reposit
 
 IMPORTANT: Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so you must complete this step even if `git clone` already works on your machine. By default, Antora reads credentials from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file (with a fallback to `$XDG_CONFIG_HOME/git/credentials`).
 
-To store credentials one time using the https://cli.github.com[GitHub CLI^], run:
+If you aren't already signed in to the https://cli.github.com[GitHub CLI^], run `gh auth login` first. Then store credentials one time:
 
 ```bash
 echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
 chmod 600 ~/.git-credentials
 ```
 
-If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token^]: select `redpanda-data` as the resource owner, grant the token access to the private doc repositories, and set the `Contents` permission to read-only. Use the token in place of `$(gh auth token)`. Organization approval may be required before the token becomes active.
 
 NOTE: Tokens from `gh auth token` rotate when you sign in to the GitHub CLI again. If Antora builds start failing with `401` or `404` errors on remote content sources, remove the stale `github.com` line from `~/.git-credentials` and re-run the setup command.
 

--- a/README.adoc
+++ b/README.adoc
@@ -60,6 +60,23 @@ Check the open docs issues. If you find an issue you'd like to work on:
 - If the issue is already assigned to someone else, please consider another one.
 - If the issue is unassigned, add a comment expressing your interest in working on it.
 
+== Prerequisites: GitHub authentication
+
+The Antora playbook in this repository fetches content from private GitHub repositories (`cloud-docs`, `rp-connect-docs`, and `adp-docs`), so building the site requires a GitHub token — even for read-only builds.
+
+IMPORTANT: Antora does not use git credential helpers (such as the `gh` CLI helper or the macOS keychain), so this step is required even if `git clone` already works on your machine. Antora reads credentials only from the `GIT_CREDENTIALS` environment variable or the `~/.git-credentials` file.
+
+One-time setup using the https://cli.github.com[GitHub CLI]:
+
+```bash
+echo "https://$(gh auth token):@github.com" >> ~/.git-credentials
+chmod 600 ~/.git-credentials
+```
+
+If you don't use the GitHub CLI, https://github.com/settings/personal-access-tokens/new[create a fine-grained personal access token] with `Contents: Read-only` permission on the `redpanda-data` doc repositories and use it in place of `$(gh auth token)`.
+
+NOTE: Tokens from `gh auth token` rotate when you sign in to the GitHub CLI again. If Antora builds start failing with `401` or `404` errors on remote content sources, remove the stale `github.com` line from `~/.git-credentials` and re-run the setup command.
+
 == Local development
 
 If you want to run the website locally, install and update the packages:


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-2303
Review deadline: 2026-08-11

The doc content repos (`docs`, `cloud-docs`, `rp-connect-docs`, `adp-docs`) are being made private. Antora fetches these repos as remote content sources during every local build, and it does not use git credential helpers, so writers need a one-time credentials setup that isn't covered by an existing `gh` or keychain login.

This PR adds a **Set up GitHub authentication** section to the README documenting the one-time `~/.git-credentials` setup Antora requires. The private-repo list in the section matches this repo's `local-antora-playbook.yml` content sources.

Merge alongside the repo visibility change (tracked in DEVPROD-4604).

## Page previews

None: README changes only, no site pages affected.

## Checks

- [x] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
