### PR TITLE
Document that rpk plugins do not upgrade with rpk

### DIFF
--- a/modules/get-started/pages/rpk-install.adoc
+++ b/modules/get-started/pages/rpk-install.adoc
@@ -33,6 +33,26 @@ include::get-started:partial$install-rpk-linux.adoc[]
 
 include::get-started:partial$install-rpk-macos.adoc[]
 
+== Upgrade rpk plugins
+
+Plugins, such as `rpk connect` and `rpk ai`, are separate binaries that `rpk` downloads and runs on your behalf. Upgrading `rpk` does not upgrade its plugins. An installed plugin stays at its version until you upgrade it, even across `rpk` upgrades.
+
+To see which plugins are installed:
+
+[,bash]
+----
+rpk plugin list --local
+----
+
+To upgrade a plugin, run its `upgrade` command. For example:
+
+[,bash]
+----
+rpk connect upgrade
+----
+
+NOTE: Some plugins install themselves the first time you run one of their commands. For example, `rpk connect run` downloads the latest Redpanda Connect if it is not already installed. This happens only on first use. After that, the plugin never updates itself.
+
 == Next steps
 
 For the complete list of `rpk` commands and their syntax, see the xref:reference:rpk/index.adoc[rpk reference].


### PR DESCRIPTION
## What

Adds an "Upgrade rpk plugins" section to the Install or Update rpk page: plugins are separate binaries, upgrading `rpk` never upgrades them, `rpk plugin list --local` shows what's installed, and each plugin has its own `upgrade` command. A NOTE covers the one nuance that trips people: some plugins (Connect) self-install the latest on first functional use, but never self-update afterwards.

## Evidence

Every statement is empirically verified (full test log and reproduction steps in the Jira): a plugin pinned at ai 0.2.30 survived an rpk v26.1.12 → v26.2.1 binary upgrade untouched, stayed at 0.2.30 across invocations through the new rpk, and moved to 0.2.34 only when `rpk ai upgrade` ran. `rpk connect run` on a clean setup downloaded latest (4.103.1) on first use and did not re-check afterwards.

## Placement

Inside the `tag::single-source[]` region, so the cloud-docs `rpk-install.adoc` stub (a pure include) inherits the section with no change needed in that repo. Companion one-line fixes for the plugin-specific pages: rp-connect-docs and adp-docs PRs linked from the Jira.

## Jira

Resolves [DOC-2417](https://redpandadata.atlassian.net/browse/DOC-2417).

[DOC-2417]: https://redpandadata.atlassian.net/browse/DOC-2417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ