### PR TITLE
docs: document applyInternalDNSNames for custom-issuer TLS (DOC-182)

### DIFF
--- a/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
+++ b/modules/manage/pages/kubernetes/security/tls/k-cert-manager.adoc
@@ -303,6 +303,21 @@ helm upgrade --install redpanda redpanda/redpanda --namespace <namespace> --crea
 ====
 include::manage:partial$kubernetes/tls-update-note.adoc[]
 ====
++
+When you provide your own Issuer, the Helm chart does not add the brokers' internal Kubernetes Service addresses to the Certificate, because public CAs such as Let's Encrypt cannot issue certificates for cluster-local names. If your Issuer is a private CA that can issue certificates for internal addresses, set `applyInternalDNSNames` to `true`. This setting adds the internal addresses to the Certificate so that clients inside the Kubernetes cluster can validate connections to the internal listeners with the same Certificate:
++
+[,yaml]
+----
+tls:
+  enabled: true
+  certs:
+    external:
+      issuerRef:
+        name: <issuer-name>
+        kind: <issuer>
+      applyInternalDNSNames: true
+      caEnabled: false
+----
 
 . Make sure the Certificates are in a `READY` state.
 +


### PR DESCRIPTION
Resolves [DOC-182](https://redpandadata.atlassian.net/browse/DOC-182) (May 2024): the Helm chart option that injects the brokers' internal DNS names into user-provided Issuer Certificates (helm-charts#1156, now `tls.certs.<cert>.applyInternalDNSNames`) was never documented in the TLS guide - it appears only in the generated CRD reference.

Adds an explanation to the *Use a public CA certificate* section of `k-cert-manager.adoc`: with a custom `issuerRef`, internal Service addresses are omitted from the Certificate (public CAs cannot issue for cluster-local names), and private-CA users can set `applyInternalDNSNames: true` to restore them so in-cluster clients validate internal listeners with the same Certificate.

Verified against chart source: `charts/redpanda/certs.go` appends the internal Service DNS names when `issuerRef` is nil or `applyInternalDNSNames` is true, and the field lives on the per-certificate `TLSCert` struct in `values.go`. The Netlify preview validates the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-182]: https://redpandadata.atlassian.net/browse/DOC-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ