### PR TITLE
docs(glossary): remove remaining ADP acronym from term hover texts

### DIFF
--- a/modules/terms/partials/oauth-client.adoc
+++ b/modules/terms/partials/oauth-client.adoc
@@ -1,4 +1,4 @@
 === OAuth client
 :term-name: OAuth client
-:hover-text: An ADP resource that governs inbound authentication: an external app (Claude Desktop, ChatGPT, Copilot Studio) authenticating to AI Gateway so the app's users can invoke MCP tools. Separate from an OAuth provider, which governs outbound authentication.
+:hover-text: An Agentic Data Plane resource that governs inbound authentication: an external app (Claude Desktop, ChatGPT, Copilot Studio) authenticating to AI Gateway so the app's users can invoke MCP tools. Separate from an OAuth provider, which governs outbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/oauth-provider.adoc
+++ b/modules/terms/partials/oauth-provider.adoc
@@ -1,4 +1,4 @@
 === OAuth provider
 :term-name: OAuth provider
-:hover-text: An ADP resource that governs outbound authentication: AI Gateway authenticating to an upstream system (GitHub, Slack, Salesforce, and so on) on a user's behalf so MCP servers can call it. Separate from an OAuth client, which governs inbound authentication.
+:hover-text: An Agentic Data Plane resource that governs outbound authentication: AI Gateway authenticating to an upstream system (GitHub, Slack, Salesforce, and so on) on a user's behalf so MCP servers can call it. Separate from an OAuth client, which governs inbound authentication.
 :category: Agentic Data Plane

--- a/modules/terms/partials/self-managed-agent.adoc
+++ b/modules/terms/partials/self-managed-agent.adoc
@@ -1,4 +1,4 @@
 === self-managed agent
 :term-name: self-managed agent
-:hover-text: An AI agent you build and run yourself, in your own runtime and framework, registered with Redpanda ADP as an identity. The AI Gateway becomes the agent's LLM and MCP endpoint, so ADP attributes spend, tokens, latency, and traces back to the agent. ADP does not host or run the agent. Contrast with a declarative agent, which runs in Redpanda's managed runtime.
+:hover-text: An AI agent you build and run yourself, in your own runtime and framework, registered with Redpanda Agentic Data Plane as an identity. The AI Gateway becomes the agent's LLM and MCP endpoint, so the Agentic Data Plane attributes spend, tokens, latency, and traces back to the agent. The Agentic Data Plane does not host or run the agent. Contrast with a declarative agent, which runs in Redpanda's managed runtime.
 :category: Agentic Data Plane

--- a/modules/terms/partials/self-managed-mcp-server.adoc
+++ b/modules/terms/partials/self-managed-mcp-server.adoc
@@ -1,4 +1,4 @@
 === self-managed MCP server
 :term-name: self-managed MCP server
-:hover-text: An MCP server you host and operate yourself, registered with Redpanda ADP so the AI Gateway can proxy tool calls to it. Contrast with a managed MCP server, which Redpanda hosts in-process for you.
+:hover-text: An MCP server you host and operate yourself, registered with Redpanda Agentic Data Plane so the AI Gateway can proxy tool calls to it. Contrast with a managed MCP server, which Redpanda hosts in-process for you.
 :category: Agentic Data Plane


### PR DESCRIPTION
## Summary

Removes the last six standalone `ADP` usages from glossary term hover texts, replacing them with `Agentic Data Plane`. Follow-up to the coordinated ADP-acronym removal (redpanda-data/docs#1890, redpanda-data/adp-docs#200, redpanda-data/docs-site#204), which fixed the rpk-ai reference and homepage but did not touch the glossary.

These hover texts were the source of the 6 `ADP` hits the site crawl found on https://docs.redpanda.com/streaming/current/reference/glossary/ (Slack thread in #tw-chat, 2026-08-06).

## Changes

- `modules/terms/partials/oauth-client.adoc` — "An ADP resource" → "An Agentic Data Plane resource"
- `modules/terms/partials/oauth-provider.adoc` — "An ADP resource" → "An Agentic Data Plane resource"
- `modules/terms/partials/self-managed-agent.adoc` — 3 occurrences replaced
- `modules/terms/partials/self-managed-mcp-server.adoc` — "Redpanda ADP" → "Redpanda Agentic Data Plane"

## Scope

Because the `shared` component is versionless, this one PR fixes the glossary page for every published version (current back to 23.3) plus the `cloud-data-platform` and `agentic-data-plane` component glossaries, and every glossterm tooltip that embeds these hover texts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)