### PR TITLE
Fix link to relocated contribution/authoring guide (DOC-2303)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ If you are a Redpanda employee, submit doc issues in `redpanda-data/documentatio
 You have two options to contribute to the documentation:
 
 . Directly edit a page on GitHub by selecting **Make a contribution** > **Edit on GitHub** located at the bottom of a documentation page.
-. Clone the docs repository to make changes locally on your machine. For a guide, see {url-playbook}/blob/main/meta-docs/CONTRIBUTING.adoc[Submit your first contribution].
+. Clone the docs repository to make changes locally on your machine. For a guide, see {url-playbook}/blob/main/meta-docs/AUTHORING.adoc[Build and test your changes locally].
 
 Check the open docs issues. If you find an issue you'd like to work on:
 

--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,13 @@ Check the open docs issues. If you find an issue you'd like to work on:
 - If the issue is already assigned to someone else, please consider another one.
 - If the issue is unassigned, add a comment expressing your interest in working on it.
 
+== Set up GitHub authentication
+
+Building this site locally fetches content from other GitHub repositories, including the private `docs`, `cloud-docs`, `rp-connect-docs`, and `adp-docs` repositories, so you need a GitHub token even for read-only builds. See "Set up GitHub authentication" in the {url-playbook}/blob/main/meta-docs/AUTHORING.adoc[authoring guide].
+
 == Local development
+
+Local builds require the GitHub authentication set up above.
 
 If you want to run the website locally, install and update the packages:
 

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ This repository hosts the documentation content for Redpanda Streaming.
 
 The Redpanda docs are open source, and we welcome your contributions!
 
-Before you add or edit content, consult the Redpanda https://github.com/redpanda-data/docs-site/blob/main/meta-docs/STYLE-GUIDE.adoc[Style Guide] for product documentation guidelines.
+Before you add or edit content, consult the Redpanda https://github.com/redpanda-data/docs-team-standards/blob/main/resources/writing-style/style-guide.md[Style Guide] for product documentation guidelines.
 
 To contribute to the Redpanda docs, you have the following options:
 

--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ If you are a Redpanda employee, submit doc issues in `redpanda-data/documentatio
 You have two options to contribute to the documentation:
 
 . Directly edit a page on GitHub by selecting **Make a contribution** > **Edit on GitHub** located at the bottom of a documentation page.
-. Clone the docs repository to make changes locally on your machine. For a guide, see {url-playbook}/blob/main/meta-docs/AUTHORING.adoc[Build and test your changes locally].
+. Clone the docs repository to make changes locally on your machine. For a guide, see https://github.com/redpanda-data/cupboard/blob/main/sales/customer-success/documentation/2026-08-04-authoring-guide.md[Build and test your changes locally].
 
 Check the open docs issues. If you find an issue you'd like to work on:
 
@@ -62,7 +62,7 @@ Check the open docs issues. If you find an issue you'd like to work on:
 
 == Set up GitHub authentication
 
-Building this site locally fetches content from other GitHub repositories, including the private `docs`, `cloud-docs`, `rp-connect-docs`, and `adp-docs` repositories, so you need a GitHub token even for read-only builds. See "Set up GitHub authentication" in the {url-playbook}/blob/main/meta-docs/AUTHORING.adoc[authoring guide].
+Building this site locally fetches content from other GitHub repositories, including the private `docs`, `cloud-docs`, `rp-connect-docs`, and `adp-docs` repositories, so you need a GitHub token even for read-only builds. See "Set up GitHub authentication" in the https://github.com/redpanda-data/cupboard/blob/main/sales/customer-success/documentation/2026-08-04-authoring-guide.md[authoring guide].
 
 == Local development
 


### PR DESCRIPTION
## Description

Related to https://redpandadata.atlassian.net/browse/DOC-2303.

`docs-site/meta-docs/CONTRIBUTING.adoc` was split and renamed to `AUTHORING.adoc` (redpanda-data/docs-site#201), then that file was deleted entirely and ported to internal-only `redpanda-data/cupboard` (redpanda-data/cupboard#677) — every one of these repos' `local-antora-playbook.yml` cross-fetches the private `docs`/`cloud-docs`/`rp-connect-docs`/`adp-docs` repos to build locally at all, so the audience for that guide was already internal in practice.

This repoints both the "clone locally" contribution link and the "Set up GitHub authentication" pointer at the ported cupboard guide.