### PR TITLE
docs: point production K8s pages at the local kind/minikube guide (DOC-517)

### DIFF
--- a/modules/deploy/pages/redpanda/kubernetes/k-production-deployment.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/k-production-deployment.adoc
@@ -8,6 +8,8 @@
 
 This topic describes how to configure and deploy one or more Redpanda clusters and Redpanda Console in Kubernetes. Each Redpanda cluster runs within a single Kubernetes cluster. For multi-region topologies and other deployment shapes, see xref:deploy:redpanda/kubernetes/k-choose-deployment.adoc[].
 
+TIP: To try Redpanda on a local Kubernetes cluster for development or testing, see the xref:deploy:redpanda/kubernetes/local-guide.adoc[guide for kind and minikube] instead.
+
 == Prerequisites
 
 Make sure that your Kubernetes cluster meets the xref:deploy:redpanda/kubernetes/k-requirements.adoc[requirements].

--- a/modules/deploy/pages/redpanda/kubernetes/k-production-workflow.adoc
+++ b/modules/deploy/pages/redpanda/kubernetes/k-production-workflow.adoc
@@ -7,6 +7,8 @@
 
 The production deployment tasks involve Kubernetes administrators (admins) as well as Kubernetes users.
 
+TIP: This workflow is for production deployments. To try Redpanda on a local Kubernetes cluster for development or testing, see the xref:deploy:redpanda/kubernetes/local-guide.adoc[guide for kind and minikube] instead.
+
 . All: xref:deploy:redpanda/kubernetes/k-requirements.adoc[Review the requirements and recommendations] to align on prerequisites.
 . Admin: xref:deploy:redpanda/kubernetes/k-tune-workers.adoc[Tune the worker nodes] for best performance.
 . User: xref:deploy:redpanda/kubernetes/k-production-deployment.adoc[Deploy Redpanda] using either the Redpanda Operator or the Redpanda Helm chart.


### PR DESCRIPTION
Resolves [DOC-517](https://redpandadata.atlassian.net/browse/DOC-517): a user browsing the production deployment docs had no signpost to the local kind/minikube guide and had to find it through search.

Adds a TIP to the two production entry points (`k-production-workflow` and `k-production-deployment`) linking the local development guide. The xref target is the existing `local-guide.adoc` page. Two-line change, no structural impact. The Netlify preview validates the links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-517]: https://redpandadata.atlassian.net/browse/DOC-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ